### PR TITLE
chore(redirects): add legacy sunscreen route redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -181,6 +181,31 @@
   status = 301
   force = true
 
+# Sunscreen: legacy routes → current cluster guide (2026-04-17 cleanup)
+[[redirects]]
+  from = "/guides/sunscreen-basics"
+  to = "/guides/sunscreen"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/guides/sunscreen-basics/"
+  to = "/guides/sunscreen"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/guides/sunscreen-skin-protection"
+  to = "/guides/sunscreen"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/guides/sunscreen-skin-protection/"
+  to = "/guides/sunscreen"
+  status = 301
+  force = true
+
 # Deprecated GPT-5 bubble post → 2026 AI market update
 [[redirects]]
   from = "/posts/gpt5-cold-reality-bubble"


### PR DESCRIPTION
## Summary
Adds redirects for legacy sunscreen guide routes.

## Changes
- Redirects:
  - /guides/sunscreen-basics → /guides/sunscreen
  - /guides/sunscreen-skin-protection → /guides/sunscreen
- Includes trailing slash variants

## Why this matters
- prevents broken links from older content
- consolidates SEO authority to the current sunscreen guide
- avoids duplicate route indexing