### PR TITLE
feat(kidney): add CKD guides and GLP-1 kidney protection post

### DIFF
--- a/src/content/guides/chronic-kidney-disease-stages-explained.md
+++ b/src/content/guides/chronic-kidney-disease-stages-explained.md
@@ -1,0 +1,254 @@
+---
+title: "Chronic Kidney Disease Stages Explained"
+description: "A clear explanation of CKD stages 1 to 5, how eGFR and albuminuria are used together, what progression means, and how to reduce your risk."
+category: "Diabetes"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["chronic kidney disease", "CKD stages", "eGFR", "albuminuria", "kidney disease progression", "kidney failure", "dialysis"]
+draft: false
+faq:
+  - q: "What is a normal eGFR?"
+    a: "An eGFR of 90 or above is considered normal for most adults. However, eGFR naturally declines with age — an eGFR of 60–75 in an older adult without other signs of kidney damage may not indicate disease. Context matters."
+  - q: "Is Stage 3 CKD serious?"
+    a: "Stage 3 is moderate CKD and warrants medical attention, but many people with Stage 3a or 3b CKD live with stable kidney function for many years. The priority is identifying and managing causes (blood pressure, blood glucose) to prevent progression."
+  - q: "What is the difference between Stage 3a and 3b?"
+    a: "Both are Stage 3, but 3a (eGFR 45–59) represents milder impairment than 3b (eGFR 30–44). Stage 3b carries a higher risk of progression and cardiovascular disease, and typically requires closer follow-up."
+  - q: "Can you reverse CKD stages?"
+    a: "In most cases, CKD damage is not reversible. However, the goal of treatment is to stabilise kidney function — and some people with Stage 1 or 2 CKD caused by a treatable condition (such as obstruction) may see improvement. Progression is not inevitable."
+  - q: "When does CKD become kidney failure?"
+    a: "Kidney failure (Stage 5, also called end-stage kidney disease or ESKD) is defined as an eGFR below 15 mL/min/1.73m². At this point, the kidneys can no longer adequately filter waste and fluid. Dialysis or transplant becomes necessary only when symptoms of kidney failure emerge — not automatically at a particular eGFR number."
+  - q: "Does everyone with CKD need dialysis eventually?"
+    a: "No. The majority of people with CKD — especially those diagnosed in early stages — never reach kidney failure. Even in Stage 4, careful management can sometimes maintain adequate kidney function for years."
+---
+
+## Intro
+
+Chronic kidney disease (CKD) is measured and classified using a staging system that combines two pieces of information: how well the kidneys filter blood (eGFR), and how much protein is leaking into the urine (albuminuria). Together, these give clinicians — and patients — a clearer picture of where someone stands and how closely they need to be monitored.
+
+This guide explains the stages from 1 through 5, what they mean in practice, and what can be done to slow or prevent progression.
+
+---
+
+## Key Points
+
+- CKD is staged using **eGFR** (kidney filtration rate) and **urine albumin** (protein leakage)
+- Stages run from 1 (mildest) to 5 (kidney failure); sub-stages 3a and 3b are important distinctions
+- **Stage alone does not tell the whole story** — albuminuria, rate of change, and underlying cause all matter
+- Most people with CKD, especially Stages 1–3, **never reach kidney failure**
+- **Blood pressure control and blood glucose management** are the most important tools for slowing progression
+- Dialysis and transplant are late-stage options, not inevitable outcomes
+
+---
+
+## eGFR: The Filtration Rate
+
+eGFR stands for estimated glomerular filtration rate. It estimates how much blood the kidneys filter per minute, adjusted for body surface area. It is derived from a blood test (serum creatinine), together with age and sex.
+
+A quick reference:
+
+| eGFR (mL/min/1.73m²) | Meaning |
+|---|---|
+| 90 or above | Normal or high |
+| 60–89 | Mildly reduced |
+| 45–59 | Mildly to moderately reduced |
+| 30–44 | Moderately to severely reduced |
+| 15–29 | Severely reduced |
+| Below 15 | Kidney failure |
+
+eGFR naturally declines slightly with age — roughly 1 mL/min/1.73m² per year after the age of 40. A modest decline in an older adult without other evidence of kidney damage is not automatically CKD. Context matters.
+
+---
+
+## Albuminuria: Protein in the Urine
+
+Albumin is a protein found in blood. Healthy kidneys keep albumin inside the bloodstream. When kidneys are damaged, albumin leaks into the urine — a sign of structural or functional impairment.
+
+Albuminuria is measured using the urine albumin-to-creatinine ratio (ACR):
+
+| ACR | Category |
+|---|---|
+| Below 3 mg/mmol (< 30 mg/g) | A1 — Normal to mildly increased |
+| 3–30 mg/mmol (30–300 mg/g) | A2 — Moderately increased |
+| Above 30 mg/mmol (> 300 mg/g) | A3 — Severely increased |
+
+High albuminuria (A2 or A3) carries an independent risk of CKD progression and cardiovascular disease — even in people with relatively preserved eGFR. It is not just a side note; it is a key part of the overall risk picture.
+
+---
+
+## The Stages of CKD
+
+### Stage 1 — Kidney Damage with Normal Function
+**eGFR: 90 or above**
+
+At Stage 1, the kidneys are filtering blood normally or near-normally, but there is evidence of damage — most commonly albuminuria, abnormalities on imaging, or persistent blood in the urine. eGFR alone would not indicate CKD; it is the presence of damage markers that defines this stage.
+
+Most people with Stage 1 CKD have no symptoms. Detection is usually incidental — found on routine testing for diabetes or blood pressure follow-up.
+
+**Outlook:** With attention to underlying causes, function can remain stable. The focus is on preventing progression.
+
+---
+
+### Stage 2 — Mild Reduction in Kidney Function
+**eGFR: 60–89**
+
+Stage 2 is characterised by mildly reduced filtration alongside evidence of kidney damage. Again, eGFR in this range without damage markers would not be classified as CKD — the combination matters.
+
+Symptoms remain absent in most people. Regular monitoring, blood pressure control, and management of underlying conditions are the priorities.
+
+**Outlook:** Many people with Stage 2 remain stable for years. Early intervention gives the best chance of preventing further decline.
+
+---
+
+### Stage 3a — Mild to Moderate Reduction
+**eGFR: 45–59**
+
+Stage 3 represents the point where kidney impairment becomes more meaningful. The 3a sub-stage covers the less severe half of this range.
+
+Mild complications may begin to appear — slightly elevated blood pressure or mild anaemia — though most people still have no noticeable symptoms.
+
+**Outlook:** Regular monitoring is recommended. Some people remain at Stage 3a for many years.
+
+---
+
+### Stage 3b — Moderate to Severe Reduction
+**eGFR: 30–44**
+
+Stage 3b carries meaningfully higher risk than 3a — both of progression to later stages and of cardiovascular disease. People in this stage are more likely to have complications such as anaemia, bone mineral problems, or difficulty maintaining blood pressure.
+
+Referral to a nephrologist (kidney specialist) is often recommended at Stage 3b, particularly if eGFR is declining or albuminuria is high.
+
+**Outlook:** More intensive monitoring and management. With optimal control of blood pressure and blood glucose, some people stabilise here.
+
+---
+
+### Stage 4 — Severe Reduction in Kidney Function
+**eGFR: 15–29**
+
+Stage 4 is advanced CKD. Waste products and fluid begin to accumulate. Complications including anaemia, elevated phosphate, altered calcium metabolism, and cardiovascular risk become significant.
+
+At this stage, planning for future kidney replacement therapy (dialysis or transplant) begins — not because it is imminent, but to allow time for preparation if needed.
+
+Symptoms may start to appear: fatigue, reduced appetite, swelling.
+
+**Outlook:** Close specialist management. Some people remain at Stage 4 for years with careful treatment.
+
+---
+
+### Stage 5 — Kidney Failure (End-Stage Kidney Disease)
+**eGFR: below 15**
+
+At Stage 5, kidney function is insufficient to adequately filter waste and maintain fluid and electrolyte balance. This is end-stage kidney disease (ESKD).
+
+Kidney replacement therapy — dialysis or kidney transplantation — becomes necessary when symptoms of kidney failure emerge. Not everyone with an eGFR below 15 begins dialysis immediately; clinical judgement, symptoms, and patient preference all factor in.
+
+Kidney transplantation, where possible, generally provides better long-term outcomes than dialysis.
+
+---
+
+## Why Stage Alone Does Not Tell the Whole Story
+
+CKD staging is not purely about the eGFR number. Two people at Stage 3a may have very different outlooks depending on:
+
+- **Rate of decline** — an eGFR falling by 5 mL/min/year is far more concerning than a stable eGFR of 50 over five years
+- **Albuminuria level** — someone with Stage 3a and A3 albuminuria has a substantially higher risk of progression than someone with Stage 3a and A1
+- **Underlying cause** — treatable causes (hypertension, obstruction, medication-related) carry better prospects than progressive glomerular diseases
+- **Cardiovascular health** — for many people with CKD, cardiovascular disease is a greater near-term risk than kidney failure
+
+CKD staging is a useful tool for communicating risk and guiding monitoring frequency — but prognosis is always individual.
+
+---
+
+## What Progression Means
+
+Progression in CKD is defined by:
+
+- A sustained decline in eGFR over time (typically >5 mL/min/1.73m² per year)
+- Worsening albuminuria category (e.g. from A1 to A2)
+- Movement from one CKD stage to a higher one
+
+Not all CKD progresses. A significant proportion of people — particularly those with Stage 1–3 CKD detected early and managed well — remain stable for the rest of their lives without reaching kidney failure.
+
+---
+
+## Slowing Progression: What Works
+
+The most effective strategies for slowing CKD progression are well established:
+
+**Blood pressure control**
+Maintaining blood pressure below 130/80 mmHg (and sometimes lower in people with significant albuminuria) is among the single most important interventions for kidney protection.
+
+**Blood glucose management**
+In people with [type 2 diabetes](/guides/type-2-diabetes) and CKD, tight blood glucose control reduces the rate of kidney damage. This is why diabetes management and kidney management are closely linked.
+
+**Medicines with kidney-protective effects**
+- **ACE inhibitors and ARBs** — these blood pressure medicines also reduce albuminuria and have direct kidney-protective effects
+- **SGLT2 inhibitors** (such as empagliflozin and dapagliflozin) — originally diabetes drugs, now shown in large trials to slow CKD progression independently of blood glucose effects
+- **GLP-1 receptor agonists** — growing evidence suggests these may also reduce CKD progression, particularly in people with diabetes and obesity; see [Could GLP-1 Drugs Help Protect the Kidneys?](/posts/ozempic-glp1-kidney-protection-2026)
+
+**Lifestyle factors**
+- Stop smoking — smoking accelerates kidney disease progression and cardiovascular risk
+- Reduce salt intake — helps with blood pressure management
+- Maintain a healthy weight — obesity contributes to both diabetes and hypertension
+- Avoid NSAIDs (ibuprofen, naproxen) regularly — these reduce blood flow to the kidneys and can accelerate decline
+- Stay well hydrated, but do not over-drink
+
+**Regular follow-up**
+Monitoring frequency depends on stage and albuminuria. People at higher risk should have eGFR and urine albumin checked regularly — often every 3–6 months for advanced stages.
+
+---
+
+## Dialysis and Transplant
+
+Dialysis and kidney transplantation are treatments for kidney failure — Stage 5 CKD — not for earlier stages.
+
+**Dialysis** replaces some kidney function by filtering waste products and excess fluid from the blood. It does not restore kidney function or reverse CKD. There are two main forms: haemodialysis (typically done at a clinic several times per week) and peritoneal dialysis (done at home daily).
+
+**Kidney transplantation** involves placing a donated kidney (from a living or deceased donor) into the body. A successful transplant generally provides better quality of life and survival than dialysis, though it requires lifelong immunosuppression and is not suitable for everyone.
+
+The key message: these are options that become relevant only at the most advanced stage, and for many people with CKD, they are never needed.
+
+---
+
+## FAQ
+
+**Q: What is a normal eGFR?**
+A: An eGFR of 90 or above is considered normal for most adults. However, eGFR naturally declines with age — an eGFR of 60–75 in an older adult without other signs of kidney damage may not indicate disease. Context matters.
+
+**Q: Is Stage 3 CKD serious?**
+A: Stage 3 is moderate CKD and warrants medical attention, but many people with Stage 3a or 3b CKD live with stable kidney function for many years. The priority is identifying and managing causes to prevent progression.
+
+**Q: What is the difference between Stage 3a and 3b?**
+A: Both are Stage 3, but 3a (eGFR 45–59) represents milder impairment than 3b (eGFR 30–44). Stage 3b carries a higher risk of progression and cardiovascular disease, and typically requires closer follow-up.
+
+**Q: Can you reverse CKD stages?**
+A: In most cases, CKD damage is not reversible. However, the goal of treatment is to stabilise kidney function — and some people with Stage 1 or 2 CKD caused by a treatable condition may see improvement. Progression is not inevitable.
+
+**Q: When does CKD become kidney failure?**
+A: Kidney failure (Stage 5, or ESKD) is defined as an eGFR below 15 mL/min/1.73m². Dialysis or transplant becomes necessary when symptoms of kidney failure emerge — not automatically at a particular number.
+
+**Q: Does everyone with CKD need dialysis eventually?**
+A: No. The majority of people with CKD — especially those diagnosed in early stages — never reach kidney failure. Even in Stage 4, careful management can sometimes maintain adequate kidney function for years.
+
+---
+
+## Further Reading
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
+- [KDIGO — Clinical Practice Guidelines for CKD](https://kdigo.org/guidelines/ckd-evaluation-and-management/)
+- [National Kidney Foundation — Kidney Disease Stages](https://www.kidney.org/kidney-topics/chronic-kidney-disease-ckd)
+- [NIDDK — Managing CKD](https://www.niddk.nih.gov/health-information/kidney-disease/chronic-kidney-disease-ckd/managing)
+- [NHS — Chronic Kidney Disease: Stages](https://www.nhs.uk/conditions/kidney-disease/)
+
+---
+
+## Related Guides
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — foundations: causes, symptoms, and tests
+- [Type 2 Diabetes](/guides/type-2-diabetes) — the leading cause of CKD; managing diabetes is inseparable from managing diabetic kidney disease
+- [High Blood Pressure](/guides/high-blood-pressure) — blood pressure control is the most important modifiable factor in slowing progression
+- [Diabetes Hub](/guides/diabetes-hub) — broader context on diabetes types, complications, and management
+- [Could GLP-1 Drugs Help Protect the Kidneys?](/posts/ozempic-glp1-kidney-protection-2026) — emerging evidence on GLP-1 medications and kidney function
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice, diagnosis, or treatment. Always speak with a qualified healthcare provider about your specific situation.*

--- a/src/content/guides/what-is-chronic-kidney-disease.md
+++ b/src/content/guides/what-is-chronic-kidney-disease.md
@@ -1,0 +1,203 @@
+---
+title: "What Is Chronic Kidney Disease?"
+description: "A clear guide to chronic kidney disease — what it is, why it often goes unnoticed, how it is measured, and when to seek medical advice."
+category: "Diabetes"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["chronic kidney disease", "CKD", "kidney function", "eGFR", "albuminuria", "kidney damage", "renal disease"]
+draft: false
+faq:
+  - q: "Can CKD be cured?"
+    a: "CKD is generally not reversible, but it can often be slowed significantly with the right treatment and lifestyle changes. For some people — especially those with early-stage CKD and treatable causes — function can stabilise for many years."
+  - q: "Does CKD always progress to kidney failure?"
+    a: "No. Most people with CKD — especially those diagnosed at early stages — never reach kidney failure. The goal of management is to slow progression and reduce cardiovascular risk. Many people live with stable, mild CKD for decades."
+  - q: "Will I know if my kidneys are failing?"
+    a: "Not necessarily, especially in early stages. CKD is usually silent until it is advanced. This is why blood and urine tests are important for people with risk factors, even when they feel well."
+  - q: "Is CKD the same as kidney failure?"
+    a: "No. CKD covers a spectrum from mild to severe kidney impairment. Kidney failure (end-stage kidney disease, or ESKD) is the most severe end of the spectrum, where the kidneys can no longer function adequately without dialysis or a transplant."
+  - q: "Can I develop CKD without diabetes or high blood pressure?"
+    a: "Yes, though these are the two most common causes. Autoimmune conditions, inherited diseases, repeated infections, and other factors can all cause kidney damage. Some people develop CKD with no identifiable cause."
+  - q: "Can children get CKD?"
+    a: "Yes, though it is far less common in children. When it does occur, inherited or congenital causes — such as abnormal kidney development or polycystic kidney disease — are more likely than in adults."
+---
+
+## Intro
+
+Chronic kidney disease (CKD) is not a single condition. It is an umbrella term for persistent, long-lasting kidney damage or a reduction in kidney function — usually defined as lasting three months or more.
+
+CKD is one of the most common serious conditions in the world. It is also one of the least recognised by the people who have it. Most people with early to moderate CKD have no symptoms and no idea their kidneys are not working as they should.
+
+---
+
+## Key Points
+
+- CKD means the kidneys are damaged or not filtering blood efficiently — persisting for three months or more
+- It is very common and often has **no symptoms** until it is advanced
+- The most common causes are **type 2 diabetes** and **high blood pressure**
+- Early detection relies on blood and urine tests, not symptoms
+- CKD can often be **slowed but not reversed**
+- Most people with CKD never reach kidney failure — but all stages carry increased cardiovascular risk
+
+---
+
+## What the Kidneys Do
+
+The kidneys are two bean-shaped organs that sit on either side of the spine, below the ribcage. Each is roughly the size of a fist.
+
+Their main jobs include:
+
+- **Filtering blood** — removing waste products and excess fluid, which leave the body as urine
+- **Regulating blood pressure** — through control of fluid volume and hormone signals
+- **Balancing electrolytes** — sodium, potassium, phosphorus, and bicarbonate levels
+- **Producing hormones** — including erythropoietin (which stimulates red blood cell production)
+- **Activating vitamin D** — needed for bone health and immune function
+
+Healthy kidneys filter around 180 litres of blood every day. When this process is impaired — even partially — the effects ripple across many body systems.
+
+---
+
+## What CKD Means
+
+CKD is defined as either:
+
+- **Kidney damage** shown by abnormal urine, blood, or imaging tests, or
+- **Reduced kidney function** — an eGFR below 60 mL/min/1.73m²
+
+...persisting for **three months or more**.
+
+The "chronic" in CKD distinguishes it from acute kidney injury (AKI), which develops rapidly over hours or days and may be reversible. CKD represents sustained loss of kidney capacity — gradual in most cases, with damage that usually cannot be fully undone.
+
+---
+
+## Common Causes
+
+CKD does not have a single cause. It develops from long-term damage from one or more sources.
+
+**Metabolic and vascular causes (most common):**
+- **Type 2 diabetes** — the leading cause of CKD worldwide. Persistently high blood glucose damages the small blood vessels that supply the kidney's filtering units (diabetic nephropathy)
+- **High blood pressure (hypertension)** — sustained high pressure damages the kidneys' delicate filtration structures
+- **Obesity** — contributes through its effects on blood pressure, blood glucose, and additional metabolic pathways
+
+**Kidney-specific causes:**
+- **Glomerulonephritis** — inflammation affecting the glomeruli (the kidney's filtering units)
+- **Polycystic kidney disease (PKD)** — an inherited condition causing fluid-filled cysts in the kidneys
+
+**Other causes:**
+- **Autoimmune conditions** — including lupus and IgA nephropathy
+- **Recurrent kidney infections** — repeated pyelonephritis can lead to scarring
+- **Obstruction** — kidney stones, enlarged prostate, or structural problems that block urine flow
+- **Certain medicines** — including long-term use of NSAIDs (ibuprofen, naproxen) and some antibiotics
+
+In many people, no single cause is identified. Age, genetics, and cumulative damage all play a role.
+
+---
+
+## Why CKD Is Often Silent
+
+The kidneys have significant reserve capacity. In early stages, healthy tissue compensates for damaged areas — and the body gives no warning. Symptoms, when they do appear, tend to reflect advanced disease.
+
+By the time symptoms such as fatigue, fluid retention, or reduced urination develop, CKD may already be at a late stage.
+
+This is why screening matters — particularly for people with type 2 diabetes, high blood pressure, a family history of kidney disease, or established cardiovascular disease.
+
+---
+
+## How CKD Is Measured
+
+### eGFR — Estimated Glomerular Filtration Rate
+
+eGFR estimates how efficiently the kidneys filter blood. It is calculated from a blood test (serum creatinine), along with age and sex.
+
+A rough guide to eGFR ranges:
+- **90 or above** — normal or high (if damage is also present, this may still be CKD Stage 1)
+- **60–89** — mildly reduced
+- **30–59** — moderately reduced
+- **15–29** — severely reduced
+- **Below 15** — kidney failure territory
+
+A single low reading is not diagnostic. CKD requires the finding to persist over at least three months.
+
+### Urine Albumin / Protein
+
+Albumin is a protein found in blood. Healthy kidneys keep albumin out of urine. When the kidneys are damaged, albumin leaks through — a condition called albuminuria or proteinuria.
+
+Urine albumin is measured as the albumin-to-creatinine ratio (ACR):
+- **Normal:** below 3 mg/mmol (below 30 mg/g)
+- **Mildly elevated (A2):** 3–30 mg/mmol
+- **Severely elevated (A3):** above 30 mg/mmol
+
+Both eGFR and urine albumin are used together to classify CKD severity and predict risk. See [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) for the full staging system.
+
+---
+
+## When to Seek Medical Advice
+
+Speak to a doctor if:
+
+- You have [type 2 diabetes](/guides/type-2-diabetes) and have not had a recent kidney function test
+- You have [high blood pressure](/guides/high-blood-pressure) that is difficult to control
+- You have a family history of kidney disease or polycystic kidney disease
+- A routine blood or urine test has flagged a concern about kidney function
+- You are taking regular NSAIDs or other medicines that may affect the kidneys
+
+If you have risk factors for CKD, regular monitoring is usually recommended even if you feel well.
+
+---
+
+## Red Flags — Seek Urgent Care
+
+Seek urgent medical attention if you experience:
+
+- Sudden, marked change in urine output — much less or much more than normal
+- Severe swelling of the legs, ankles, or around the eyes
+- Difficulty breathing (which may indicate fluid build-up)
+- Confusion, severe fatigue, or difficulty concentrating
+- Dark, foamy, or blood-coloured urine
+
+These may indicate rapidly worsening kidney function requiring prompt assessment.
+
+---
+
+## FAQ
+
+**Q: Can CKD be cured?**
+A: CKD is generally not reversible, but it can often be slowed significantly with the right treatment and lifestyle changes. For some people — especially those with early-stage CKD and treatable causes — function can stabilise for many years.
+
+**Q: Does CKD always progress to kidney failure?**
+A: No. Most people with CKD — especially those diagnosed at early stages — never reach kidney failure. The goal of management is to slow progression and reduce cardiovascular risk. Many people live with stable, mild CKD for decades.
+
+**Q: Will I know if my kidneys are failing?**
+A: Not necessarily, especially in early stages. CKD is usually silent until it is advanced. This is why blood and urine tests are important for people with risk factors, even when they feel well.
+
+**Q: Is CKD the same as kidney failure?**
+A: No. CKD covers a spectrum from mild to severe kidney impairment. Kidney failure (end-stage kidney disease, or ESKD) is the most severe end of the spectrum, where the kidneys can no longer function adequately without dialysis or a transplant.
+
+**Q: Can I develop CKD without diabetes or high blood pressure?**
+A: Yes, though these are the two most common causes. Autoimmune conditions, inherited diseases, repeated infections, and other factors can all cause kidney damage. Some people develop CKD with no identifiable cause.
+
+**Q: Can children get CKD?**
+A: Yes, though it is far less common in children. When it does occur, inherited or congenital causes — such as abnormal kidney development or polycystic kidney disease — are more likely than in adults.
+
+---
+
+## Further Reading
+
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained)
+- [CDC — Chronic Kidney Disease](https://www.cdc.gov/kidneydisease/)
+- [National Kidney Foundation — About CKD](https://www.kidney.org/kidney-topics/chronic-kidney-disease-ckd)
+- [NIDDK — What Is Chronic Kidney Disease?](https://www.niddk.nih.gov/health-information/kidney-disease/chronic-kidney-disease-ckd)
+- [NHS — Chronic Kidney Disease](https://www.nhs.uk/conditions/kidney-disease/)
+
+---
+
+## Related Guides
+
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) — the staging system, eGFR numbers, and how risk is classified
+- [Type 2 Diabetes](/guides/type-2-diabetes) — the leading cause of CKD globally
+- [High Blood Pressure](/guides/high-blood-pressure) — second leading cause; blood pressure control is central to kidney protection
+- [Diabetes Hub](/guides/diabetes-hub) — overview of diabetes types, complications, and management
+- [GLP-1 Weight Loss Drugs](/guides/glp-1-weight-loss-drugs) — background on GLP-1 medications increasingly linked to kidney protection
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice, diagnosis, or treatment. Always speak with a qualified healthcare provider about any medical concerns.*

--- a/src/content/posts/ozempic-glp1-kidney-protection-2026.md
+++ b/src/content/posts/ozempic-glp1-kidney-protection-2026.md
@@ -1,0 +1,145 @@
+---
+title: "Could Ozempic and Similar Drugs Help Protect the Kidneys?"
+slug: "ozempic-glp1-kidney-protection-2026"
+description: "GLP-1 drugs are best known for diabetes and weight loss, but growing evidence suggests they may also help protect kidney function in some patients."
+publishDate: "2026-05-31"
+tags: ["GLP-1", "semaglutide", "Ozempic", "chronic kidney disease", "CKD", "kidney protection", "cardiometabolic", "type 2 diabetes"]
+draft: false
+related:
+  - /guides/what-is-chronic-kidney-disease
+  - /guides/chronic-kidney-disease-stages-explained
+  - /guides/ozempic-glp-1-guide
+---
+
+## Hook
+
+For the past few years, GLP-1 receptor agonists — semaglutide (Ozempic, Wegovy), liraglutide, dulaglutide, tirzepatide — have dominated the conversation around weight loss and type 2 diabetes.
+
+But a quieter story has been building in the background.
+
+Evidence now suggests that GLP-1 drugs may do something beyond managing blood sugar and body weight: they may help slow kidney disease.
+
+If that holds up across larger, longer trials, GLP-1 medications will no longer be just a metabolic story. They may become part of how medicine thinks about protecting the kidneys — one of the most silently damaged organs in modern disease.
+
+---
+
+## Context
+
+Chronic kidney disease affects an estimated 850 million people worldwide. Yet most people with CKD have no idea they have it — the kidneys lose function quietly, over years, before any symptoms emerge.
+
+The connection between CKD and metabolic disease is not coincidental. The two most common causes of CKD are **type 2 diabetes** and **high blood pressure** — conditions that also sit at the centre of the cardiometabolic cluster that GLP-1 drugs were designed to address.
+
+Diabetic nephropathy (kidney damage caused by persistently high blood glucose) is the single largest driver of kidney failure worldwide. And it is not just blood sugar: obesity, vascular inflammation, and elevated blood pressure all accelerate kidney damage through overlapping pathways.
+
+This is the context in which the new kidney data matters. GLP-1 drugs are not primarily kidney medicines. But they act on several of the pathways that destroy kidney function — and that may be why kidney benefits are appearing.
+
+---
+
+## Your Take
+
+The story here is not "Ozempic cures kidney disease."
+
+The story is more interesting: **kidney disease is often a downstream consequence of metabolic dysfunction** — of uncontrolled diabetes, excess weight, elevated blood pressure, chronic low-grade inflammation, and vascular damage. GLP-1 drugs may help the kidneys because they act on several of those upstream problems at once.
+
+A drug that lowers blood glucose, reduces weight, lowers blood pressure, reduces inflammation, and reduces albuminuria is not a surprise as a kidney protector. It is a logical consequence of the same biology.
+
+That does not mean these drugs should replace established kidney-protective therapies, or that everyone with CKD should be on a GLP-1 agonist. The picture is more nuanced. But it does suggest that the conversation around GLP-1 medications is expanding — from metabolic medicine into broader organ protection territory.
+
+---
+
+## What the Evidence Suggests
+
+The kidney data for GLP-1 drugs comes from a combination of secondary analyses of diabetes cardiovascular outcome trials, observational data, and — increasingly — trials with kidney outcomes as primary endpoints.
+
+The FLOW trial (semaglutide in people with type 2 diabetes and CKD) showed a reduction in major kidney events and cardiovascular outcomes. This was among the first large dedicated kidney trials for a GLP-1 drug, and its results added weight to what earlier trials had suggested.
+
+It is worth noting that this evidence is strongest in people who have **type 2 diabetes, obesity, or elevated cardiometabolic risk**. The kidney benefits seen in these populations may not translate directly to people with CKD caused by other mechanisms (such as glomerular disease, polycystic kidney disease, or autoimmune conditions).
+
+---
+
+## How GLP-1 Drugs May Help the Kidneys
+
+The kidney benefits are thought to arise through several overlapping mechanisms — none of them unique to the kidneys, but collectively significant:
+
+**1. Blood glucose control**
+High blood glucose damages the small blood vessels that supply the kidney's filtering units. Better glucose management — the primary effect of GLP-1 drugs in type 2 diabetes — reduces this ongoing vascular damage. This is not a new idea; improving HbA1c has long been associated with slower diabetic nephropathy progression.
+
+**2. Weight reduction**
+Obesity is an independent risk factor for CKD, partly through its effects on blood pressure and blood glucose, and partly through direct mechanical and metabolic pressure on the kidneys. GLP-1-mediated weight loss may reduce this burden.
+
+**3. Lower blood pressure**
+GLP-1 drugs are associated with modest but consistent reductions in systolic blood pressure. In the context of kidney disease — where high blood pressure is both a cause and a consequence of CKD — even modest blood pressure reductions matter over time.
+
+**4. Reduced albuminuria**
+Several trials have shown reductions in urine albumin (a marker of kidney damage) in people taking GLP-1 receptor agonists. Reduced albuminuria is independently associated with slower CKD progression — though whether the albuminuria reduction seen with GLP-1 drugs reflects genuine structural kidney protection, or is partly a haemodynamic effect, remains under investigation.
+
+**5. Anti-inflammatory and vascular effects**
+GLP-1 receptors are present in multiple tissues, including the kidneys and blood vessels. Animal and early human data suggest potential direct anti-inflammatory effects in the kidney. Whether these translate meaningfully to clinical outcomes in humans is still being studied.
+
+---
+
+## Important Caveats
+
+**Benefits are not universal.**
+The evidence for kidney protection with GLP-1 drugs is strongest in people with type 2 diabetes, obesity, or both. People with CKD caused by autoimmune conditions, inherited diseases, or other non-metabolic mechanisms have less evidence to draw on.
+
+**GLP-1 drugs are not the only kidney-protective option — and may not be first-line.**
+SGLT2 inhibitors (empagliflozin, dapagliflozin, canagliflozin) have substantial, high-quality evidence for slowing CKD progression — including in people without diabetes. ACE inhibitors and ARBs have been kidney-protective for decades. Any conversation about kidney protection has to include all of these options, not just the newest class.
+
+**Not everyone with CKD should take GLP-1 drugs.**
+There are contraindications, cautions, and individual factors that matter. Some GLP-1 drugs may require dose adjustment in kidney disease. Treatment decisions in CKD — which drugs, in what combination, at what stage — belong with a clinician who knows the full picture.
+
+**We are still learning.**
+The FLOW trial represents important progress, but it is not the final word. Longer-term data, head-to-head comparisons, and data in non-diabetic CKD populations are still emerging.
+
+---
+
+## Implications
+
+If GLP-1 drugs do become a standard component of kidney protection in people with type 2 diabetes and CKD, several things follow:
+
+- **CKD management becomes more integrated.** Kidney disease, cardiovascular disease, diabetes, and obesity are managed together — not in silos between specialists.
+- **GLP-1 prescribing indications widen.** The initial indication was type 2 diabetes. Then obesity. Now cardiovascular protection. Kidney protection may be next.
+- **Combination metabolic therapy becomes more common.** SGLT2 inhibitors plus GLP-1 agonists, possibly alongside ACE inhibitors or ARBs, may become a standard protective stack for high-risk individuals.
+- **Earlier intervention becomes more compelling.** If GLP-1 drugs can help slow CKD progression from the metabolic side, detecting CKD earlier — and treating its drivers earlier — becomes more important.
+
+---
+
+## FAQ
+
+**Q: Can Ozempic treat kidney disease?**
+A: No GLP-1 drug is currently approved specifically to treat CKD. Evidence suggests these drugs may help slow kidney disease progression in people with type 2 diabetes and CKD, but they are not a treatment for kidney disease itself. Anyone with CKD should discuss their medication options with a nephrologist or GP.
+
+**Q: Is semaglutide safe to use if I have CKD?**
+A: Some GLP-1 drugs can be used in CKD, but dose adjustments or specific cautions may apply depending on kidney function and the specific drug. This is a question for a prescribing clinician with access to your kidney function results and full medical history.
+
+**Q: What is the FLOW trial?**
+A: FLOW was a large randomised controlled trial evaluating semaglutide in people with type 2 diabetes and CKD. It was designed with kidney outcomes (such as sustained decline in eGFR or kidney failure) as primary endpoints — making it one of the first trials to assess a GLP-1 drug specifically for kidney protection rather than as a secondary finding from a cardiovascular trial.
+
+**Q: Are SGLT2 inhibitors better than GLP-1 drugs for the kidneys?**
+A: SGLT2 inhibitors (such as empagliflozin and dapagliflozin) currently have stronger and broader kidney outcome data, including in people without diabetes. They are widely considered first-line kidney-protective medicines. GLP-1 drugs are not a replacement — they may be complementary, and the two classes work through different mechanisms.
+
+**Q: Do GLP-1 drugs protect the kidneys in people without diabetes?**
+A: The evidence is much stronger in people with type 2 diabetes. Whether GLP-1 drugs provide meaningful kidney protection in people with CKD from non-diabetic causes is not yet well established. Research in non-diabetic CKD populations is ongoing.
+
+**Q: What other steps protect the kidneys?**
+A: The most evidence-backed kidney-protective strategies include controlling blood pressure (often with ACE inhibitors or ARBs), managing blood glucose in diabetes, stopping smoking, maintaining a healthy weight, avoiding regular NSAID use, and taking SGLT2 inhibitors where appropriate. GLP-1 drugs are a potential addition for people who meet relevant criteria — not a replacement for these foundations.
+
+**Q: Should I ask my doctor about GLP-1 drugs for my kidneys?**
+A: If you have CKD alongside type 2 diabetes or obesity, it is a reasonable question to raise. A clinician can weigh your specific stage of CKD, other medications, cardiovascular risk, and overall health to advise whether a GLP-1 drug is appropriate for you.
+
+---
+
+## Further Reading
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained)
+- [Ozempic and GLP-1 Weight Loss Drugs](/guides/ozempic-glp-1-guide)
+- [GLP-1 Weight Loss Drugs: How They Work, Benefits, and Risks](/guides/glp-1-weight-loss-drugs)
+- [National Kidney Foundation — CKD](https://www.kidney.org/kidney-topics/chronic-kidney-disease-ckd)
+- [NIDDK — Diabetic Kidney Disease](https://www.niddk.nih.gov/health-information/diabetes/overview/preventing-problems/diabetic-kidney-disease)
+- [KDIGO — Clinical Practice Guidelines for CKD](https://kdigo.org/guidelines/ckd-evaluation-and-management/)
+
+---
+
+*This article is for informational purposes only. It does not constitute medical advice, and does not represent the views of any clinical body. Always consult a qualified healthcare professional before making changes to your treatment.*


### PR DESCRIPTION
## Summary

- Adds two evergreen CKD guides: **What Is Chronic Kidney Disease?** and **Chronic Kidney Disease Stages Explained**
- Adds a timely analysis post: **Could Ozempic and Similar Drugs Help Protect the Kidneys?**
- All three files are plain `.md`, `draft: false`, dated `"2026-05-31"`

## Category enum note

No `Kidney`, `Renal`, or `Nephrology` category exists in `src/content/config.ts`. Both CKD guides use **`"Diabetes"`** — the best available fit, since diabetic nephropathy is the leading cause of CKD worldwide and the cluster sits squarely within the diabetes-metabolic nexus. The post uses the optional `POST_CATEGORY` field and is not assigned one (valid per schema).

If a `"Kidney & Urinary Health"` category is added to the enum in a future pass, these guides should be re-categorised.

## Content

**Guide 1 — What Is Chronic Kidney Disease?**
Covers: what the kidneys do, CKD as an umbrella term, causes (diabetes, hypertension, glomerular, autoimmune, hereditary, obstructive, NSAID-related), why CKD is silent, eGFR and urine albumin measurement, when to seek care, red flags, 6-item FAQ, external further reading (CDC, NKF, NIDDK, NHS), related guides.

**Guide 2 — Chronic Kidney Disease Stages Explained**
Covers: eGFR reference table, albuminuria A1/A2/A3 classification, Stages 1–2–3a–3b–4–5 in detail, why stage alone doesn't tell the whole story (rate of decline, albuminuria, underlying cause), what progression means, risk reduction (blood pressure, blood glucose, SGLT2i, GLP-1, ACE/ARB, lifestyle), dialysis/transplant as late-stage options only, 6-item FAQ, external further reading (KDIGO, NKF, NIDDK, NHS).

**Post — Could Ozempic and Similar Drugs Help Protect the Kidneys?**
Angle: kidney disease is often downstream of metabolic dysfunction; GLP-1 drugs may help because they act on several upstream pathways at once (blood glucose, weight, blood pressure, albuminuria, possible anti-inflammatory effects). Makes clear that SGLT2 inhibitors have stronger/broader kidney evidence and remain important; that benefits are strongest in T2DM/obesity/cardiometabolic populations; that treatment decisions belong with clinicians. References the FLOW trial. 7-item FAQ. Links both new CKD guides + external sources (NKF, NIDDK, KDIGO).

## Internal links

All internal links point only to existing or newly-created routes. Draft guides (`heart-health-hub`) are not linked.

## Build results

- `npm run content:check`: ✅ 0 errors, 213 warnings (all pre-existing FAQ-schema warnings on other guides; both new guides include `faq:` frontmatter)
- `npm run build`: ✅ clean — 709 pages indexed, finished without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)