### PR TITLE
content: add Hib guide + resurgence post

### DIFF
--- a/src/content/guides/hib-infection-vaccine.mdx
+++ b/src/content/guides/hib-infection-vaccine.mdx
@@ -1,0 +1,187 @@
+---
+title: "Haemophilus influenzae type b (Hib): Infection, Symptoms, and Vaccination"
+slug: hib-infection-vaccine
+description: "A clear guide to Hib infection, symptoms, complications, and how vaccination protects against serious disease."
+category: "Vaccination"
+publishDate: "2026-04-17"
+updatedDate: "2026-04-17"
+draft: false
+tags:
+  - hib
+  - vaccination
+  - infection
+  - meningitis
+  - child-health
+faq:
+  - q: "Is Hib the same as influenza?"
+    a: "No. Haemophilus influenzae type b is a bacterium, not the influenza virus. The name is a historical accident — it was isolated during a flu pandemic before the influenza virus was identified."
+  - q: "How serious is Hib infection?"
+    a: "Invasive Hib disease can be life-threatening. Bacterial meningitis, epiglottitis, and sepsis can progress rapidly and cause permanent complications or death, particularly in young children."
+  - q: "Who is most at risk?"
+    a: "Children under five are at highest risk, especially infants. People with certain immune conditions, those without a functioning spleen, and populations with lower vaccine coverage also carry elevated risk."
+  - q: "Do adults need Hib vaccination?"
+    a: "Most adults with a complete childhood vaccination history do not need Hib vaccine. However, it is recommended for adults without a spleen, with certain immune deficiencies, or those who were never vaccinated. Check with a clinician if unsure."
+  - q: "What happens if a child misses a Hib dose?"
+    a: "Missed doses should be caught up as soon as possible. The catch-up schedule depends on the child's age and how many doses they have already received. Consult your immunisation provider."
+  - q: "Can Hib still happen in vaccinated populations?"
+    a: "Yes, though rarely. Vaccine failure occurs occasionally, and cases continue to appear in under-vaccinated pockets or among people with immune deficiencies. Herd immunity gaps also allow the bacterium to circulate."
+schema:
+  medicalCondition:
+    name: "Haemophilus influenzae type b (Hib)"
+    description: "Hib is a bacterial infection caused by Haemophilus influenzae type b, capable of causing life-threatening invasive disease including meningitis, epiglottitis, and sepsis, primarily in young children."
+    alternateName:
+      - "Hib disease"
+      - "Hib meningitis"
+      - "Invasive Hib disease"
+    riskFactors:
+      - "Age under five years"
+      - "Incomplete vaccination"
+      - "Asplenia or functional asplenia"
+      - "Immunodeficiency"
+      - "Close contact with an infected person"
+    symptoms:
+      - "Fever"
+      - "Stiff neck (meningitis)"
+      - "Severe sore throat and drooling (epiglottitis)"
+      - "Cough and breathing difficulty (pneumonia)"
+      - "Rapid deterioration (sepsis)"
+    possibleComplication:
+      - "Permanent hearing loss"
+      - "Brain damage"
+      - "Airway obstruction"
+      - "Death"
+    contagious: true
+    sameAs:
+      - "https://www.cdc.gov/hib/index.html"
+      - "https://www.who.int/immunization/diseases/hib/en/"
+---
+
+# Haemophilus influenzae type b (Hib): Infection, Symptoms, and Vaccination
+
+Haemophilus influenzae type b (Hib) is a bacterial infection that was once one of the most feared childhood illnesses in the world. Routine vaccination has dramatically reduced its burden — but it has not eliminated it. Where vaccine coverage is incomplete, Hib remains capable of causing fast-moving, life-threatening disease.
+
+<div class="callout">
+  <strong>At a glance:</strong> Despite its name, Hib has nothing to do with influenza. It is a bacterium that can cause bacterial meningitis, epiglottitis, and sepsis — primarily in young children. Vaccination has made it rare, but not gone.
+</div>
+
+## Key Points
+
+- Hib is a **bacterial** infection, not related to the influenza virus
+- It can cause meningitis, epiglottitis, pneumonia, and sepsis
+- Before vaccination, it was the leading cause of bacterial meningitis in children under five
+- Vaccination has made severe Hib disease much rarer in countries with strong immunisation programs
+- Cases still occur, particularly where vaccine coverage is incomplete or in people with immune deficiencies
+
+## Background
+
+Haemophilus influenzae is a group of bacteria first identified during the 1890 influenza pandemic. At the time, scientists mistakenly thought the bacterium caused influenza — hence the name. The influenza virus was not identified until the 1930s.
+
+There are several types of Haemophilus influenzae, distinguished by their surface capsules (types a through f) or by lacking a capsule entirely (non-typeable strains). **Type b (Hib)** was historically the most dangerous, responsible for the large majority of serious invasive disease before vaccines were introduced.
+
+Before routine Hib vaccination became widespread in the early 1990s:
+
+- Hib was the **most common cause of bacterial meningitis** in children under five in many countries
+- Approximately 1 in 200 children under five in the United States developed invasive Hib disease before age five
+- Thousands of children died each year; many more were left with permanent hearing loss or brain damage
+- Epiglottitis — a rapidly progressive, life-threatening swelling of the airway — was predominantly a paediatric Hib disease
+
+Vaccination changed this picture dramatically. In countries with high coverage, invasive Hib disease fell by more than 95%.
+
+## How Hib Spreads
+
+Hib lives in the nose and throat of infected people and some asymptomatic carriers. It spreads primarily through:
+
+- **Respiratory droplets** — coughing, sneezing, or close contact
+- **Direct contact** with respiratory secretions
+
+Most people who carry Hib in their nasopharynx never become seriously ill. Invasive disease occurs when the bacterium crosses from the respiratory tract into the bloodstream or surrounding tissues, triggering infection in the brain, lungs, blood, joints, or other sites.
+
+Young children are particularly vulnerable because their immune systems have not yet developed the antibodies needed to contain Hib before it spreads.
+
+## Symptoms and Complications
+
+Hib can cause several distinct clinical syndromes. The presentation depends on which part of the body is infected.
+
+| Condition | What it can cause |
+|---|---|
+| **Meningitis** | Fever, lethargy, neck stiffness, headache, vomiting, photophobia; neurological complications including hearing loss and brain damage |
+| **Epiglottitis** | Severe throat swelling, high fever, drooling, difficulty swallowing, stridor; emergency airway risk requiring urgent intervention |
+| **Pneumonia** | Cough, fever, rapid breathing, chest pain; may require hospitalisation |
+| **Sepsis** | Rapid deterioration, high fever or hypothermia, poor perfusion, shock; can be fatal within hours |
+| **Septic arthritis** | Joint swelling, pain, reduced movement; primarily large joints in young children |
+| **Cellulitis** | Skin infection, typically on the face or neck in young children; may indicate bloodstream spread |
+
+Hib meningitis and epiglottitis are the presentations most likely to be immediately life-threatening.
+
+## Diagnosis and Treatment
+
+**Diagnosis** is based on clinical suspicion and confirmed with laboratory testing:
+
+- Blood cultures are the primary diagnostic tool for invasive disease
+- Cerebrospinal fluid (CSF) culture and analysis for suspected meningitis
+- Imaging and other tests depending on the clinical picture
+
+Hib infection is a **medical emergency**. Suspected cases require:
+
+- **Urgent hospital admission**
+- **Intravenous antibiotics** — third-generation cephalosporins (e.g., ceftriaxone) are standard first-line treatment
+- **Supportive intensive care** where required, including airway management for epiglottitis
+- Corticosteroids are sometimes used alongside antibiotics in meningitis to reduce inflammation and the risk of complications such as hearing loss
+
+Early treatment significantly improves outcomes. Delays increase the risk of permanent complications and death.
+
+## Risks and Prognosis
+
+Without treatment, invasive Hib disease carries a high risk of death or serious permanent injury. Even with treatment:
+
+- **Bacterial meningitis** causes permanent hearing loss in approximately 15–20% of survivors and other neurological complications in a significant proportion
+- **Epiglottitis** can cause fatal airway obstruction if not managed immediately
+- **Sepsis** carries a substantial mortality risk, particularly if there is delayed recognition
+
+Long-term effects after invasive Hib disease can include cognitive difficulties, developmental delays, and communication problems, depending on the extent of any neurological involvement.
+
+Vaccination substantially reduces all of these risks by preventing the infection from occurring in the first place.
+
+## Vaccination
+
+The Hib conjugate vaccine, introduced into routine childhood schedules in the early 1990s, is one of the most successful vaccines ever developed.
+
+**Key points about Hib vaccination:**
+
+- Hib vaccine is included in **routine childhood immunisation schedules** in most high-income countries and an increasing number of lower-income countries
+- In **Australia**, Hib vaccine is given as part of combination vaccines at **2, 4, and 6 months**, with a booster at **12–18 months**, under the National Immunisation Program
+- Combination vaccines (such as those also covering diphtheria, tetanus, pertussis, hepatitis B, and polio) are commonly used to reduce the number of injections
+
+**Catch-up vaccination** is recommended for children who have missed scheduled doses — the schedule depends on age and number of prior doses. Adults without a spleen, or with certain immune conditions, should discuss Hib vaccination with their clinician.
+
+Vaccination does not only protect the individual — high coverage reduces circulation of the bacterium, protecting those who cannot be vaccinated.
+
+## Frequently Asked Questions
+
+**Is Hib the same as influenza?**
+No. Haemophilus influenzae type b is a bacterium. The influenza virus is a completely separate pathogen. The name is a historical error from the pre-virology era. Hib infection does not cause the flu.
+
+**How serious is Hib infection?**
+Invasive Hib disease is a medical emergency. Meningitis, epiglottitis, and sepsis can progress to death or permanent disability within hours. Even with treatment, a significant proportion of survivors have lasting complications.
+
+**Who is most at risk?**
+Children under five are at highest risk, particularly infants under twelve months who have not yet completed the primary vaccination course. People without a functioning spleen, those with immune deficiencies, and unvaccinated individuals of any age also carry elevated risk.
+
+**Do adults need Hib vaccination?**
+Most adults who completed childhood vaccination do not need Hib vaccine. Exceptions include people without a spleen (asplenia), those with certain immune conditions including HIV, and adults who were never vaccinated. Discuss with a clinician if you are unsure of your vaccination history.
+
+**What happens if a child misses a Hib dose?**
+Missed doses should be caught up as soon as possible. The number of doses required depends on the child's age at the time of catch-up. An immunisation provider can advise on the appropriate schedule. Partial vaccination still provides some protection, but completing the course is important.
+
+**Can Hib still happen in vaccinated populations?**
+Yes, though rarely. Occasional vaccine failure occurs. More commonly, cases arise in under-vaccinated individuals or communities where coverage has fallen. Immunocompromised people may also be at risk despite vaccination. Pockets of under-vaccination allow Hib to continue circulating, creating ongoing risk.
+
+## Further Reading
+
+- [CDC: Hib Disease and Vaccination](https://www.cdc.gov/hib/index.html)
+- [WHO: Haemophilus influenzae type b (Hib)](https://www.who.int/immunization/diseases/hib/en/)
+- [Australian Immunisation Handbook — Haemophilus influenzae type b](https://immunisationhandbook.health.gov.au/vaccines/hib-haemophilus-influenzae-type-b)
+
+## Related Guides
+
+- [Vaccination](/guides/vaccination)

--- a/src/content/posts/hib-resurgence-2026.md
+++ b/src/content/posts/hib-resurgence-2026.md
@@ -1,0 +1,122 @@
+---
+title: "Hib Was Supposed to Be Gone. It Isn't."
+slug: hib-resurgence-2026
+description: "CDC surveillance data shows why \"solved\" diseases can quietly return."
+publishDate: "2026-04-17"
+updatedDate: "2026-04-17"
+tags:
+  - vaccination
+  - public-health
+  - analysis
+draft: false
+category: "Public Health"
+related:
+  - /guides/hib-infection-vaccine
+---
+
+## Hook
+
+In the 1980s, Haemophilus influenzae type b killed or permanently disabled thousands of children every year in the United States alone.
+
+Then the vaccine arrived. Coverage climbed. Cases fell by more than 95%.
+
+By the mid-1990s, Hib had largely dropped out of public consciousness. Paediatricians who trained after that point have rarely — if ever — seen a case. It felt solved.
+
+It isn't.
+
+---
+
+## Context
+
+CDC Morbidity and Mortality Weekly Report (MMWR) data have continued to surface Hib cases in circumstances that highlight a persistent and uncomfortable pattern: vaccination success does not mean uniform protection.
+
+What the surveillance picture shows:
+
+- **Cases cluster where vaccination coverage is incomplete** — whether due to access barriers, hesitancy, or gaps in catch-up scheduling
+- **Disparities are visible across demographic lines** — Alaska Native communities, for example, have historically faced disproportionate Hib burden, a pattern that reflects broader structural inequities in healthcare access
+- **Immunocompromised individuals remain at risk** regardless of prior vaccination status or herd immunity levels
+- **Infants too young to have completed the primary course** remain a biologically vulnerable window — even in high-coverage settings
+
+None of this is new in principle. But each surveillance cycle that surfaces avoidable Hib cases is a reminder that coverage statistics mask uneven distributions. A national average of 90% coverage means something very different from 90% coverage everywhere.
+
+---
+
+## Your Take
+
+### The vaccine success paradox
+
+Vaccination programs are, in a precise sense, victims of their own success.
+
+When a disease becomes rare, the perceived risk of the disease drops. The perceived risk of the vaccine — which never disappears from public consciousness, even when it is minimal — does not fall at the same rate. The asymmetry creates drift.
+
+Parents who have never seen a child with Hib meningitis make a different intuitive calculation than parents who have. This is not irrationality. It is the expected consequence of success. But it creates fragility.
+
+### Uneven coverage creates pockets, not protection
+
+Herd immunity is not a uniform shield. It is a probabilistic aggregate that can fail locally even when the national number looks strong.
+
+A community with 70% vaccination coverage — whether due to geography, hesitancy, access, or a cohort of missed infants — functions as a corridor for transmission. Hib can circulate and find its way to an unvaccinated infant or an immunocompromised adult with no exposure to the public health headline.
+
+The gap between "nearly eliminated" and "eliminated" is not academic. It is where children still get meningitis.
+
+### Clinicians are less familiar than they used to be
+
+There is a second-order risk that does not show up in vaccination statistics.
+
+A generation of clinicians has trained in an environment where Hib disease is genuinely rare. The differential diagnosis patterns, the urgency reflexes, the instinct to consider invasive bacterial disease in a febrile child — these are skills that erode when they are rarely needed.
+
+Rare diseases get diagnosed late. Epiglottitis can be fatal within hours of symptom onset. Bacterial meningitis causes permanent neurological damage in a window that is measured in hours, not days.
+
+Familiarity matters. And it is thinning.
+
+---
+
+## Implications
+
+**For parents:**
+A child who has not completed the Hib vaccination schedule — including catch-up doses — carries meaningful risk that does not have to exist. This is fixable. Check your child's immunisation record. If doses are missing, ask about catch-up.
+
+A febrile child who seems unusually unwell — particularly with neck stiffness, difficulty swallowing, drooling, or stridor — needs urgent assessment. Do not wait.
+
+**For clinicians:**
+Hib should remain on the differential for severe bacterial presentations in young unvaccinated or incompletely vaccinated children. The rarity of the disease makes it easy to not think of. That is exactly the condition under which delayed diagnosis happens.
+
+For patients presenting with epiglottitis or acute bacterial meningitis, the question of vaccination status is clinically relevant — not just epidemiologically interesting.
+
+**For public health systems:**
+Coverage data reported as national averages obscure pockets of vulnerability. Granular, local data on vaccination rates — particularly among infants completing primary courses — matter more than headline percentages.
+
+Equity is not a footnote to vaccination policy. Communities with lower access to care are the communities where preventable cases accumulate. Surveillance without follow-through on access gaps is not a strategy.
+
+---
+
+## FAQ
+
+**Is Hib still a real threat?**
+Yes, in specific populations. Children who are unvaccinated or incompletely vaccinated, those with immune deficiencies, and communities with low coverage remain genuinely at risk. Rare does not mean zero.
+
+**Isn't herd immunity supposed to prevent this?**
+Herd immunity reduces transmission across a population, but it is not uniform. Local gaps in coverage create local vulnerabilities. It also does not protect immunocompromised individuals who cannot mount an adequate immune response even after vaccination.
+
+**What should I do if I'm not sure about my child's vaccination history?**
+Contact your GP, paediatrician, or immunisation provider. In Australia, the Australian Immunisation Register (AIR) holds vaccination records. Catch-up schedules exist and are effective — incomplete vaccination is correctable.
+
+**Why isn't this getting more attention?**
+Because the disease is rare in aggregate, and rare things are hard to sustain attention on. That is the paradox. The rarity is the result of the vaccine working. But rarity creates the conditions for complacency that allow the gaps to persist.
+
+---
+
+## Further Reading
+
+- [Haemophilus influenzae type b (Hib): Infection, Symptoms, and Vaccination](/guides/hib-infection-vaccine)
+- [CDC MMWR — Hib surveillance and reports](https://www.cdc.gov/mmwr/index.html)
+
+---
+
+## Closing
+
+Hib was not defeated. It was suppressed by a technology that requires continuous, equitable, and attentive maintenance.
+
+Stop maintaining it — unevenly, locally, quietly — and it comes back.
+
+That is not a warning about the future. It is a description of what is already happening in the gaps.


### PR DESCRIPTION
## Summary

- Adds evergreen Hib vaccination guide in MDX format (`src/content/guides/hib-infection-vaccine.mdx`)
- Adds public health post on Hib re-emergence risk and surveillance gaps (`src/content/posts/hib-resurgence-2026.md`)
- No existing files modified; no schema or config changes

## Test plan

- [ ] Build passes (`npm run build`) — verified locally at 679 pages, no errors
- [ ] Guide frontmatter validates against `guides` collection schema (`category: "Vaccination"`, quoted ISO dates, `faq` q/a pairs, `schema.medicalCondition`)
- [ ] Post frontmatter validates against `posts` collection schema (`category: "Public Health"`, `related` array)
- [ ] Internal link `/guides/hib-infection-vaccine` resolves correctly
- [ ] No broken MDX/JSX in guide (plain HTML callout only, no component imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)