### PR TITLE
feat(sleep): add sleep health hub and guide cluster

### DIFF
--- a/src/content/guides/cbt-insomnia.md
+++ b/src/content/guides/cbt-insomnia.md
@@ -123,6 +123,8 @@ A: Yes. Pills may help in the short term but do not address root causes. CBT-I i
 - [National Sleep Foundation](https://www.thensf.org/insomnia/)  
 
 ## Related Guides
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [What Is Insomnia?](/guides/what-is-insomnia)
 - [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
 - [Healthy Sleep Hygiene](/guides/sleep-hygiene)
 - [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)

--- a/src/content/guides/melatonin-benefits-risks-safe-use.md
+++ b/src/content/guides/melatonin-benefits-risks-safe-use.md
@@ -1,0 +1,245 @@
+---
+title: "Melatonin: Benefits, Risks, and Safe Use"
+slug: "melatonin-benefits-risks-safe-use"
+description: "Melatonin is best used for shifting sleep timing — jet lag, shift work, and delayed sleep phase — not as a general sleep aid. Evidence, dosing, safety, and what melatonin cannot do."
+category: "Mental Health"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["melatonin", "sleep", "jet lag", "shift work", "circadian rhythm", "sleep supplements", "insomnia", "sleep health"]
+draft: false
+faq:
+  - q: "What does melatonin actually do?"
+    a: "Melatonin is a hormone produced by the pineal gland that signals to the body that it is nighttime. It does not cause sleep directly but shifts the timing of the sleep-wake cycle. It is most effective for adjusting circadian timing — jet lag, shift work, and delayed sleep phase syndrome — rather than treating insomnia."
+  - q: "What is the right dose of melatonin?"
+    a: "For most uses, 0.5–1 mg taken 1–2 hours before the desired sleep time is as effective as higher doses. Most over-the-counter products contain 5–10 mg — far above the physiologically active range. Higher doses do not produce better sleep and may cause next-morning grogginess."
+  - q: "Is melatonin safe?"
+    a: "Melatonin is generally considered safe for short-term use in adults. It is non-habit-forming and does not cause rebound insomnia on stopping. Long-term data are limited; it is best used for specific purposes (jet lag, shift work, delayed sleep phase) rather than as an indefinite nightly supplement."
+  - q: "Can melatonin treat chronic insomnia?"
+    a: "Evidence for melatonin in treating chronic insomnia is modest at best. It may slightly reduce time to fall asleep but does not address the underlying causes. Cognitive behavioural therapy for insomnia (CBT-I) is far more effective and should be the primary treatment."
+  - q: "Is melatonin safe for children?"
+    a: "Melatonin is sometimes used in children with neurodevelopmental conditions such as ADHD or autism spectrum disorder under clinician supervision. It should not be given to children without medical guidance, as effects on pubertal development with long-term use have not been fully studied."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Melatonin: Benefits, Risks, and Safe Use"
+    description: "Melatonin is best used for shifting sleep timing — jet lag, shift work, and delayed sleep phase — not as a general sleep aid. Evidence, dosing, safety, and what melatonin cannot do."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/melatonin-benefits-risks-safe-use"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["melatonin", "jet lag", "shift work", "circadian rhythm", "sleep supplement", "insomnia", "delayed sleep phase"]
+    about:
+      "@type": "Drug"
+      name: "Melatonin"
+      sameAs: "https://en.wikipedia.org/wiki/Melatonin"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What does melatonin actually do?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Melatonin signals to the body that night has arrived, shifting the timing of the sleep-wake cycle. It adjusts circadian timing rather than sedating — it is most effective for jet lag, shift work, and delayed sleep phase."
+      - "@type": "Question"
+        name: "What is the right dose of melatonin?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "0.5–1 mg is as effective as higher doses for most uses. Most OTC products are substantially overdosed at 5–10 mg. Timing matters more than dose — take 1–2 hours before the desired sleep time."
+      - "@type": "Question"
+        name: "Can melatonin treat chronic insomnia?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Evidence is weak. CBT-I is far more effective for chronic insomnia. Melatonin can support circadian-related sleep difficulty but does not address the perpetuating cycle of insomnia."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+      - "@type": "ListItem"
+        position: 3
+        name: "Melatonin: Benefits, Risks, and Safe Use"
+        item: "https://patientguide.io/guides/melatonin-benefits-risks-safe-use"
+---
+
+## Intro
+
+Melatonin is the most widely used sleep supplement in the world. In many countries it is available over the counter; in others it is prescription-only. Consumer interest has grown dramatically, but the evidence base is often misunderstood: melatonin is not a sleeping pill. It is a circadian signal.
+
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub)*
+
+---
+
+## Key Points
+
+- Melatonin is a hormone — a signal to the body that night has arrived. It shifts the timing of sleep rather than sedating.
+- It is most effective for **jet lag**, **shift work**, and **delayed sleep phase syndrome**.
+- Evidence for treating chronic insomnia is weak. [CBT-I](/guides/cbt-insomnia) is far more effective.
+- Effective doses are **0.5–1 mg**. Most commercial products are substantially overdosed at 5–10 mg.
+- **Timing matters more than dose** — take melatonin 1–2 hours before the desired sleep time.
+- Non-habit-forming and generally safe short term. Long-term safety data, particularly in children, are limited.
+
+---
+
+## What Melatonin Is
+
+Melatonin (N-acetyl-5-methoxytryptamine) is a hormone produced by the pineal gland, primarily at night in response to darkness. Secretion begins 1–3 hours before habitual sleep time, peaks during the middle of the night, and declines before dawn. It acts as a timing signal to the circadian clock — telling the body that it is night and that sleep is appropriate — but it does not cause sleep directly.
+
+Exogenous melatonin (supplemental or prescription) mimics this signal. Its primary pharmacological effect is to shift the phase of the circadian clock — either advancing it (moving sleep earlier) or delaying it (moving sleep later), depending on when it is taken.
+
+This makes melatonin a **chronobiotic** (circadian clock-shifter), not a traditional hypnotic.
+
+---
+
+## What the Evidence Shows
+
+### Jet lag
+
+Melatonin has the strongest evidence base for jet lag. Crossing multiple time zones misaligns the circadian clock with the local environment. Taking melatonin at the destination's local bedtime accelerates clock re-entrainment and reduces jet lag symptoms — broken sleep, daytime drowsiness, and impaired concentration.
+
+**Practical use:** Take 0.5–1 mg at the local bedtime of your destination, starting on the day of travel, for 2–4 days. Eastward travel (which requires phase advance) benefits most.
+
+### Shift work sleep disorder
+
+People working night shifts, early mornings, or rotating schedules frequently develop [shift work sleep disorder](/guides/shift-work-sleep-disorder) — difficulty sleeping at the required time and excessive sleepiness when awake. Taking melatonin at the intended sleep time (e.g. on returning home after a night shift) can shorten sleep onset and improve daytime sleep duration.
+
+Melatonin is most effective as part of a broader strategy that includes [light therapy](/guides/light-therapy) to block alerting light signals at the right time, and [sleep hygiene practices](/guides/sleep-hygiene) adapted to the shift schedule.
+
+### Delayed sleep phase syndrome
+
+Delayed sleep phase syndrome (DSPS) is a circadian rhythm disorder in which the sleep-wake cycle is chronically shifted several hours later than conventional timing — people cannot fall asleep until 2–4 am or later and struggle to wake before midday. It is more common in adolescents and young adults.
+
+Low-dose melatonin (0.5 mg) taken 5–6 hours before the habitual sleep onset time gradually shifts the clock earlier over several weeks. This is the phase-advance window; melatonin taken at other times has different and sometimes counterproductive effects.
+
+### Insomnia
+
+Evidence for melatonin in treating chronic insomnia is modest. Meta-analyses find that melatonin reduces sleep onset latency by approximately 7 minutes and slightly improves total sleep time — effects unlikely to be clinically meaningful for people with significant insomnia.
+
+Melatonin does not address the perpetuating behavioural and cognitive factors that maintain chronic insomnia. [CBT-I](/guides/cbt-insomnia) remains the first-line treatment.
+
+**Exception:** Prolonged-release melatonin (2 mg) has some evidence for improving sleep quality in adults aged 55 and over, in whom melatonin secretion naturally declines with age. This is a licensed indication in some countries.
+
+### Other uses
+
+- **Pre-operative anxiety:** Used in some paediatric anaesthetic protocols to reduce anxiety before procedures
+- **ICU patients:** Some evidence for reducing delirium in hospitalised patients; research ongoing
+- **Children with neurodevelopmental conditions:** Used under clinician supervision for sleep initiation in children with ADHD and autism spectrum disorder, where the evidence base is moderate
+
+---
+
+## Dosing
+
+### The over-dosing problem
+
+Most commercial melatonin products contain 5–10 mg per dose. Physiologically active doses in controlled human studies are 0.1–1 mg. The supraphysiological amounts in most products may cause next-morning grogginess, suppress the body's own melatonin production with chronic use, and produce non-linear or counterproductive effects at certain times of day.
+
+**Recommended dose:** 0.5–1 mg is as effective as higher doses for most uses. Start with the lowest available dose.
+
+### Timing
+
+Timing is the critical variable — often more important than dose:
+
+| Use | When to take |
+|---|---|
+| Jet lag (eastward travel) | Local bedtime at destination, starting day of travel |
+| Jet lag (westward travel) | Local bedtime at destination or shortly before |
+| Shift work (night shift) | Morning after night shift, at the start of intended sleep |
+| Delayed sleep phase | 5–6 hours before current habitual sleep time; shift earlier gradually |
+| General sleep onset aid | 1–2 hours before intended sleep time |
+
+---
+
+## Side Effects
+
+Melatonin is generally well-tolerated. Reported side effects are mild and include:
+- Next-morning grogginess or "hangover" (most common at higher doses)
+- Headache
+- Dizziness
+- Nausea
+- Vivid dreams or nightmares
+
+Melatonin **does not** cause physical dependence or rebound insomnia on stopping.
+
+---
+
+## Safety Considerations
+
+**Short-term use (days to weeks):** Well-established safety profile in adults.
+
+**Long-term use:** Limited long-term data in adults. If using nightly for months without a clear circadian indication, consider whether [CBT-I](/guides/cbt-insomnia) or treatment of an underlying condition is more appropriate.
+
+**Children:** Should not be given without medical supervision. Long-term effects on pubertal development have not been ruled out.
+
+**Pregnancy and breastfeeding:** Insufficient safety data; avoid unless directed by a clinician.
+
+**Drug interactions:**
+- Warfarin and anticoagulants — melatonin may enhance anticoagulant effect; monitoring required
+- CNS depressants — additive sedative effect
+- Immunosuppressants — theoretical interaction; discuss with prescriber
+
+**Regulatory status:** Melatonin is a prescription-only medicine in the UK, Australia, and several European countries. It is available over the counter in the US, Canada, and many other countries. OTC product quality and actual melatonin content vary widely between brands where unregulated.
+
+---
+
+## What Melatonin Cannot Do
+
+- Treat chronic insomnia effectively — [CBT-I](/guides/cbt-insomnia) does this
+- Compensate for chronically insufficient sleep
+- Fix the underlying causes of poor sleep — [sleep hygiene](/guides/sleep-hygiene) and treatment of contributing conditions are needed
+- Replace clinical evaluation when the cause of poor sleep is unknown
+
+---
+
+## FAQ
+
+**Q: What does melatonin actually do?**  
+A: It signals to the body that night has arrived, shifting the timing of the sleep-wake cycle. It adjusts circadian timing rather than sedating — most effective for jet lag, shift work, and delayed sleep phase.
+
+**Q: What is the right dose?**  
+A: 0.5–1 mg is as effective as higher doses. Most OTC products are substantially overdosed. Timing matters more than dose — take 1–2 hours before the desired sleep time.
+
+**Q: Is melatonin safe?**  
+A: Generally safe for short-term use in adults. Non-habit-forming. Long-term data are limited; not recommended for children without medical guidance.
+
+**Q: Can it treat chronic insomnia?**  
+A: Evidence is weak. [CBT-I](/guides/cbt-insomnia) is far more effective. Melatonin can support circadian-related sleep difficulty but does not address the perpetuating cycle of chronic insomnia.
+
+**Q: Is there a best time to take melatonin?**  
+A: Yes — timing is critical. For jet lag, take it at the local bedtime of your destination. For shift work, at the start of your intended sleep window. For general use, 1–2 hours before intended sleep. For delayed sleep phase, 5–6 hours before your current habitual sleep time.
+
+---
+
+## Further Reading
+
+- [NHS — Melatonin](https://www.nhs.uk/medicines/melatonin/)
+- [National Sleep Foundation — Melatonin and Sleep](https://www.thensf.org/melatonin-and-sleep/)
+- [American Academy of Sleep Medicine — Melatonin](https://aasm.org/)
+
+---
+
+## Related Guides
+
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Shift Work Sleep Disorder](/guides/shift-work-sleep-disorder)
+- [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+- [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+- [Light Therapy](/guides/light-therapy)
+
+---
+
+*Educational only; not a substitute for professional medical advice.*

--- a/src/content/guides/restless-legs-syndrome.md
+++ b/src/content/guides/restless-legs-syndrome.md
@@ -1,0 +1,237 @@
+---
+title: "Restless Legs Syndrome"
+slug: "restless-legs-syndrome"
+description: "Restless legs syndrome (RLS) causes uncomfortable sensations in the legs that worsen at rest and at night, disrupting sleep onset. Learn about causes, the role of iron deficiency, diagnosis, and treatment."
+category: "Neurology"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["restless legs syndrome", "RLS", "Willis-Ekbom disease", "sleep disorders", "iron deficiency", "neurology", "sleep health"]
+draft: false
+faq:
+  - q: "What is restless legs syndrome?"
+    a: "Restless legs syndrome (RLS), also known as Willis-Ekbom disease, is a neurological condition characterised by uncomfortable sensations in the legs — often described as crawling, creeping, aching, or an irresistible urge to move — that worsen during rest and in the evening and are partially relieved by movement."
+  - q: "What causes restless legs syndrome?"
+    a: "The primary mechanism involves dopamine dysregulation in the brain's motor control circuits. Iron deficiency is a major modifiable risk factor — iron is a cofactor for dopamine synthesis, and low ferritin is found in a significant proportion of RLS cases. Genetic factors also play a strong role; RLS runs in families."
+  - q: "How is restless legs syndrome diagnosed?"
+    a: "Diagnosis is clinical, based on four core criteria: an urge to move the legs (usually with uncomfortable sensations); worsening at rest; partial relief with movement; and worse symptoms in the evening or at night. Blood tests including ferritin are routinely checked to identify iron deficiency as a treatable cause."
+  - q: "Is restless legs syndrome treatable?"
+    a: "Yes. Iron supplementation substantially improves or resolves RLS in people with ferritin below 75 µg/L, even when ferritin falls within the conventional laboratory normal range. Lifestyle measures, sleep hygiene, and — where needed — dopaminergic medications or alpha-2-delta ligands are effective treatment options."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Restless Legs Syndrome"
+    description: "Restless legs syndrome (RLS) causes uncomfortable sensations in the legs that worsen at rest and at night, disrupting sleep onset. Causes, iron deficiency, diagnosis, and treatment."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/restless-legs-syndrome"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["restless legs syndrome", "RLS", "Willis-Ekbom disease", "iron deficiency", "sleep disorder", "dopamine", "insomnia"]
+    about:
+      "@type": "MedicalCondition"
+      name: "Restless Legs Syndrome"
+      alternateName: ["Willis-Ekbom disease", "RLS"]
+      sameAs: "https://en.wikipedia.org/wiki/Restless_legs_syndrome"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What is restless legs syndrome?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "A neurological condition causing uncomfortable leg sensations — crawling, aching, or an urge to move — that worsen at rest and in the evening and are partially relieved by movement."
+      - "@type": "Question"
+        name: "What causes restless legs syndrome?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Dopamine dysregulation in the brain's motor circuits is the primary mechanism. Iron deficiency is a major modifiable cause — iron is needed for dopamine synthesis, and low ferritin is found in many RLS cases. Genetic factors are also important."
+      - "@type": "Question"
+        name: "Is restless legs syndrome treatable?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Yes. Iron supplementation is effective when ferritin is below 75 µg/L. Dopaminergic medications and alpha-2-delta ligands are effective for moderate-severe cases. Most patients achieve significant symptom reduction."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+      - "@type": "ListItem"
+        position: 3
+        name: "Restless Legs Syndrome"
+        item: "https://patientguide.io/guides/restless-legs-syndrome"
+---
+
+## Intro
+
+Restless legs syndrome (RLS), formally known as Willis-Ekbom disease, is a common and significantly under-recognised neurological condition. It affects an estimated 5–10% of adults in Western populations, yet many cases go undiagnosed for years or are dismissed as anxiety, growing pains, or simply fidgeting. For people with moderate to severe symptoms, RLS is one of the most disruptive sleep disorders — directly delaying sleep onset every night.
+
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub)*
+
+---
+
+## Key Points
+
+- RLS is defined by four core features: urge to move the legs, worsening at rest, partial relief with movement, and worsening in the evening.
+- It is a neurological condition — not anxiety, "growing pains," or habitual restlessness.
+- **Iron deficiency** is a major modifiable cause; ferritin should be measured in all cases and the treatment target is **above 75 µg/L** — higher than the conventional laboratory normal.
+- RLS is frequently missed because symptoms occur mainly at night, away from clinical observation.
+- Effective treatments exist: iron supplementation, dopaminergic medications, and alpha-2-delta ligands.
+
+---
+
+## Symptoms
+
+RLS is diagnosed on four core clinical criteria (International RLS Study Group):
+
+1. **An urge to move the legs**, usually accompanied by uncomfortable sensations  
+   Described as crawling, creeping, pulling, aching, throbbing, electric, or simply an irresistible need to move. In severe cases, sensations extend to the arms.
+2. **Worsening at rest** — the urge begins or intensifies during inactivity: lying down, sitting in a cinema, long-haul flights
+3. **Partial or complete relief with movement** — walking, stretching, or rubbing temporarily relieves symptoms
+4. **Worse in the evening or at night** — symptoms follow a clear circadian pattern, peaking in the late evening and overnight
+
+**Impact on sleep:**
+RLS delays sleep onset because lying down to sleep is the exact condition that triggers symptoms. Severe cases prevent sleep for hours. The resulting sleep deprivation causes [daytime fatigue](/guides/why-am-i-always-tired), mood disturbance, and impaired cognition — often the chief complaint that brings patients to a doctor.
+
+**Associated features:**
+- **Periodic limb movements in sleep (PLMS):** Repetitive, involuntary leg jerks occurring during sleep in up to 80% of RLS patients. These may further fragment sleep and are sometimes noticed by bed partners.
+- **Periodic limb movement disorder (PLMD):** When PLMS causes clinically significant sleep disruption without accompanying RLS, it is classified as PLMD — a related but distinct diagnosis.
+
+---
+
+## Causes and Risk Factors
+
+### Central dopamine dysregulation
+
+RLS is associated with reduced dopaminergic transmission in the A11 diencephalospinal pathway, which regulates motor control in the spinal cord. The circadian pattern of symptoms — peaking in the evening — mirrors the circadian nadir of brain dopamine levels, explaining why symptoms worsen at night.
+
+### Iron deficiency
+
+Iron is a cofactor in the rate-limiting step of dopamine synthesis. Low brain iron — detectable by low serum ferritin — reduces dopamine production and directly triggers or worsens RLS. Key findings from clinical research:
+- A substantial proportion of RLS patients have ferritin below 75 µg/L
+- Iron supplementation improves RLS severity even when ferritin is within the conventional "normal" laboratory range (typically 12–150 µg/L)
+- The treatment target for ferritin in RLS is **above 75–100 µg/L**, not merely "within range"
+
+### Genetic factors
+
+RLS has a strong hereditary component. First-degree relatives of patients have approximately a 3–5-fold increased risk. Multiple susceptibility loci have been identified. Early-onset RLS (before age 45) tends to be more strongly familial.
+
+### Secondary causes
+
+Conditions and medications that can trigger or significantly worsen RLS in susceptible individuals:
+- Pregnancy (iron depletion and hormonal factors)
+- End-stage renal disease (affects up to 25% of dialysis patients)
+- Peripheral neuropathy
+- [Parkinson's disease](/guides/parkinsons-disease-overview)
+- Medications: antidopaminergics (metoclopramide, antipsychotics), antihistamines, many antidepressants (SSRIs, mirtazapine, TCAs), certain antiemetics
+- Caffeine and alcohol may exacerbate symptoms in susceptible individuals
+
+---
+
+## Diagnosis
+
+RLS is a **clinical diagnosis** — there is no definitive blood test or imaging finding.
+
+A clinician will:
+1. Assess the four core diagnostic criteria
+2. Exclude mimics: leg cramps (no urge to move component), positional discomfort, peripheral neuropathy, venous insufficiency, anxiety-related restlessness
+3. Assess severity using a validated tool such as the International RLS Rating Scale (IRLS)
+4. **Measure ferritin** — essential in all cases; ferritin below 75 µg/L warrants iron treatment regardless of haemoglobin
+5. Check full blood count, renal function, and fasting glucose to exclude secondary causes
+6. Consider referral to neurology or sleep medicine for moderate-severe or refractory cases
+
+A **sleep study** is not required for RLS diagnosis but may be arranged if periodic limb movement disorder is suspected or sleep disruption is severe and multi-factorial.
+
+---
+
+## Treatment
+
+### Iron supplementation
+
+Iron treatment is the first step when ferritin is below 75 µg/L:
+
+**Oral iron:**
+Ferrous sulphate or ferrous fumarate, taken on an empty stomach where tolerated, with vitamin C to enhance absorption. Repeat ferritin in 3 months and continue until above 75–100 µg/L. GI side effects (nausea, constipation) are common; taking with food reduces them at the cost of some absorption.
+
+**Intravenous iron:**
+Considered for patients with GI intolerance to oral iron, malabsorption, or persistently low ferritin despite oral treatment. Some centres use IV iron as first-line for moderate-severe RLS given faster and more complete repletion. Clinical response typically follows within 4–6 weeks.
+
+### Lifestyle and non-pharmacological measures
+
+- **[Sleep hygiene](/guides/sleep-hygiene):** A consistent sleep schedule and onset routine reduce symptom severity. The reduction in sleep pressure from irregular schedules worsens RLS.
+- **Exercise:** Moderate aerobic exercise and lower limb stretching reduce RLS severity over weeks. Intense exercise close to bedtime may worsen symptoms acutely.
+- **Reduce triggers:** Reduce or eliminate caffeine and alcohol, particularly in the evening. Review all medications with a prescriber.
+- **Warm baths and massage:** Provide temporary symptomatic relief.
+- **Mental engagement during inactivity:** Keeping the mind engaged (mental tasks, fidgeting devices) during unavoidable inactivity (long journeys, cinemas) can reduce symptom severity.
+
+### Pharmacological treatment for moderate to severe RLS
+
+When non-pharmacological measures and iron supplementation are insufficient:
+
+**Alpha-2-delta ligands (preferred for chronic daily use):**
+- Pregabalin and gabapentin — increasingly preferred over dopamine agonists for chronic daily RLS because of lower augmentation risk; also treat associated insomnia and anxiety
+- Side effects include dizziness and sedation, particularly at initiation
+
+**Dopaminergic agents:**
+- Pramipexole and ropinirole (dopamine agonists) — effective for reducing RLS severity; risk of **augmentation** (worsening of symptoms over time, earlier onset, spread to arms) with long-term use at higher doses
+- Levodopa — effective for intermittent RLS; high augmentation risk with daily use; rarely used as first-line now
+
+**Augmentation** is the most important complication of dopaminergic therapy — occurring in 30–50% of patients over years. It manifests as earlier symptom onset, greater intensity, and spread to the arms. If suspected, dose reduction or switch to an alpha-2-delta ligand is recommended under specialist guidance.
+
+**Opioids:**
+Low-dose oxycodone or buprenorphine — reserved for severe, refractory RLS under specialist supervision.
+
+---
+
+## FAQ
+
+**Q: What is restless legs syndrome?**  
+A: A neurological condition causing an urge to move the legs, accompanied by uncomfortable sensations that worsen at rest and in the evening and are partially relieved by movement. Caused primarily by central dopamine dysregulation, often with iron deficiency as a modifiable contributor.
+
+**Q: What causes it?**  
+A: Primarily dopamine dysregulation. Iron deficiency is a major treatable cause — iron is required for dopamine synthesis. Genetic factors, pregnancy, kidney disease, and certain medications can also trigger or worsen RLS.
+
+**Q: How is it diagnosed?**  
+A: Clinically, based on the four core criteria. Ferritin measurement is standard. No sleep study is required for the diagnosis itself, though one may be arranged for associated sleep disruption.
+
+**Q: Is it treatable?**  
+A: Yes. Iron supplementation substantially improves RLS when ferritin is below 75 µg/L — the treatment target is higher than the conventional normal range. Dopaminergic medications and alpha-2-delta ligands are effective for moderate-severe cases.
+
+**Q: Does RLS cause Parkinson's disease?**  
+A: RLS and Parkinson's share dopaminergic pathways and often co-occur. However, the vast majority of people with RLS do not develop Parkinson's disease. They are related but distinct conditions.
+
+---
+
+## Further Reading
+
+- [Restless Legs Syndrome Foundation](https://www.rls.org/)
+- [NHS — Restless Legs Syndrome](https://www.nhs.uk/conditions/restless-legs-syndrome/)
+- [American Academy of Sleep Medicine](https://aasm.org/)
+
+---
+
+## Related Guides
+
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Why Am I Always Tired?](/guides/why-am-i-always-tired)
+- [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+- [Parkinson's Disease — Overview](/guides/parkinsons-disease-overview)
+- [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+
+---
+
+*Educational only; not a substitute for professional medical advice. If you suspect restless legs syndrome, seek assessment from a healthcare professional.*

--- a/src/content/guides/shift-work-sleep-disorder.md
+++ b/src/content/guides/shift-work-sleep-disorder.md
@@ -1,0 +1,262 @@
+---
+title: "Shift Work Sleep Disorder"
+slug: "shift-work-sleep-disorder"
+description: "Shift work sleep disorder occurs when work schedules conflict with the body's circadian rhythm, causing chronic sleep disruption and excessive sleepiness. Learn causes, symptoms, and how to manage it."
+category: "Mental Health"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["shift work", "shift work sleep disorder", "circadian rhythm", "sleep disorders", "night shift", "melatonin", "fatigue", "sleep health"]
+draft: false
+faq:
+  - q: "What is shift work sleep disorder?"
+    a: "Shift work sleep disorder (SWSD) is a circadian rhythm disorder that occurs when work requires someone to be awake and active during the body's biological night. This misalignment between the internal clock and the required sleep-wake schedule causes difficulty sleeping at the intended time and excessive sleepiness while at work."
+  - q: "Who is at risk of shift work sleep disorder?"
+    a: "Anyone working night shifts, early morning shifts (starting before 6 am), or rotating schedules is at risk. SWSD is estimated to affect 10–38% of shift workers. Nurses, emergency services, transport workers, and industrial workers are disproportionately affected."
+  - q: "How is shift work sleep disorder managed?"
+    a: "Management combines strategic light exposure (bright light during work to promote alertness; blocking light when sleeping), timed melatonin use at the start of the intended sleep window, adapted sleep hygiene, and — where needed — schedule modifications or wakefulness-promoting medications."
+  - q: "Can shift work permanently damage sleep?"
+    a: "Chronic shift work is associated with lasting disruption of circadian rhythms and increased long-term risk of depression, obesity, cardiovascular disease, and type 2 diabetes. Many people who leave shift work find circadian function gradually recovers over months, though some residual sleep difficulty may persist."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Shift Work Sleep Disorder"
+    description: "Shift work sleep disorder occurs when work schedules conflict with the body's circadian rhythm, causing chronic sleep disruption and excessive sleepiness."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/shift-work-sleep-disorder"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["shift work sleep disorder", "circadian rhythm disorder", "night shift", "sleep", "melatonin", "light therapy", "fatigue"]
+    about:
+      "@type": "MedicalCondition"
+      name: "Shift Work Sleep Disorder"
+      sameAs: "https://en.wikipedia.org/wiki/Shift_work_sleep_disorder"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What is shift work sleep disorder?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "A circadian rhythm disorder caused by work requiring activity during the body's biological night. Core symptoms are difficulty sleeping at the required time and excessive sleepiness during work, persisting for at least 3 months."
+      - "@type": "Question"
+        name: "Who is at risk?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Anyone on night, early morning, or rotating shifts. Estimated to affect 10–38% of shift workers. Nurses, emergency services, transport workers, and industrial workers are most commonly affected."
+      - "@type": "Question"
+        name: "How is shift work sleep disorder managed?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Strategic light exposure (bright during work, blocked when sleeping), timed melatonin at the intended sleep window, adapted sleep hygiene, and where needed, schedule modifications or wakefulness-promoting medications."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+      - "@type": "ListItem"
+        position: 3
+        name: "Shift Work Sleep Disorder"
+        item: "https://patientguide.io/guides/shift-work-sleep-disorder"
+---
+
+## Intro
+
+The circadian clock runs on an approximately 24-hour cycle, synchronised primarily by light and dark. For most of human history, this clock aligned with when people were awake and active. Shift work breaks that alignment. Sleeping against the biological clock has real physiological costs, and shift work sleep disorder is the clinical expression of those costs in workers whose sleep and performance are significantly impaired.
+
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub)*
+
+---
+
+## Key Points
+
+- SWSD is a **circadian rhythm disorder**, not simply poor sleep hygiene or insufficient willpower.
+- It affects approximately **10–38% of shift workers** — a large occupationally exposed population.
+- Core features: **difficulty sleeping at the required time** and **excessive sleepiness during work**, persisting for at least 3 months.
+- Strategic **light exposure** and **timed melatonin** are the most evidence-supported interventions.
+- Chronic shift work is independently associated with cardiovascular disease, obesity, depression, and type 2 diabetes.
+- Workers with SWSD have substantially elevated risk of **occupational and road traffic accidents**.
+
+---
+
+## Why the Body Struggles with Shift Work
+
+The suprachiasmatic nucleus (SCN) in the hypothalamus — the master circadian clock — is primarily synchronised by **light signals** from the retina. It coordinates the timing of melatonin secretion, cortisol release, body temperature, and alertness across the 24-hour cycle.
+
+When work requires activity during the biological night (approximately 10 pm–6 am for most people), two problems arise:
+
+**1. The clock actively opposes wakefulness during the work shift.**
+Melatonin rises, core body temperature falls, and arousal systems downregulate — directly working against the demand for performance and wakefulness.
+
+**2. Daytime sleep is shorter and less restorative than night sleep.**
+Morning light entering the bedroom suppresses melatonin and activates wake-promoting circuits, causing premature awakening. Most night-shift workers sleep 1–4 fewer hours per day than day workers, accumulating substantial sleep debt.
+
+The circadian clock adapts slowly — at a maximum rate of about 1–1.5 hours per day — so rotating schedules or regular transitions between day and night work prevent full adaptation entirely.
+
+---
+
+## Symptoms
+
+### Core diagnostic features
+
+- **Insomnia at the intended sleep time** — difficulty initiating or maintaining daytime sleep after a night shift, or early-morning sleep after an early shift
+- **Excessive sleepiness during required waking hours** — particularly during the work shift
+- These symptoms persist for at least **3 months** and are temporally linked to the work schedule
+
+### Associated symptoms
+
+- Fatigue that does not resolve regardless of sleep opportunity
+- Impaired concentration, memory, and decision-making during shifts
+- Irritability and mood disturbance
+- GI symptoms — circadian disruption affects gut motility and appetite timing
+- Social and relationship difficulties — shift workers often cannot participate in normal family and social rhythms
+- Increased sick leave and occupational errors
+
+### Long-term health consequences
+
+Chronic SWSD is associated with:
+- **Cardiovascular disease:** Shift workers have a 40% higher risk of coronary heart disease and stroke compared to day workers
+- **Metabolic disease:** Increased risk of obesity, [insulin resistance](/guides/insulin-resistance), and [type 2 diabetes](/guides/type-2-diabetes) — partly mediated by disrupted appetite hormones and eating during the biological night
+- **[Depression](/guides/depression) and anxiety:** Chronic circadian disruption dysregulates mood-regulating neurochemical systems
+- **Cancer:** Long-term night shift work is classified by the WHO as a probable carcinogen on the basis of circadian disruption; breast cancer risk in women is most studied
+- **Reproductive effects:** Increased risk of menstrual irregularity and adverse pregnancy outcomes in women working regular night shifts
+
+---
+
+## Diagnosis
+
+SWSD is a clinical diagnosis based on:
+
+1. Work schedule requiring activity during the biological night for at least 3 months
+2. Insomnia or excessive sleepiness temporally linked to the work schedule
+3. Sleep-wake diary or actigraphy documenting the misalignment over 2 weeks
+4. Exclusion of other primary sleep disorders
+
+A **sleep study** is not required but may be arranged if [sleep apnoea](/guides/sleep-apnoea) is suspected as a co-contributing factor — the two conditions frequently coexist and compound each other significantly.
+
+---
+
+## Management
+
+### 1. Strategic light exposure
+
+Light is the strongest signal to the circadian clock. Strategic use of light can shift the clock toward the required schedule:
+
+**For night shift workers:**
+- **Bright light during the work shift** (especially in the early part) promotes alertness and facilitates adaptation to the night schedule
+- **Block morning light on the commute home** — wear blue-light-blocking glasses or wraparound sunglasses; morning light is the strongest signal resetting the clock toward a day schedule
+- **Blackout curtains** in the bedroom are essential — even low-level light exposure during daytime sleep fragments sleep and shortens duration
+
+A 10,000-lux light box used at the start of the night shift and blocked on the commute home is one of the most effective practical strategies. See [Light Therapy](/guides/light-therapy).
+
+### 2. Timed melatonin
+
+[Melatonin](/guides/melatonin-benefits-risks-safe-use) is most effective for circadian rhythm disorders. In SWSD:
+
+- Taken at the **start of the intended sleep window** (e.g. on arriving home after a night shift)
+- Dose: **0.5–1 mg** — low doses are as effective as higher ones
+- Consistent use accelerates circadian adaptation to the required schedule
+- Timed melatonin combined with strategic light exposure produces the best outcomes
+
+### 3. Sleep hygiene adaptations for daytime sleep
+
+Standard [sleep hygiene](/guides/sleep-hygiene) requires modification for shift workers:
+
+- **Treat daytime sleep with the same priority as night-time sleep** — communicate with household members, use blackout blinds, switch phone to silent
+- **Maintain a consistent sleep schedule on days off where possible** — dramatic "social jetlag" (reverting entirely to a day schedule on days off) compounds circadian disruption
+- **Anchor sleep timing:** Keeping a consistent start time for sleep improves sleep quality, even if total duration is shorter than ideal
+
+### 4. Strategic napping
+
+- A **20–30 minute nap before a night shift** (a prophylactic nap) reduces sleepiness during the first hours of the shift
+- A brief nap during a break mid-shift can temporarily restore alertness where facilities allow
+- Avoid long naps that fragment the main sleep period
+
+### 5. Caffeine timing
+
+Caffeine manages acute sleepiness during shifts but should be avoided in the **last 4–6 hours before the intended sleep window** to avoid delaying sleep onset. The early portion of the shift is the optimal window for caffeine use.
+
+### 6. Medications
+
+**Wakefulness-promoting agents:**
+- **Modafinil** — licensed for shift work sleep disorder in some countries; improves alertness during night shifts without the same crash profile as stimulants; does not correct the underlying circadian misalignment
+- **Armodafinil** — longer-acting variant
+
+**For initiating daytime sleep:**
+- Low-dose melatonin (first choice — see above)
+- Short-acting z-drugs (zolpidem, zopiclone) — can establish daytime sleep short-term; tolerance develops with regular use; note the additional safety risk given that shift workers may need to respond to emergencies during the intended sleep period
+
+### 7. Occupational and schedule considerations
+
+- **Clockwise rotation** (day → evening → night) is better tolerated physiologically than anticlockwise rotation (night → evening → day)
+- **Slower rotation schedules** allow more circadian adaptation time than rapid (weekly or less) rotation
+- **Schedule predictability** reduces health impact — irregular schedules are harder to adapt to than regular fixed ones
+- **Occupational health referral** is appropriate for workers with significant SWSD; many workplaces have provisions for schedule modification on health grounds
+
+---
+
+## Safety
+
+Shift workers with SWSD are at substantially elevated risk of:
+- **Occupational accidents** — the early morning hours (4–6 am) represent the highest risk period for performance-critical errors and accidents
+- **Motor vehicle accidents on the commute home** — driving after a night shift carries accident risk comparable to driving at the legal alcohol limit in some studies
+
+If you feel unsafe to drive after a shift, do not drive. Take public transport, a taxi, or ask someone to collect you. This is a medical decision, not merely a preference.
+
+---
+
+## FAQ
+
+**Q: What is shift work sleep disorder?**  
+A: A circadian rhythm disorder caused by misalignment between the body's internal clock and the required work schedule. Core symptoms are difficulty sleeping at the intended time and excessive sleepiness during work, persisting for at least 3 months.
+
+**Q: Who gets it?**  
+A: Anyone on night, early morning, or rotating shifts. Estimated to affect 10–38% of shift workers. Nurses, emergency services, transport workers, and industrial workers are most affected.
+
+**Q: What helps most?**  
+A: Strategic light exposure (bright light during work; blocking light when sleeping), timed melatonin at the start of the sleep window, and consistent daytime sleep hygiene. Modafinil is an option for wakefulness during severe cases.
+
+**Q: Can shift work cause long-term health problems?**  
+A: Yes. Chronic shift work is independently associated with increased cardiovascular disease, type 2 diabetes, obesity, and depression. Many workers recover circadian function after leaving shift work, but some residual effects may persist.
+
+**Q: Is it safe to drive home after a night shift?**  
+A: Not always. The risk of road traffic accidents after a night shift is substantially elevated. If you feel unsafe, do not drive.
+
+---
+
+## Further Reading
+
+- [NHS — Night Shift Working and Health](https://www.nhs.uk/live-well/sleep-and-tiredness/)
+- [American Academy of Sleep Medicine](https://aasm.org/)
+- [National Sleep Foundation — Shift Work](https://www.thensf.org/sleep-topics/shift-work-and-sleep/)
+- [NIOSH — Work Schedules and Health](https://www.cdc.gov/niosh/)
+
+---
+
+## Related Guides
+
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Melatonin: Benefits, Risks, and Safe Use](/guides/melatonin-benefits-risks-safe-use)
+- [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+- [Light Therapy](/guides/light-therapy)
+- [Why Am I Always Tired?](/guides/why-am-i-always-tired)
+- [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+
+---
+
+*Educational only; not a substitute for professional medical advice. Workers with significant shift work sleep disorder should seek assessment from a clinician with expertise in occupational or sleep medicine.*

--- a/src/content/guides/sleep-apnoea.md
+++ b/src/content/guides/sleep-apnoea.md
@@ -85,7 +85,11 @@ A: CPAP, lifestyle changes, oral appliances, and sometimes surgery.
 - [National Heart, Lung, and Blood Institute](https://www.nhlbi.nih.gov/health/sleep-apnea)  
 
 ## Related Guides
+- [Sleep Health Hub](/guides/sleep-health-hub)
 - [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Why Am I Always Tired?](/guides/why-am-i-always-tired)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+- [Restless Legs Syndrome](/guides/restless-legs-syndrome)
 - [Healthy Sleep Hygiene](/guides/sleep-hygiene)
 - [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
 - [Shortness of Breath — When to Seek Urgent Help](/guides/shortness-of-breath)

--- a/src/content/guides/sleep-health-hub.md
+++ b/src/content/guides/sleep-health-hub.md
@@ -1,0 +1,182 @@
+---
+title: "Sleep Health Hub"
+slug: "sleep-health-hub"
+description: "Your complete guide to sleep health: insomnia, sleep apnoea, restless legs syndrome, shift work disorder, sleep hygiene, melatonin, and when to get help."
+category: "Guide Hubs"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["sleep", "insomnia", "sleep apnoea", "restless legs", "shift work", "sleep hygiene", "melatonin", "CBT-I", "sleep disorders", "sleep health"]
+draft: false
+faq:
+  - q: "What are the most common sleep disorders?"
+    a: "The most common sleep disorders are insomnia, obstructive sleep apnoea, and restless legs syndrome. Circadian rhythm disorders such as shift work sleep disorder are also frequent, particularly in people working non-standard hours."
+  - q: "How much sleep do adults need?"
+    a: "Most adults need 7–9 hours per night. Consistently sleeping fewer than 6 hours is associated with increased risk of depression, cardiovascular disease, and metabolic dysfunction regardless of perceived tolerance."
+  - q: "When should I see a doctor about sleep problems?"
+    a: "See a doctor if sleep problems persist for more than 3 months, occur at least 3 nights per week, significantly impair daytime functioning, or are accompanied by loud snoring, witnessed breathing pauses, or excessive daytime sleepiness."
+  - q: "What is the best treatment for insomnia?"
+    a: "Cognitive behavioural therapy for insomnia (CBT-I) is the first-line treatment recommended by international guidelines. It addresses the thoughts and behaviours that perpetuate insomnia and produces more durable results than sleeping pills."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Sleep Health Hub"
+    description: "Your complete guide to sleep health: insomnia, sleep apnoea, restless legs syndrome, shift work disorder, sleep hygiene, melatonin, and when to get help."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/sleep-health-hub"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["sleep", "insomnia", "sleep apnoea", "restless legs syndrome", "shift work", "melatonin", "CBT-I", "sleep disorders"]
+    about:
+      "@type": "MedicalEntity"
+      name: "Sleep health"
+      sameAs: "https://en.wikipedia.org/wiki/Sleep"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What are the most common sleep disorders?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "The most common sleep disorders are insomnia, obstructive sleep apnoea, and restless legs syndrome. Circadian rhythm disorders such as shift work sleep disorder are also frequent."
+      - "@type": "Question"
+        name: "How much sleep do adults need?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Most adults need 7–9 hours per night. Consistently sleeping fewer than 6 hours is associated with increased risk of depression, cardiovascular disease, and metabolic dysfunction."
+      - "@type": "Question"
+        name: "When should I see a doctor about sleep problems?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "See a doctor if sleep problems persist for more than 3 months, occur at least 3 nights per week, significantly impair daytime functioning, or are accompanied by loud snoring, witnessed breathing pauses, or excessive daytime sleepiness."
+      - "@type": "Question"
+        name: "What is the best treatment for insomnia?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Cognitive behavioural therapy for insomnia (CBT-I) is the first-line treatment recommended by international guidelines. It produces more durable results than sleeping pills and addresses the thoughts and behaviours that perpetuate insomnia."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+---
+
+## Introduction
+
+Sleep is not passive downtime. It is a biologically essential process during which the brain consolidates memories, clears metabolic waste, regulates hormones, and restores immune function. A third of adults in high-income countries regularly sleep less than the recommended 7–9 hours — most without recognising the cumulative cost.
+
+Poor sleep does not stay confined to the night. The evidence consistently links disrupted or insufficient sleep to heart disease, weight gain, type 2 diabetes, depression, anxiety, cognitive decline, and accelerated biological ageing.
+
+This hub is the central navigation point for all PatientGuide sleep content.
+
+---
+
+## Why Sleep Matters
+
+**Heart disease and blood pressure**
+Short sleep duration and disturbed sleep raise blood pressure, increase inflammatory markers, and contribute independently to heart attack and stroke risk. Obstructive sleep apnoea is an independent risk factor for atrial fibrillation, heart failure, and stroke. See [Heart & Circulation — Guide Hub](/guides/heart-circulation) and [High Blood Pressure](/guides/high-blood-pressure).
+
+**Obesity and metabolism**
+Sleep restriction of even a few nights impairs insulin sensitivity and disrupts hunger hormones — raising ghrelin (appetite) and suppressing leptin (satiety). Poor sleep is an independent risk factor for [insulin resistance](/guides/insulin-resistance) and [type 2 diabetes](/guides/type-2-diabetes). See [Obesity and Metabolic Health](/guides/obesity-basics).
+
+**Mental health**
+Sleep and mental health are bidirectional. Poor sleep worsens [depression](/guides/depression) and [anxiety](/guides/anxiety); both conditions disrupt sleep. Treating insomnia independently improves mental health outcomes, including antidepressant response.
+
+**Memory and dementia risk**
+The glymphatic system — the brain's waste-clearance network — is most active during deep slow-wave sleep, clearing amyloid-beta and tau proteins implicated in Alzheimer's disease. Chronic poor sleep is an independent risk factor for [mild cognitive impairment](/guides/mild-cognitive-impairment) and dementia. See [Brain Health Hub](/guides/brain-health-hub).
+
+**Ageing and longevity**
+Chronic sleep deprivation accelerates biological ageing at the cellular level and is associated with reduced longevity in population studies. See [Ageing and Longevity Basics](/guides/aging-and-longevity-basics).
+
+---
+
+## Common Sleep Problems
+
+### [What Is Insomnia?](/guides/what-is-insomnia)
+Insomnia is the most common sleep disorder — difficulty falling asleep, staying asleep, or waking too early on at least three nights per week. Understand the difference between acute and chronic insomnia, what the 3P model explains about why it persists, and how it is treated.
+
+### [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+Obstructive sleep apnoea (OSA) occurs when the upper airway repeatedly collapses during sleep, causing breathing pauses and oxygen desaturation. It is seriously underdiagnosed, particularly in women, and carries major cardiovascular and metabolic risk if left untreated.
+
+### [Restless Legs Syndrome](/guides/restless-legs-syndrome)
+Restless legs syndrome (RLS) causes uncomfortable sensations in the legs — an irresistible urge to move — that worsen at rest and in the evening, directly disrupting sleep onset. Iron deficiency is a key modifiable cause.
+
+### [Shift Work Sleep Disorder](/guides/shift-work-sleep-disorder)
+People working nights, early mornings, or rotating shifts are at high risk of this circadian rhythm disorder. It causes difficulty sleeping at the required time and excessive sleepiness during work, with significant long-term health consequences.
+
+---
+
+## Better Sleep
+
+### [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+The evidence-based daily habits — consistent schedules, morning light exposure, caffeine timing, screen curfews, and bedroom environment — that form the behavioural foundation of healthy sleep.
+
+### [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
+CBT-I is the first-line treatment for chronic insomnia per international guidelines. It retrains the thoughts and behaviours that perpetuate sleeplessness and is more effective long term than any sleeping pill.
+
+### [Melatonin: Benefits, Risks, and Safe Use](/guides/melatonin-benefits-risks-safe-use)
+Melatonin is best used for shifting sleep timing — jet lag, shift work, and delayed sleep phase syndrome — not as a general sleep aid. Understand what the evidence supports, effective dosing, and what melatonin cannot do.
+
+### [When to Seek Help for Insomnia](/guides/when-to-seek-help-for-insomnia)
+How to know when occasional poor sleep has crossed the threshold into something that warrants professional assessment, what to expect at that appointment, and how to access CBT-I.
+
+---
+
+## Symptoms
+
+### [Why Am I Always Tired?](/guides/why-am-i-always-tired)
+Persistent tiredness has many potential causes beyond inadequate sleep — including sleep apnoea, depression, thyroid disease, iron deficiency anaemia, and diabetes. A practical differential guide, with clear signposting on when to seek medical investigation.
+
+---
+
+## Why Sleep Matters — In Detail
+
+**Blood pressure**
+The blood pressure dip that normally occurs during sleep ("nocturnal dipping") is reduced or absent in people with poor sleep quality and untreated sleep apnoea. Over years, this raises cardiovascular risk independently of daytime blood pressure.
+
+**Weight and appetite**
+Even two nights of partial sleep deprivation raises ghrelin by up to 28% and reduces leptin by 18% in controlled studies. Across a population, this contributes to progressive weight gain and worsens the obesity-diabetes cycle.
+
+**Mood and emotional regulation**
+The amygdala becomes substantially more reactive after sleep deprivation, driving heightened anxiety, irritability, and emotional lability. This is one reason poor sleep and mental health conditions are so strongly linked.
+
+**Cognition**
+Memory consolidation — the transfer of experiences from short-term to long-term storage — occurs during slow-wave and REM sleep. Even modest sleep restriction impairs working memory, attention, and decision-making measurably the following day.
+
+**Dementia risk**
+The glymphatic system clears amyloid and tau from the brain predominantly during deep slow-wave sleep. Chronic sleep restriction reduces glymphatic clearance and is associated with higher amyloid deposition on imaging studies — suggesting sleep is not just a correlate but a mechanism in dementia pathogenesis. See [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview).
+
+---
+
+## Related Guides
+
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Depression: Symptoms, Causes, and Treatment](/guides/depression)
+- [Anxiety Disorders](/guides/anxiety)
+- [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause)
+- [Obesity and Metabolic Health](/guides/obesity-basics)
+- [Metabolic and Mental Health Link](/guides/metabolic-mental-health-link)
+- [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview)
+- [Brain Health Hub](/guides/brain-health-hub)
+- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
+- [High Blood Pressure — What It Means and How to Manage It](/guides/high-blood-pressure)
+- [Ageing and Longevity Basics](/guides/aging-and-longevity-basics)
+- [Light Therapy](/guides/light-therapy)
+- [Mental Health Toolkit](/guides/mental-health-toolkit)
+
+---
+
+*Educational only; not a substitute for professional medical advice.*

--- a/src/content/guides/sleep-hygiene.md
+++ b/src/content/guides/sleep-hygiene.md
@@ -151,7 +151,11 @@ A: Most people notice improvements within 2–3 weeks of consistent habits.
 - [American Academy of Sleep Medicine – Patient Resources](https://aasm.org/resources/)  
 
 ## Related Guides
+- [Sleep Health Hub](/guides/sleep-health-hub)
 - [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [What Is Insomnia?](/guides/what-is-insomnia)
 - [Cognitive Behavioral Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
 - [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
 - [When to Seek Help for Insomnia](/guides/when-to-seek-help-for-insomnia)
+- [Melatonin: Benefits, Risks, and Safe Use](/guides/melatonin-benefits-risks-safe-use)
+- [Shift Work Sleep Disorder](/guides/shift-work-sleep-disorder)

--- a/src/content/guides/sleep.md
+++ b/src/content/guides/sleep.md
@@ -114,7 +114,7 @@ jsonLd:
 
 Sleep is not passive downtime — it is a biologically essential process that governs memory consolidation, emotional regulation, immune function, hormone balance, and metabolic health. A third of adults in high-income countries regularly sleep less than the recommended amount, and most are unaware of the cumulative cost.
 
-*[← Back to Toolkit](/guides/mental-health-toolkit)*
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub) · [← Back to Toolkit](/guides/mental-health-toolkit)*
 
 ---
 
@@ -171,7 +171,7 @@ Chronic pain, heartburn (GERD), frequent nocturia, and respiratory conditions ca
 
 **Sleep disorders**
 - **Obstructive sleep apnoea (OSA):** repeated upper-airway collapse during sleep; often unrecognised
-- **Restless legs syndrome (RLS):** uncomfortable limb sensations that worsen at rest and disrupt sleep onset
+- **[Restless legs syndrome (RLS)](/guides/restless-legs-syndrome):** uncomfortable limb sensations that worsen at rest and disrupt sleep onset
 - **Circadian rhythm disorders:** e.g., delayed sleep phase syndrome (inability to sleep until very late and difficulty waking early)
 - **Parasomnias:** sleepwalking, night terrors, REM sleep behaviour disorder
 
@@ -289,6 +289,12 @@ A: A short nap of 10–20 minutes in the early afternoon can improve alertness a
 
 ## Related Guides
 
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+- [Why Am I Always Tired?](/guides/why-am-i-always-tired)
+- [Restless Legs Syndrome](/guides/restless-legs-syndrome)
+- [Shift Work Sleep Disorder](/guides/shift-work-sleep-disorder)
+- [Melatonin: Benefits, Risks, and Safe Use](/guides/melatonin-benefits-risks-safe-use)
 - [Healthy Sleep Hygiene](/guides/sleep-hygiene)
 - [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
 - [When to Seek Help for Insomnia](/guides/when-to-seek-help-for-insomnia)

--- a/src/content/guides/what-is-insomnia.md
+++ b/src/content/guides/what-is-insomnia.md
@@ -1,0 +1,291 @@
+---
+title: "What Is Insomnia?"
+slug: "what-is-insomnia"
+description: "Insomnia is the most common sleep disorder — difficulty falling asleep, staying asleep, or waking too early. Learn what causes it, how it is diagnosed, and how to treat it."
+category: "Mental Health"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["insomnia", "sleep disorder", "chronic insomnia", "sleep", "CBT-I", "sleep health"]
+draft: false
+faq:
+  - q: "What is insomnia?"
+    a: "Insomnia is a sleep disorder characterised by difficulty falling asleep, staying asleep, or waking too early — occurring at least three nights per week and causing daytime impairment. When this pattern lasts three months or more, it is classified as chronic insomnia."
+  - q: "What is the difference between acute and chronic insomnia?"
+    a: "Acute insomnia lasts days to weeks and is typically triggered by an identifiable stressor such as illness, work pressure, or bereavement. Chronic insomnia persists for three months or more and is often maintained by conditioned arousal and maladaptive sleep behaviours even after the original trigger has resolved."
+  - q: "What causes chronic insomnia?"
+    a: "The 3P model describes insomnia as the product of predisposing factors (genetics, anxiety trait), a precipitating event (illness, stress), and perpetuating behaviours (irregular schedules, excessive time in bed, worry about sleep) that maintain the disorder long after the trigger has passed."
+  - q: "How is insomnia treated?"
+    a: "Cognitive behavioural therapy for insomnia (CBT-I) is the first-line treatment recommended by international clinical guidelines. It addresses the behavioural and cognitive factors that perpetuate insomnia. Sleep hygiene changes, relaxation techniques, and — where appropriate — short-term medication can also play a role."
+  - q: "Can insomnia go away on its own?"
+    a: "Acute insomnia often resolves once the triggering stressor passes. Chronic insomnia is less likely to resolve without intervention because the perpetuating behaviours that maintain it tend to become self-reinforcing over time."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "What Is Insomnia?"
+    description: "Insomnia is the most common sleep disorder — difficulty falling asleep, staying asleep, or waking too early. Learn what causes it, how it is diagnosed, and how to treat it."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/what-is-insomnia"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["insomnia", "chronic insomnia", "sleep disorder", "CBT-I", "sleep", "insomnia causes", "insomnia treatment"]
+    about:
+      "@type": "MedicalCondition"
+      name: "Insomnia"
+      alternateName: ["chronic insomnia", "sleep disorder"]
+      sameAs: "https://en.wikipedia.org/wiki/Insomnia"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What is insomnia?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Insomnia is a sleep disorder characterised by difficulty falling asleep, staying asleep, or waking too early on at least three nights per week, with daytime consequences including fatigue, mood disturbance, or impaired concentration."
+      - "@type": "Question"
+        name: "What is the difference between acute and chronic insomnia?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Acute insomnia lasts days to weeks and is usually triggered by an identifiable stressor. Chronic insomnia persists for 3 months or more and is often maintained by conditioned arousal and maladaptive behaviours, even after the original trigger has resolved."
+      - "@type": "Question"
+        name: "How is insomnia treated?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Cognitive behavioural therapy for insomnia (CBT-I) is the first-line treatment per international guidelines. It addresses the behavioural and cognitive factors that perpetuate insomnia. Sleep hygiene and short-term medication may also have a role."
+      - "@type": "Question"
+        name: "Can insomnia go away on its own?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "Acute insomnia often resolves once the trigger passes. Chronic insomnia is less likely to resolve without intervention because the perpetuating cycle tends to be self-reinforcing."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+      - "@type": "ListItem"
+        position: 3
+        name: "What Is Insomnia?"
+        item: "https://patientguide.io/guides/what-is-insomnia"
+---
+
+## Intro
+
+Insomnia is the most common sleep disorder. It affects an estimated 10–15% of adults as a chronic condition and up to 30–40% of the general population in milder or transient forms. Yet it is consistently under-treated — most people either normalise it, self-medicate with alcohol, or manage it with over-the-counter sedatives, none of which address the underlying problem.
+
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub)*
+
+---
+
+## Key Points
+
+- Insomnia is difficulty falling asleep, staying asleep, or waking too early on at least **3 nights per week** — with **daytime consequences** such as fatigue, mood disturbance, or impaired concentration.
+- **Acute insomnia** (less than 3 months) is usually triggered by a specific stressor and often resolves when it passes.
+- **Chronic insomnia** (3 months or more) is maintained by conditioned arousal and maladaptive behaviours — independent of the original trigger.
+- [CBT-I](/guides/cbt-insomnia) is the first-line treatment per international guidelines — more effective long term than any sleeping pill.
+- Insomnia frequently co-occurs with [depression](/guides/depression), [anxiety](/guides/anxiety), and chronic pain — these relationships are bidirectional.
+
+---
+
+## What Insomnia Is — and Is Not
+
+Clinical insomnia requires three components:
+
+1. **A sleep complaint** — difficulty initiating sleep, maintaining sleep, or waking earlier than desired
+2. **Adequate opportunity for sleep** — the problem is not simply insufficient time in bed
+3. **Daytime impairment** — fatigue, mood disturbance, concentration problems, reduced performance, or increased errors or accidents
+
+Insomnia should be distinguished from:
+- **Normal sleep variation** — sleeping slightly less than average without any daytime impairment
+- **Insufficient sleep syndrome** — sleeping too little by choice rather than inability
+- **Circadian rhythm disorders** — delayed sleep phase (unable to sleep until very late) or advanced sleep phase (waking extremely early); these involve timing, not the ability to sleep
+- **Other sleep disorders** — [sleep apnoea](/guides/sleep-apnoea) and [restless legs syndrome](/guides/restless-legs-syndrome) can both fragment sleep but require different evaluation and treatment
+
+---
+
+## Acute vs Chronic Insomnia
+
+**Acute insomnia** (also called short-term or adjustment insomnia):
+- Duration: less than 3 months
+- Usually triggered by an identifiable cause: stress, illness, jet lag, shift change, or environmental disruption
+- Often resolves when the trigger resolves
+- Risk of becoming chronic if perpetuating behaviours develop
+
+**Chronic insomnia:**
+- Duration: 3 months or more, at least 3 nights per week
+- Often started with an acute trigger but is now maintained by conditioned arousal — the brain has learnt to associate the bedroom with wakefulness and anxiety
+- The original trigger may long since have passed
+- The perpetuating behaviours — lying in bed awake for hours, irregular schedules, excessive time in bed, pre-sleep anxiety — maintain the disorder in a self-reinforcing cycle
+
+---
+
+## Causes and Contributing Factors
+
+Insomnia is best understood using the **3P model**:
+
+**Predisposing factors** — make you vulnerable:
+- Trait anxiety or worry-prone thinking style
+- Genetic sleep architecture (lighter sleepers)
+- Female sex (insomnia is approximately twice as common in women)
+- Older age
+- Personal or family history of mood disorders
+
+**Precipitating factors** — trigger the episode:
+- Acute stress: work pressure, relationship breakdown, bereavement
+- Medical events: illness, surgery, pain
+- Psychiatric events: depressive episode, anxiety disorder onset
+- Life changes: new baby, shift change, moving home
+- Medications: stimulants, corticosteroids, some antidepressants
+
+**Perpetuating factors** — maintain the disorder:
+- Spending excessive time in bed trying to catch up on sleep
+- Inconsistent sleep and wake times
+- Daytime napping
+- Using the bedroom for activities other than sleep and sex
+- Catastrophic thinking about sleep ("I'll never function tomorrow")
+- Checking the clock repeatedly during the night
+- Using alcohol as a sleep aid
+
+---
+
+## Symptoms
+
+**Night-time symptoms:**
+- Lying awake for 30 minutes or more before falling asleep
+- Waking frequently during the night and finding it difficult to return to sleep
+- Waking substantially earlier than desired and being unable to fall back asleep
+- Sleep that feels light, unrefreshing, or non-restorative despite adequate time in bed
+
+**Daytime consequences:**
+- Fatigue and low energy
+- Difficulty concentrating or remembering
+- Mood disturbance — irritability, low mood, anxiety
+- Reduced performance at work or school
+- Increased errors or safety concerns
+- Social withdrawal or reduced enjoyment of activities
+- Preoccupation or hypervigilance about sleep
+
+---
+
+## Common Co-occurring Conditions
+
+Insomnia rarely exists in isolation:
+
+- **[Depression](/guides/depression):** Insomnia is both a symptom of depression and an independent risk factor for developing it. The relationship is bidirectional — treating either condition partially improves the other.
+- **[Anxiety](/guides/anxiety):** Anxiety disorders are among the strongest correlates of chronic insomnia. Hyperarousal at bedtime drives both conditions.
+- **[Sleep apnoea](/guides/sleep-apnoea):** OSA fragments sleep and causes non-restorative sleep; it can present as or worsen insomnia. The two conditions frequently coexist. CBT-I remains effective in the context of treated OSA.
+- **Chronic pain:** Pain disrupts sleep architecture and insomnia lowers pain thresholds — a reinforcing cycle.
+- **Menopause:** Night sweats and hormonal shifts make insomnia extremely common during the menopausal transition. See [Menopause](/guides/menopause).
+
+---
+
+## Diagnosis
+
+Insomnia is a clinical diagnosis — no blood test or imaging is required. A clinician will typically:
+
+1. Take a **sleep history**: pattern, duration, daytime impact, precipitating and perpetuating factors
+2. Assess for **co-occurring conditions**: depression, anxiety, sleep apnoea, restless legs, pain, medications
+3. Review a **sleep diary** — a 1–2 week log of bed time, wake time, estimated sleep duration, and quality
+4. Consider **standardised questionnaires** such as the Insomnia Severity Index (ISI) or Pittsburgh Sleep Quality Index (PSQI)
+5. Order a **sleep study** only if a co-occurring sleep disorder such as OSA or periodic limb movement disorder is suspected
+
+---
+
+## Treatment
+
+### First line: CBT-I
+
+[Cognitive behavioural therapy for insomnia (CBT-I)](/guides/cbt-insomnia) is the first-line treatment recommended by the American College of Physicians, the British Association for Psychopharmacology, and the European Sleep Research Society.
+
+It combines:
+- **Sleep restriction** — consolidating time in bed to build sleep pressure
+- **Stimulus control** — rebuilding the bed as a sleep cue only
+- **Cognitive restructuring** — challenging catastrophic sleep beliefs
+- **Relaxation training** — reducing physiological arousal at bedtime
+- **Sleep hygiene** — optimising behaviour and environment
+
+A full course runs 6–8 sessions. Improvements typically begin within 2–3 weeks and are sustained at 12-month follow-up. Digital CBT-I programmes have comparable efficacy for many patients.
+
+### Sleep hygiene
+
+[Sleep hygiene](/guides/sleep-hygiene) — consistent schedules, morning light, screen curfew, bedroom environment — is necessary but not sufficient for chronic insomnia. It is foundational and should accompany all other treatment.
+
+### Medication
+
+Medications are not a first-line treatment for chronic insomnia. Short-term use may be appropriate when sleep deprivation is acutely impairing safety, CBT-I is not yet accessible, or an underlying condition is being treated. All sedative-hypnotics carry risks of tolerance, dependence, and rebound insomnia with prolonged use. Discuss options and duration with a prescriber.
+
+[Melatonin](/guides/melatonin-benefits-risks-safe-use) has a role in circadian-related sleep difficulty (delayed sleep phase, jet lag, shift work) but limited evidence for treating chronic insomnia.
+
+---
+
+## When to Seek Help
+
+See a doctor if:
+- Difficulty sleeping has persisted for **more than 3 months**
+- Sleep problems occur at least **3 nights per week**
+- Daytime impairment is affecting work, relationships, or safety
+- You are relying on alcohol or sedatives to sleep
+- You suspect [sleep apnoea](/guides/sleep-apnoea) — snoring, witnessed breathing pauses, gasping, or excessive daytime sleepiness despite time in bed
+- Low mood, anxiety, or other mental health symptoms accompany the sleep problem
+
+See [When to Seek Help for Insomnia](/guides/when-to-seek-help-for-insomnia) for a detailed decision guide.
+
+---
+
+## FAQ
+
+**Q: What is insomnia?**  
+A: A sleep disorder characterised by difficulty falling asleep, staying asleep, or waking too early on at least 3 nights per week, with daytime consequences including fatigue, mood disturbance, or impaired concentration.
+
+**Q: What is the difference between acute and chronic insomnia?**  
+A: Acute insomnia lasts days to weeks and is usually triggered by an identifiable stressor. Chronic insomnia persists for 3 months or more and is often maintained by conditioned arousal and maladaptive behaviours, even after the original trigger has resolved.
+
+**Q: What causes chronic insomnia?**  
+A: The 3P model: predisposing vulnerability, a precipitating event, and perpetuating behaviours — irregular schedules, excessive time in bed, catastrophic thinking about sleep — that maintain the disorder long after the trigger has passed.
+
+**Q: How is insomnia treated?**  
+A: CBT-I is the first-line treatment per international guidelines. It addresses the behavioural and cognitive factors that perpetuate insomnia. Sleep hygiene and short-term medication may also have a role.
+
+**Q: Can insomnia go away on its own?**  
+A: Acute insomnia often resolves once the trigger passes. Chronic insomnia is less likely to resolve without intervention because the perpetuating cycle tends to be self-reinforcing.
+
+---
+
+## Further Reading
+
+- [NHS — Insomnia](https://www.nhs.uk/conditions/insomnia/)
+- [American Academy of Sleep Medicine](https://aasm.org/)
+- [National Sleep Foundation — Insomnia](https://www.thensf.org/insomnia/)
+- [Insomnia Severity Index (ISI)](https://www.ons.org/sites/default/files/InsomniaSeverityIndex_ISI.pdf)
+
+---
+
+## Related Guides
+
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Cognitive Behavioural Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
+- [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+- [When to Seek Help for Insomnia](/guides/when-to-seek-help-for-insomnia)
+- [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+- [Restless Legs Syndrome](/guides/restless-legs-syndrome)
+- [Melatonin: Benefits, Risks, and Safe Use](/guides/melatonin-benefits-risks-safe-use)
+- [Depression: Symptoms, Causes, and Treatment](/guides/depression)
+- [Anxiety Disorders](/guides/anxiety)
+- [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause)
+
+---
+
+*Educational only; not a substitute for professional medical advice.*

--- a/src/content/guides/when-to-seek-help-for-insomnia.md
+++ b/src/content/guides/when-to-seek-help-for-insomnia.md
@@ -138,5 +138,9 @@ A: They can be helpful short term but are not recommended as a long-term solutio
 - [NIH – Cognitive Behavioral Therapy for Insomnia](https://www.nhlbi.nih.gov/health/cognitive-behavioral-therapy-insomnia)  
 
 ## Related Guides
-- [Cognitive Behavioral Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)  
-- [Healthy Sleep Hygiene](/guides/sleep-hygiene)  
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+- [Cognitive Behavioral Therapy for Insomnia (CBT-I)](/guides/cbt-insomnia)
+- [Healthy Sleep Hygiene](/guides/sleep-hygiene)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)

--- a/src/content/guides/why-am-i-always-tired.md
+++ b/src/content/guides/why-am-i-always-tired.md
@@ -1,0 +1,260 @@
+---
+title: "Why Am I Always Tired?"
+slug: "why-am-i-always-tired"
+description: "Persistent tiredness has many causes beyond poor sleep — including sleep apnoea, depression, thyroid disease, anaemia, and diabetes. A practical guide to the differential and when to seek investigation."
+category: "General Health"
+publishDate: "2026-05-31"
+updatedDate: "2026-05-31"
+tags: ["fatigue", "tiredness", "exhaustion", "sleep", "anaemia", "thyroid", "depression", "sleep apnoea", "general health"]
+draft: false
+faq:
+  - q: "What are the most common causes of persistent tiredness?"
+    a: "The most common causes include insufficient or poor-quality sleep, obstructive sleep apnoea, iron deficiency anaemia, depression, anxiety, hypothyroidism, type 2 diabetes, vitamin deficiencies, and medication side effects. In many people, more than one factor is present simultaneously."
+  - q: "When should I see a doctor about fatigue?"
+    a: "See a doctor if fatigue is persistent (more than 4 weeks), unexplained by obvious lifestyle factors, accompanied by other symptoms such as unintentional weight loss, breathlessness, palpitations, or low mood, or if it is significantly affecting daily life, work, or safety."
+  - q: "What blood tests are done for unexplained tiredness?"
+    a: "A typical initial screen includes a full blood count (checking for anaemia), thyroid function tests, fasting blood glucose or HbA1c, ferritin (iron stores), vitamin B12, vitamin D, CRP or ESR (inflammation markers), and kidney and liver function. Your doctor may add further tests based on the clinical picture."
+  - q: "Is chronic fatigue syndrome the same as being always tired?"
+    a: "No. Chronic fatigue syndrome (CFS/ME) is a specific, diagnosed condition characterised by severe post-exertional fatigue that does not improve with rest, accompanied by cognitive difficulties, sleep problems, and autonomic dysfunction. General tiredness from lifestyle factors or common medical conditions is distinct. If you have been diagnosed with CFS/ME, see the dedicated guide."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Why Am I Always Tired?"
+    description: "Persistent tiredness has many causes beyond poor sleep — including sleep apnoea, depression, thyroid disease, anaemia, and diabetes. A practical guide to the differential and when to seek investigation."
+    datePublished: "2026-05-31"
+    dateModified: "2026-05-31"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/why-am-i-always-tired"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["fatigue", "tiredness", "chronic fatigue", "sleep apnoea", "anaemia", "hypothyroidism", "depression", "why am I always tired"]
+    about:
+      "@type": "MedicalEntity"
+      name: "Fatigue"
+      sameAs: "https://en.wikipedia.org/wiki/Fatigue"
+  - "@context": "https://schema.org"
+    "@type": "FAQPage"
+    mainEntity:
+      - "@type": "Question"
+        name: "What are the most common causes of persistent tiredness?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "The most common causes include insufficient sleep, sleep apnoea, iron deficiency anaemia, depression, anxiety, hypothyroidism, type 2 diabetes, vitamin deficiencies, and medication side effects. Multiple causes often coexist."
+      - "@type": "Question"
+        name: "When should I see a doctor about fatigue?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "See a doctor if fatigue has lasted more than 4 weeks, is unexplained by obvious factors, significantly impairs daily function, or is accompanied by other symptoms such as weight change, breathlessness, or mood disturbance."
+      - "@type": "Question"
+        name: "What blood tests are done for unexplained tiredness?"
+        acceptedAnswer:
+          "@type": "Answer"
+          text: "A standard screen includes full blood count, thyroid function, fasting glucose or HbA1c, ferritin, vitamin B12, vitamin D, CRP or ESR, and kidney and liver function."
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Sleep Health Hub"
+        item: "https://patientguide.io/guides/sleep-health-hub"
+      - "@type": "ListItem"
+        position: 3
+        name: "Why Am I Always Tired?"
+        item: "https://patientguide.io/guides/why-am-i-always-tired"
+---
+
+## Intro
+
+Tiredness is one of the most common reasons people visit a doctor. Feeling chronically fatigued — dragging through the day, waking unrefreshed, struggling to concentrate — is never normal when it persists. It is always a signal worth investigating, even when no obvious cause is apparent.
+
+*[← Back to Sleep Health Hub](/guides/sleep-health-hub)*
+
+---
+
+## Key Points
+
+- Persistent unexplained fatigue should always be investigated — it is not something to simply push through indefinitely.
+- The most common identifiable causes are poor or insufficient sleep, [sleep apnoea](/guides/sleep-apnoea), [depression](/guides/depression), [anxiety](/guides/anxiety), iron deficiency anaemia, thyroid disease, and diabetes.
+- More than one cause is often present simultaneously.
+- [Chronic Fatigue Syndrome / ME](/guides/chronic-fatigue) is a distinct, specific diagnosis — not the same as general tiredness from common medical causes.
+- Most causes are diagnosable with a clinical assessment and basic blood tests.
+
+---
+
+## Distinguishing This from CFS/ME
+
+If you have been diagnosed with **Chronic Fatigue Syndrome (CFS/ME)**, see [Chronic Fatigue Syndrome](/guides/chronic-fatigue) for a condition-specific guide. CFS/ME is characterised by severe post-exertional malaise (worsening of symptoms after physical or mental effort), cognitive dysfunction, and orthostatic intolerance. It is distinct from the common causes of fatigue discussed here and requires different assessment and management.
+
+---
+
+## Common Causes
+
+### 1. Insufficient or Poor-Quality Sleep
+
+The most common cause of daytime tiredness is not getting enough sleep — or not getting restorative sleep. Adults need 7–9 hours. Many people function chronically below this threshold while substantially underestimating the impairment it causes.
+
+Poor sleep quality can result from irregular schedules, late caffeine or alcohol, excessive screen use before bed, a bedroom that is too warm or light, or anxiety that fragments sleep.
+
+See [Sleep Health: Why It Matters and How to Improve It](/guides/sleep) and [Healthy Sleep Hygiene](/guides/sleep-hygiene).
+
+### 2. Obstructive Sleep Apnoea
+
+[Sleep apnoea](/guides/sleep-apnoea) is one of the most underdiagnosed causes of chronic tiredness. In obstructive sleep apnoea (OSA), the upper airway repeatedly collapses during sleep, causing hundreds of brief arousals per night — none of which reach consciousness, but all of which fragment sleep architecture and prevent restorative sleep.
+
+**Signs that suggest sleep apnoea:**
+- Loud snoring
+- Breathing pauses witnessed by a partner
+- Gasping or choking during sleep
+- Waking unrefreshed despite 7–9 hours in bed
+- Persistent daytime sleepiness that does not improve with more sleep
+- Morning headaches
+
+OSA is diagnosed with a sleep study and is highly treatable. Most people with OSA experience dramatic improvements in energy and cognition after starting CPAP therapy.
+
+### 3. Iron Deficiency Anaemia
+
+Iron deficiency is the most common nutritional deficiency globally and a very common cause of fatigue — particularly in women of reproductive age, pregnant women, vegetarians, and people with heavy menstrual bleeding or gastrointestinal blood loss.
+
+Symptoms include fatigue, pallor, breathlessness on exertion, palpitations, difficulty concentrating, cold intolerance, and — in more severe cases — brittle nails or hair loss.
+
+Diagnosed with a full blood count and ferritin level. Treated with oral iron supplementation; the underlying cause should always be identified and addressed.
+
+### 4. Depression
+
+[Depression](/guides/depression) is one of the most common causes of persistent fatigue. Fatigue and low energy are core symptoms alongside low mood, loss of pleasure, cognitive slowing, and sleep disturbance.
+
+Depression-related fatigue has a characteristic quality: everything feels effortful, motivation is absent, and activity does not relieve tiredness. Sleep disturbance — typically early morning waking — is common. Fatigue and depression are bidirectionally linked: poor sleep worsens depression, and depression worsens sleep.
+
+### 5. Anxiety
+
+[Anxiety](/guides/anxiety) disorders — particularly generalised anxiety disorder — produce physical exhaustion through sustained hyperarousal. The body running its threat-response system chronically is metabolically expensive. Disrupted sleep from racing thoughts amplifies the fatigue further.
+
+### 6. Hypothyroidism
+
+An underactive thyroid gland reduces metabolic rate and causes fatigue, cold intolerance, weight gain, constipation, low mood, cognitive slowing, and dry skin. It is more common in women and older adults.
+
+Diagnosed with a TSH blood test; treated effectively with levothyroxine replacement.
+
+### 7. Type 2 Diabetes and Prediabetes
+
+Both [type 2 diabetes](/guides/type-2-diabetes) and [prediabetes](/guides/prediabetes) are associated with fatigue — partly from disrupted cellular energy metabolism due to insulin resistance, and partly from associated sleep disruption, frequent nocturia, and, over time, peripheral neuropathy.
+
+### 8. Vitamin and Mineral Deficiencies
+
+Beyond iron, deficiencies in **vitamin B12**, **vitamin D**, and **folate** can all cause fatigue. Vitamin B12 deficiency is particularly common in older adults, vegans, and people on long-term metformin. Vitamin D deficiency is endemic in northern latitudes and associated with fatigue, low mood, and musculoskeletal symptoms.
+
+### 9. Medication Side Effects
+
+Many common medications cause fatigue as a side effect:
+- Beta-blockers (hypertension, heart disease)
+- Antihistamines
+- Benzodiazepines and sedative-hypnotics
+- Many antidepressants (particularly at initiation or dose change)
+- Statins (in some people)
+- Opioid analgesics
+- Anti-epileptic drugs
+
+If fatigue began or worsened after starting a new medication, discuss a dose adjustment or switch with your prescriber.
+
+### 10. Chronic Medical Conditions
+
+Many chronic conditions cause fatigue as a primary symptom:
+- **Chronic kidney disease** — waste product accumulation and anaemia of chronic disease
+- **Heart failure** — reduced cardiac output impairs exercise tolerance and causes fatigue even at rest
+- **COPD** — hypoxia and sleep disruption
+- **Inflammatory conditions** — rheumatoid arthritis, lupus, inflammatory bowel disease
+- **Long COVID and post-viral syndromes** — post-viral fatigue affecting energy, cognition, and exertion tolerance. See [Post-Viral Syndromes](/guides/post-viral-syndromes)
+- **[Restless Legs Syndrome](/guides/restless-legs-syndrome)** — sleep fragmentation from nocturnal leg discomfort causes significant daytime tiredness
+
+### 11. Poor Diet, Dehydration, and Inactivity
+
+Erratic eating, skipping meals, and high ultra-processed food intake destabilise blood glucose and contribute to low energy. Mild dehydration consistently impairs energy and concentration. Paradoxically, physical inactivity causes fatigue — regular aerobic exercise is one of the most reliable ways to improve energy levels over time.
+
+---
+
+## When to Seek Medical Advice
+
+See a doctor if:
+- Fatigue has persisted for **more than 4 weeks** without an obvious cause
+- It is significantly affecting work, relationships, or daily functioning
+- It is accompanied by:
+  - Unintentional weight loss
+  - Persistent fever or night sweats
+  - Shortness of breath on minimal exertion
+  - Chest pain or palpitations
+  - Swollen lymph nodes
+  - Severe or worsening low mood
+  - Heavy or irregular menstrual bleeding
+- You suspect sleep apnoea (loud snoring, gasping, witnessed breathing pauses, or excessive daytime sleepiness despite adequate time in bed)
+- You have a condition that commonly causes fatigue and your fatigue has changed in character or severity
+
+Do not defer investigation on the assumption that it is "probably just stress." Fatigue is a legitimate medical symptom.
+
+---
+
+## What to Expect at the Appointment
+
+A doctor will typically:
+1. Take a full history — onset, character, associated symptoms, medications, lifestyle
+2. Perform a clinical examination
+3. Order basic blood tests: full blood count, thyroid function, fasting glucose or HbA1c, ferritin, vitamin B12, vitamin D, CRP or ESR, kidney and liver function
+4. Ask about sleep — volume, quality, snoring, partner observations
+5. Screen for depression and anxiety
+
+Most common causes can be identified or strongly suspected from this initial assessment.
+
+---
+
+## FAQ
+
+**Q: What are the most common causes of persistent tiredness?**  
+A: Insufficient or poor-quality sleep, sleep apnoea, depression, anxiety, iron deficiency anaemia, hypothyroidism, type 2 diabetes, and medication side effects. Multiple causes often coexist.
+
+**Q: When should I see a doctor?**  
+A: If fatigue has lasted more than 4 weeks, is unexplained by obvious factors, is significantly impairing daily function, or is accompanied by other symptoms such as weight change, breathlessness, palpitations, or mood disturbance.
+
+**Q: What blood tests are usually done?**  
+A: A standard screen includes full blood count, thyroid function, fasting glucose or HbA1c, ferritin, vitamin B12, vitamin D, CRP or ESR, and kidney and liver function.
+
+**Q: Is tiredness always a sign of something serious?**  
+A: Not always. Many causes are common, treatable, and not life-threatening. But persistent fatigue that does not respond to good sleep and lifestyle measures should always be investigated rather than normalised.
+
+**Q: Is chronic fatigue syndrome the same as being always tired?**  
+A: No. CFS/ME is a specific diagnosed condition with distinct clinical criteria involving post-exertional malaise, cognitive dysfunction, and autonomic features. See [Chronic Fatigue Syndrome](/guides/chronic-fatigue).
+
+---
+
+## Further Reading
+
+- [NHS — Tiredness and Fatigue](https://www.nhs.uk/conditions/tiredness-and-fatigue/)
+- [National Sleep Foundation — Sleep and Fatigue](https://www.thensf.org/)
+- [American Thyroid Association — Hypothyroidism](https://www.thyroid.org/hypothyroidism/)
+
+---
+
+## Related Guides
+
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Sleep Health: Why It Matters and How to Improve It](/guides/sleep)
+- [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+- [Restless Legs Syndrome](/guides/restless-legs-syndrome)
+- [What Is Insomnia?](/guides/what-is-insomnia)
+- [Depression: Symptoms, Causes, and Treatment](/guides/depression)
+- [Anxiety Disorders](/guides/anxiety)
+- [Type 2 Diabetes](/guides/type-2-diabetes)
+- [Chronic Fatigue Syndrome](/guides/chronic-fatigue)
+- [Post-Viral Syndromes](/guides/post-viral-syndromes)
+
+---
+
+*Educational only; not a substitute for professional medical advice. Persistent fatigue should be assessed by a healthcare professional.*


### PR DESCRIPTION
## Summary

- **New Sleep Health Hub** (`/guides/sleep-health-hub`) — `Guide Hubs` category — central navigation page linking all sleep content, with sections on why sleep matters, common disorders, treatments, and the fatigue symptom pathway
- **5 new condition/topic guides:**
  - `what-is-insomnia.md` — `Mental Health` — condition overview, acute vs chronic, 3P model, causes, diagnosis, CBT-I treatment pathway
  - `why-am-i-always-tired.md` — `General Health` — fatigue differential covering sleep apnoea, depression, anaemia, thyroid, diabetes, medications, with CFS disambiguation
  - `melatonin-benefits-risks-safe-use.md` — `Mental Health` — evidence review, dosing (0.5–1 mg vs OTC over-dosing problem), jet lag/shift work/DSPS/insomnia, safety, drug interactions
  - `restless-legs-syndrome.md` — `Neurology` — dopamine mechanism, iron deficiency (ferritin target >75 µg/L), PLMS, clinical diagnosis, iron/alpha-2-delta/dopaminergic treatment, augmentation risk
  - `shift-work-sleep-disorder.md` — `Mental Health` — circadian misalignment mechanism, strategic light exposure, timed melatonin, daytime sleep hygiene, modafinil, occupational safety
- **Expanded internal linking on 5 existing guides** — `sleep.md`, `sleep-hygiene.md`, `cbt-insomnia.md`, `sleep-apnoea.md`, `when-to-seek-help-for-insomnia.md` — each updated with hub back-link and cross-links to new guides

## Category choices (all valid enum values from config.ts)

| Guide | Category |
|---|---|
| sleep-health-hub | `Guide Hubs` |
| what-is-insomnia | `Mental Health` |
| why-am-i-always-tired | `General Health` |
| melatonin-benefits-risks-safe-use | `Mental Health` |
| restless-legs-syndrome | `Neurology` |
| shift-work-sleep-disorder | `Mental Health` |

## Build results

- `npm run content:check`: **0 errors**, 213 warnings (all pre-existing site-wide "no FAQ" notices — not introduced by this PR)
- `npm run build`: **completed successfully — 712 pages generated**, 0 errors, 30.5 seconds
- All 6 new routes confirmed in build output

## Test plan

- [ ] Visit `/guides/sleep-health-hub` — confirm all linked guides resolve without 404
- [ ] Visit `/guides/what-is-insomnia` — confirm hub back-link, CBT-I/sleep-hygiene links, FAQ renders
- [ ] Visit `/guides/restless-legs-syndrome` — confirm Parkinson's cross-link resolves
- [ ] Visit `/guides/sleep` — confirm new hub back-link and expanded Related Guides section
- [ ] Visit `/guides/sleep-apnoea` — confirm `why-am-i-always-tired` and hub links present
- [ ] Spot-check no broken internal links via site link checker

Generated with [Claude Code](https://claude.com/claude-code)
