### PR TITLE
feat(posts): add Ebola outbreak analysis

### DIFF
--- a/src/content/posts/ebola-outbreak-why-experts-concerned-2026.md
+++ b/src/content/posts/ebola-outbreak-why-experts-concerned-2026.md
@@ -1,0 +1,139 @@
+---
+title: "Ebola Spreads Slowly. So Why Is The World So Concerned?"
+description: "The current Ebola outbreak has triggered global concern despite Ebola being far less contagious than COVID. Here's why health experts still take it so seriously."
+publishDate: "2026-05-26"
+updatedDate: "2026-05-26"
+tags: ["infectious disease", "ebola", "public health", "global health", "outbreaks"]
+draft: false
+related:
+  - /guides/infectious-disease-hub
+---
+
+## Hook
+
+In May 2026, the World Health Organization declared a Public Health Emergency of International Concern over a new Ebola outbreak in Uganda.
+
+That declaration carries weight. It's the same designation used for COVID-19 in early 2020, and for the 2014 West Africa Ebola epidemic that killed more than 11,000 people.
+
+Yet Ebola is not airborne. It doesn't spread through casual contact. Its basic reproduction number — the average number of people each case infects — is estimated between 1.5 and 2.5, far below measles or COVID. By the numbers, Ebola is not a virus that should be dominating global headlines.
+
+And yet here we are.
+
+So how can a virus that spreads relatively slowly still trigger global alarm?
+
+---
+
+## Context
+
+The current outbreak is centred in Uganda, with confirmed spread into the eastern Democratic Republic of Congo — a region already dealing with decades of armed conflict, internal displacement, and severely strained healthcare infrastructure.
+
+The strain causing this outbreak is the **Bundibugyo ebolavirus** (BDBV), one of six known species in the Ebolavirus genus. Bundibugyo was first identified in 2007, also in Uganda, and has a case fatality rate estimated at around 25–35% — lower than the Zaire strain, which has killed up to 90% in some outbreaks, but still devastating by any standard.
+
+There is no approved vaccine specifically for the Bundibugyo strain.
+
+The vaccines that exist — rVSV-ZEBOV (Ervebo) and Ad26.ZEBOV/MVA-BN-Filo (Zabdeno/Mvabea) — were developed and validated against Zaire ebolavirus. Whether they offer meaningful cross-protection against Bundibugyo is uncertain. The WHO and partners are monitoring this carefully, and compassionate use protocols may be explored, but there is no established, ring-vaccinated response ready to deploy the way there was during the 2021 DRC and Guinea outbreaks.
+
+The regional setting compounds everything.
+
+Healthcare systems in the affected areas operate with minimal capacity — few isolation units, limited personal protective equipment, and healthcare worker shortages that existed long before this outbreak began. Conflict in eastern DRC has displaced hundreds of thousands of people, creating dense, mobile populations that are extremely difficult to trace or monitor. Surveillance capacity, which is the foundation of any outbreak response, is structurally weakened.
+
+This is not a failure of will. It is a failure of decades of underinvestment in the health infrastructure of conflict-affected regions.
+
+---
+
+## Your Take
+
+Ebola is not the most contagious virus. It is one of the most unforgiving.
+
+That distinction matters, and it explains why the global health community responds to even modest case counts with intensive mobilisation.
+
+### The lethality is systemic, not just viral
+
+Ebola's danger is not purely biological. A significant portion of outbreak mortality comes from system collapse — not from the pathogen alone.
+
+When a healthcare facility detects a case, it must isolate the patient, trace all contacts, equip staff with full personal protective equipment, and implement strict infection control. In a well-resourced system with trained personnel and adequate supplies, this is hard. In a fragile healthcare environment, it can quickly become impossible.
+
+When facilities are overwhelmed, other patients stop seeking care. Maternal deaths rise. Children with malaria or treatable infections go unmanaged. The ripple effects of an Ebola outbreak extend far beyond the case count.
+
+### Hemorrhagic fever changes the psychology of care
+
+Viral hemorrhagic fevers like Ebola produce extreme symptoms — internal bleeding, organ failure, and visible systemic collapse. This is not a comparison to other diseases, but an explanation of why it is uniquely destabilising.
+
+The visible severity of illness creates intense fear among healthcare workers, which has historically driven absenteeism even among staff willing in principle to treat patients. When nurses and doctors stop coming to work — for rational self-protective reasons — facilities that were barely functional collapse entirely.
+
+Healthcare worker infections are not just a human tragedy. They are a strategic loss that accelerates outbreaks disproportionately.
+
+### Mistrust and delayed care amplify everything
+
+In regions where healthcare has been historically inadequate, people are often reluctant to present to health facilities when sick. The pattern is consistent across outbreaks: patients arrive late, in advanced stages of disease. Fatality rates among late-presenting patients are significantly higher. And by the time a case is identified, more contacts have been exposed.
+
+Community mistrust is not irrational. In the regions now affected, populations have experienced violence, exploitation, and healthcare systems that have failed them repeatedly. Outbreak response demands trust-building that takes years to establish and can be destroyed in days.
+
+### Burial practices remain a critical transmission vector
+
+Much of the transmission in past outbreaks — particularly in West Africa in 2014 — occurred during traditional funeral practices involving direct contact with the body of the deceased.
+
+Infected bodies remain highly contagious. Safe and dignified burials are a public health intervention. But requiring communities to change sacred practices, at speed, under conditions of fear and grief, creates profound social tension. Respecting cultural practice while interrupting transmission is one of the hardest things outbreak responders do.
+
+### Why fragile regions become disproportionately dangerous
+
+Outbreaks in high-income countries with functional health systems tend to terminate quickly. Single cases imported into the United States or Europe have been contained without secondary spread, because the infrastructure to contain them exists.
+
+Outbreaks in regions where that infrastructure is absent — or has been destroyed by conflict — follow a different trajectory. Contact tracing stalls. Isolation facilities fill. Healthcare workers become cases. The chain of transmission is hard to break when the tools to break it are unavailable.
+
+This is not a story about a particularly dangerous virus. It is a story about what happens when a dangerous virus meets a broken system.
+
+---
+
+## Implications
+
+The international risk from this outbreak, for now, remains low. Ebola does not spread through casual contact. It requires direct exposure to the blood or bodily fluids of a symptomatic person. Travel-related importations are possible, but secondary spread in high-income countries has historically been contained.
+
+The concern is not that Ebola will reach London or New York and spread widely. The concern is that it will continue spreading in Uganda and DRC, that cases will increase before the response can get ahead of transmission, and that a lack of effective vaccine for this strain complicates the containment toolkit.
+
+There are broader lessons that matter regardless of how this specific outbreak resolves.
+
+**Early detection is the lever that matters most.** Every day of delay between first transmission and confirmed detection allows chains of exposure to lengthen. Investment in surveillance capacity in high-risk regions is not charity. It is the infrastructure that makes early response possible.
+
+**Outbreak response is a global public good.** The costs of containment are local, but the benefits are shared internationally. Underinvestment in health systems in sub-Saharan Africa and conflict-affected regions does not protect anyone — it creates the conditions for outbreaks to accelerate before the world notices.
+
+**Public trust is a clinical variable.** Outbreak responses that fail to engage communities, that operate without cultural competence or genuine dialogue, consistently underperform. The technical response — vaccines, isolation, contact tracing — only works if people engage with it. That engagement has to be earned, and it cannot be improvised in a crisis.
+
+**Healthcare worker safety is not a side issue.** Protecting the people responding to an outbreak is operationally essential. When PPE runs short or protocols are unclear, workers become cases. Losing experienced outbreak responders mid-crisis is a force multiplier for the virus.
+
+---
+
+## FAQ
+
+**Q: Is Ebola airborne?**
+A: No. Ebola spreads through direct contact with the blood or bodily fluids of a person who is symptomatic or has died from the disease. It is not transmitted through the air, through water, or through food. Casual contact — sitting near someone on a bus, for instance — does not transmit Ebola.
+
+**Q: How deadly is Ebola?**
+A: It depends on the strain and the setting. The Zaire strain, the most studied, has killed between 25% and 90% of those infected across different outbreaks. The Bundibugyo strain currently circulating has an estimated case fatality rate of around 25–35%. Mortality drops substantially with early, supportive care — which is why access to healthcare matters so much.
+
+**Q: Why is this outbreak different from previous ones?**
+A: The Bundibugyo strain has no approved vaccine with validated efficacy. The geographic setting — spanning conflict-affected eastern DRC — significantly complicates contact tracing and community engagement. And the regional healthcare infrastructure is under severe strain. It is not necessarily more dangerous at the viral level, but it is harder to contain.
+
+**Q: Is there a vaccine for Ebola?**
+A: Yes, but not for this strain specifically. The approved vaccines target Zaire ebolavirus and have been highly effective in past outbreaks. Whether they provide meaningful cross-protection against Bundibugyo is not well established. Research is ongoing, and compassionate use of available vaccines may be considered by outbreak responders.
+
+**Q: Could Ebola spread globally like COVID-19 did?**
+A: This is extremely unlikely. COVID-19 spread globally because it is airborne, has a long pre-symptomatic infectious period, and spreads efficiently from people with mild or no symptoms. Ebola requires direct contact with bodily fluids, and people are most infectious when they are severely symptomatic — which means they are generally too ill to move around or expose many others. The biological profile is fundamentally different.
+
+---
+
+## Further Reading
+
+- [WHO Ebola Disease Fact Sheet](https://www.who.int/news-room/fact-sheets/detail/ebola-virus-disease)
+- [CDC Ebola Information](https://www.cdc.gov/ebola/)
+- [Infectious Disease Hub](/guides/infectious-disease-hub)
+
+---
+
+## Closing
+
+Ebola reminds us that the danger of an outbreak is not just the virus itself — but the strength of the systems trying to contain it.
+
+That framing shifts the question from "how lethal is this pathogen?" to "how capable are we of stopping it?" And the honest answer, in the regions currently affected, is: not capable enough, not yet.
+
+The goal is not to frighten people. It is to understand what is actually at stake — and why global health infrastructure is not a geopolitical luxury, but a shared foundation we all depend on.


### PR DESCRIPTION
## Summary

- Timely infectious disease analysis post covering the 2026 Ebola outbreak (Bundibugyo strain, Uganda/DRC)
- Calm, public-health framing that explains why experts are concerned despite Ebola's relatively low contagiousness, without sensationalism or alarmism
- Covers the vaccine gap (no approved Bundibugyo-specific vaccine), fragile health systems, healthcare worker risk, community trust dynamics, burial practice context, and global health infrastructure implications
- 5-question FAQ with factual, concise answers including airborne status, lethality, strain differences, vaccine availability, and global spread risk
- Internal link to /guides/infectious-disease-hub; external links to WHO and CDC Ebola pages
- Positioned as educational explainer for a general audience, readable without clinical background

## Test plan

- [x] npm run build succeeded (699 pages + 701 pagefind entries)
- [x] Post renders at /posts/ebola-outbreak-why-experts-concerned-2026/
- [x] Internal link to /guides/infectious-disease-hub confirmed (guide exists as infectious-disease-hub.mdx)
- [x] Frontmatter dates are quoted ISO strings; no trailing slashes in internal links
- [x] Draft set to false

Generated with Claude Code