### PR TITLE
feat(posts): CDC vaccine report delay (2026)

### DIFF
--- a/src/content/guides/coming-off-antidepressants.mdx
+++ b/src/content/guides/coming-off-antidepressants.mdx
@@ -228,5 +228,5 @@ A: Yes — stability makes symptoms easier to manage.
 
 ## Related Guides
 
-- /guides/depression  
-- /guides/anxiety  
+- [Depression: Symptoms, Causes, and Treatment](/guides/depression)  
+- [Anxiety Disorders](/guides/anxiety)  

--- a/src/content/posts/cdc-covid-vaccine-report-delay-2026.md
+++ b/src/content/posts/cdc-covid-vaccine-report-delay-2026.md
@@ -1,0 +1,98 @@
+---
+title: "When Science Gets Delayed: The CDC, COVID Vaccines, and a Trust Problem"
+slug: "cdc-covid-vaccine-report-delay-2026"
+description: "A delayed CDC report on COVID-19 vaccine effectiveness raises bigger questions about transparency, trust, and how public health decisions are communicated."
+
+publishDate: "2026-04-25"
+updatedDate: "2026-04-25"
+tags: ["public health", "covid-19", "vaccines", "trust", "policy"]
+draft: false
+related:
+  - /guides/covid-19-vaccines
+---
+
+## Hook
+
+What happens when a study showing vaccines work… doesn’t get published?
+
+That’s the question emerging after reports that the CDC halted a scheduled release on COVID-19 vaccine effectiveness—despite it passing internal scientific review.
+
+## Context
+
+According to reporting by *The Washington Post* and CIDRAP, the unpublished analysis suggested that COVID-19 vaccination reduced emergency department visits and hospitalizations by roughly 50% during the most recent winter season.
+
+The report had already cleared the CDC’s internal review process and was scheduled for publication in the **Morbidity and Mortality Weekly Report (MMWR)**—the agency’s flagship scientific outlet.
+
+Then it was pulled.
+
+Leadership cited concerns about methodology. Critics say the same methods are routinely used—including in recent influenza vaccine studies published in the same journal.
+
+At the same time, US vaccine policy has become increasingly politicized, with changes to recommendations for certain groups and leadership turnover inside the CDC.
+
+## Your Take
+
+This isn’t really about one report.
+
+It’s about **how scientific uncertainty gets handled in public view**.
+
+There are two competing risks here:
+
+- **Publishing too early** → risking flawed or misinterpreted data  
+- **Delaying too long** → eroding trust and creating suspicion  
+
+Public health depends on credibility. And credibility depends less on being perfect—and more on being **transparent about uncertainty**.
+
+When a report that appears to support vaccine effectiveness is delayed after approval, it creates an uncomfortable asymmetry:
+
+- Positive findings are questioned or withheld  
+- Existing skepticism fills the vacuum  
+
+Even if the intention is methodological rigor, the *perception* becomes political filtering.
+
+And perception matters.
+
+## Implications
+
+For clinicians, patients, and the public:
+
+- Trust in institutions like the CDC is already fragile  
+- Mixed signals on vaccines amplify confusion  
+- Delays—especially unexplained ones—can undermine confidence more than imperfect data  
+
+For public health more broadly:
+
+👉 The standard isn’t just “rigorous science” anymore  
+👉 It’s **rigorous + visible + explainable science**
+
+If people don’t understand *why* something is delayed, they’ll assume the worst.
+
+## FAQ
+
+**Q: Does this mean COVID vaccines don’t work?**  
+A: No. Multiple large studies over several years have consistently shown that COVID-19 vaccines reduce severe illness, hospitalization, and death—especially in higher-risk groups.
+
+**Q: Why would a report be delayed after approval?**  
+A: Agencies may revisit methodology, data interpretation, or communication clarity before publication. This is not unheard of—but blocking a near-published report is unusual.
+
+**Q: Is this political interference?**  
+A: That’s debated. Some former officials have raised concerns, while the CDC states the delay reflects scientific rigor. The full context isn’t yet public.
+
+**Q: How should readers interpret this?**  
+A: As a signal of uncertainty and internal disagreement—not as proof for or against vaccine effectiveness.
+
+**Q: What matters most right now?**  
+A: Clear, transparent communication about risks, benefits, and evolving evidence—especially for vulnerable populations.
+
+## Further Reading
+
+- [COVID-19 Vaccines: What We Know, What We Don't](/guides/covid-19-vaccines)  
+- https://www.cdc.gov/mmwr  
+- https://www.who.int  
+
+## Closing
+
+The problem isn’t that science changes.
+
+It’s when the process of change becomes invisible.
+
+Because in that silence, trust doesn’t wait—it erodes.


### PR DESCRIPTION
## Summary

- Adds new post analysing the 2026 CDC COVID vaccine safety report delay
- Fixes two bare internal paths in `coming-off-antidepressants.mdx` that were blocking preflight

## Test plan

- [x] `node scripts/content/preflight.mjs` — 0 errors
- [x] `npm run build` — clean build, 684 pages indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)