### PR TITLE
feat(mens-health): add men's health hub and screening cluster

### DIFF
--- a/src/content/guides/erectile-dysfunction-causes-and-treatment.md
+++ b/src/content/guides/erectile-dysfunction-causes-and-treatment.md
@@ -1,0 +1,284 @@
+---
+title: "Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment"
+slug: "erectile-dysfunction-causes-and-treatment"
+description: "A comprehensive guide to erectile dysfunction — why it is often a vascular issue, not simply a sexual one, and what its causes reveal about cardiovascular health, diabetes, sleep apnoea, obesity, testosterone, and mental wellbeing."
+category: "Men's Health"
+publishDate: "2026-06-02"
+updatedDate: "2026-06-02"
+draft: false
+tags:
+  - erectile dysfunction
+  - ED
+  - men's health
+  - cardiovascular disease
+  - diabetes
+  - obesity
+  - sleep apnoea
+  - testosterone
+  - sexual health
+  - vascular health
+  - PDE5 inhibitors
+  - sildenafil
+faq:
+  - q: "Is erectile dysfunction a sign of heart disease?"
+    a: "Erectile dysfunction (ED) is frequently the first detectable sign of systemic vascular disease, and in men who go on to develop heart disease it typically precedes a cardiac event by 3–5 years. The penile arteries are smaller than coronary arteries, so atherosclerosis affects them earlier. Any man under 60 with new or worsening ED — without an obvious psychological explanation — should have a cardiovascular risk assessment, not just a prescription."
+  - q: "What are the most common causes of erectile dysfunction?"
+    a: "The most common causes are vascular (atherosclerosis, hypertension, dyslipidaemia), metabolic (type 2 diabetes, obesity, insulin resistance), hormonal (low testosterone, thyroid dysfunction), neurological (diabetic neuropathy, post-prostatectomy nerve damage), medication side effects (antihypertensives, antidepressants, opioids), psychological (anxiety, depression, performance anxiety), and sleep disorders (obstructive sleep apnoea)."
+  - q: "Do PDE5 inhibitors (Viagra, Cialis) always work?"
+    a: "PDE5 inhibitors work in approximately 70% of men. They are less effective in severe vascular disease, in men with very low testosterone, and in diabetes with significant autonomic neuropathy. They require sexual stimulation to work — they do not cause erection independently. Men who do not respond to one agent may respond to another, a different dose, or a combination approach."
+  - q: "Can erectile dysfunction be reversed?"
+    a: "In many men, yes. Regular aerobic exercise, weight loss, smoking cessation, blood pressure and glucose control, treatment of sleep apnoea, and reduced alcohol use all improve erectile function — often significantly. For medication-related ED, switching agents frequently resolves the problem. Medical treatments (PDE5 inhibitors, testosterone therapy where appropriate) are effective for most men with persistent ED."
+---
+
+## Erectile Dysfunction Is a Vascular Issue
+
+Erectile dysfunction — the persistent inability to achieve or maintain an erection sufficient for satisfactory sexual activity — affects approximately 40% of men over 40, with prevalence rising sharply with age. But the common framing of ED as a sexual problem, or as a matter of embarrassment, misses something clinically important.
+
+**An erection is a vascular event.** It requires nitric oxide release from healthy vascular endothelium, arterial dilation, and blood flow into the corpora cavernosa of the penis. The same endothelial biology, the same risk factors, and the same pathological process — atherosclerosis — govern blood flow through coronary and cerebral arteries.
+
+The penile arteries (1–2 mm diameter) are smaller than the coronary arteries (3–4 mm). Atherosclerosis affects smaller vessels earlier. This is why ED typically precedes a cardiac event by **3–5 years** in men with shared vascular risk factors. A man who develops new ED at age 52 without a clear psychological cause is not simply experiencing a sexual problem — he may be experiencing an early warning sign of cardiovascular disease.
+
+Treating ED without assessing cardiovascular risk misses a critical prevention opportunity.
+
+---
+
+## How Erections Work
+
+Understanding why erections fail requires understanding how they occur:
+
+1. Sexual arousal activates the parasympathetic nervous system
+2. Nitric oxide (NO) is released from vascular endothelial cells and nerve terminals in the penis
+3. NO stimulates production of cGMP (cyclic guanosine monophosphate), which causes smooth muscle relaxation in penile arteries and the corpora cavernosa
+4. Arterial blood flows in; the corpora expand and compress penile veins
+5. Sustained pressure maintains rigidity
+
+Disruption at any step produces ED. Atherosclerosis reduces arterial flow. Endothelial dysfunction reduces nitric oxide. Diabetic neuropathy disrupts nerve signalling. Performance anxiety activates the sympathetic nervous system, which counteracts parasympathetic erectile response. Smoking acutely impairs nitric oxide release.
+
+---
+
+## Causes of Erectile Dysfunction
+
+### 1. Vascular Disease
+
+Atherosclerosis, hypertension, and dyslipidaemia reduce endothelial function and penile blood flow. The cardiovascular risk factors that drive coronary artery disease drive ED through identical mechanisms:
+
+- **Hypertension** — damages endothelium, reduces arterial compliance, and impairs nitric oxide production
+- **Dyslipidaemia** — elevated LDL and low HDL promote penile arterial plaque
+- **Smoking** — acutely reduces nitric oxide and chronically damages the vascular lining; smoking approximately doubles the risk of ED
+- **Age** — endothelial function declines progressively; arterial stiffness increases
+
+Vascular ED is the most common cause in men over 50. It is often gradual in onset, present in all contexts (not situational), and associated with absent or reduced morning erections.
+
+### 2. Type 2 Diabetes
+
+Diabetes causes ED through multiple simultaneous pathways:
+
+- **Microvascular disease** — small vessel damage impairs penile arterial perfusion
+- **Autonomic neuropathy** — disrupts parasympathetic nerve signals required for smooth muscle relaxation
+- **Endothelial dysfunction** — elevated blood glucose directly damages the vascular endothelium
+- **Secondary hypogonadism** — diabetes is associated with reduced testosterone
+
+ED affects approximately **50–75% of men with type 2 diabetes** — often earlier, more severely, and with a poorer response to oral medication than in non-diabetic men. Good glycaemic control (maintaining HbA1c in target range) slows the progression of both vascular and neuropathic damage.
+
+See [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes).
+
+### 3. Obesity
+
+Obesity contributes to ED through several overlapping mechanisms:
+
+- Increased aromatisation of testosterone to oestrogen in adipose tissue, lowering free testosterone
+- Insulin resistance and metabolic syndrome
+- Elevated inflammatory cytokines that impair endothelial function
+- Obstructive sleep apnoea (itself an independent cause of ED)
+- Physical deconditioning and reduced cardiovascular fitness
+
+Men who lose 10% or more of body weight demonstrate clinically significant improvements in erectile function — independent of any change in testosterone. Weight loss through lifestyle change, GLP-1 medications, or bariatric surgery all show benefit. See [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub).
+
+### 4. Obstructive Sleep Apnoea
+
+Sleep apnoea impairs erectile function through multiple pathways:
+
+- **Intermittent hypoxaemia** — repeated oxygen desaturations during apnoeic episodes damage endothelial function
+- **Nocturnal testosterone suppression** — testosterone is secreted primarily during deep sleep; sleep fragmentation impairs this
+- **Sympathetic activation** — apnoeas trigger adrenaline release that causes vasoconstriction and suppresses parasympathetic erectile response
+- **Metabolic consequences** — sleep apnoea independently drives insulin resistance and hypertension
+
+CPAP treatment of sleep apnoea improves erectile function in many men, independent of testosterone changes. Men with ED and prominent snoring, witnessed apnoeas, excessive daytime sleepiness, or a morning headache should be assessed for sleep apnoea before assuming another cause. See [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea).
+
+### 5. Low Testosterone
+
+Testosterone is required for normal libido, contributes to penile smooth muscle health, and supports nitric oxide production. However, low testosterone as a **primary** cause of ED — isolated from other vascular or metabolic risk factors — is less common than widely assumed.
+
+Many men with low testosterone have underlying obesity, sleep apnoea, or chronic illness driving both the hormonal decline and the ED. Addressing the root cause often improves both simultaneously. Testosterone therapy improves erectile function in confirmed hypogonadal men, but does not substitute for evaluating and treating vascular risk factors.
+
+If testosterone deficiency is suspected (low libido, fatigue, reduced morning erections, muscle loss), request a morning serum testosterone — levels are highest between 7–10am. See [Testosterone Replacement Therapy](/guides/testosterone-replacement-therapy) and [Natural Testosterone Optimisation](/guides/natural-testosterone-optimisation).
+
+### 6. Medications
+
+Many commonly prescribed medications impair erectile function:
+
+| Drug class | Common examples | Mechanism |
+|---|---|---|
+| Older antihypertensives | Thiazides, non-selective beta-blockers | Haemodynamic effects, altered lipid/hormone profile |
+| Antidepressants | SSRIs, SNRIs, TCAs | Serotonergic suppression of libido and ejaculation |
+| Anti-androgens | Spironolactone, bicalutamide | Testosterone receptor blockade |
+| 5-alpha reductase inhibitors | Finasteride, dutasteride | Reduced dihydrotestosterone (DHT) |
+| Opioids | Codeine, oxycodone, morphine | Suppress gonadotrophin and testosterone |
+| H2 blockers | Cimetidine | Anti-androgenic effect |
+| Antipsychotics | Many agents | Hyperprolactinaemia; dopamine blockade |
+
+**Do not stop prescribed medication without speaking to your doctor.** Many alternatives exist. Newer antihypertensives (ARBs, ACE inhibitors, calcium channel blockers) are substantially less likely to cause ED than thiazides and older beta-blockers. Among antidepressants, bupropion and mirtazapine have the lowest rates of sexual side effects; SSRIs vary — switching from paroxetine to sertraline or escitalopram may help.
+
+### 7. Psychological and Relationship Factors
+
+Anxiety, depression, performance anxiety, and relationship stress are significant contributors to ED — and interact with physical causes. A man who experiences ED due to a physical cause may develop secondary performance anxiety that perpetuates and amplifies the problem.
+
+Psychological ED is more common in:
+- Younger men (under 40) without vascular risk factors
+- Men with situational ED (present with a partner but absent during masturbation)
+- Men with preserved normal nocturnal or morning erections
+- Men with onset after a specific stressful event
+
+Performance anxiety is the most common psychological cause and typically presents as inability to achieve erection with a partner, normal erections in other contexts, and significant anticipatory anxiety. See [Male Mental Health — Depression, Help-Seeking, and Wellbeing](/guides/male-mental-health) and [Depression — Symptoms, Causes, and Treatment](/guides/depression).
+
+### 8. Neurological Causes
+
+The nerve pathways required for erection can be disrupted by:
+- Diabetic autonomic neuropathy (most common)
+- Post-radical prostatectomy nerve damage (extremely common; 30–90% of men at 12 months depending on technique)
+- Pelvic radiation for prostate or rectal cancer
+- Multiple sclerosis
+- Parkinson's disease
+- Spinal cord injury
+
+Post-prostatectomy ED may be partial or complete, and recovery — where it occurs — typically takes 12–24 months. Penile rehabilitation (early use of PDE5 inhibitors to maintain tissue oxygenation) is recommended to preserve erectile tissue during nerve recovery. See [Prostate Cancer — Guide Hub](/guides/prostate-cancer).
+
+---
+
+## Assessment: When and How to Seek Help
+
+### Seek a GP assessment if ED:
+- Is persistent (present on most attempts over 3 or more months)
+- Is new or significantly worsening
+- Occurs in a man under 60 without an obvious psychological explanation
+- Is accompanied by reduced libido, fatigue, loss of morning erections, or muscle loss (suggesting testosterone deficiency)
+- Occurs alongside urinary symptoms, testicular changes, or pelvic pain
+
+### What your doctor will assess:
+- Duration, onset (sudden or gradual), and pattern (all contexts or situational)
+- Presence of morning erections (a useful indicator of vascular vs. psychological cause)
+- Cardiovascular risk factors: smoking, blood pressure, cholesterol, diabetes, family history
+- Current medications
+- Sleep quality, snoring, daytime sleepiness
+- Mood, stress levels, relationship factors
+- Alcohol and substance use
+
+### Investigations typically include:
+- Fasting blood glucose and HbA1c
+- Fasting lipid profile
+- Morning testosterone (if symptoms suggest hypogonadism)
+- Blood pressure measurement
+- In selected men: LH, FSH, prolactin (if hypogonadism confirmed), thyroid function
+
+---
+
+## The Princeton Consensus: ED and Cardiac Risk
+
+The Princeton Consensus guidelines — the standard international framework for managing ED in men with cardiovascular disease — stratify men into three groups:
+
+- **Low cardiac risk** — no cardiac symptoms, stable coronary disease, good exercise tolerance (can climb two flights of stairs without chest pain or dyspnoea). Can initiate ED treatment without further cardiac investigation.
+- **Intermediate cardiac risk** — moderate stable angina, recent MI (within 6 weeks but more than 2 weeks), or multiple cardiovascular risk factors. Requires further cardiovascular assessment before ED treatment; exercise stress testing may be appropriate.
+- **High cardiac risk** — unstable angina, severe heart failure, recent MI (within 2 weeks), uncontrolled hypertension, significant arrhythmia. ED treatment deferred until cardiac condition is stable.
+
+Men with ED and intermediate cardiovascular risk — common in clinical practice — benefit from a structured cardiovascular risk assessment before initiating therapy. See [Cardiovascular Risk Assessment — Beyond Cholesterol](/guides/cardiovascular-risk-assessment).
+
+---
+
+## Treatment
+
+### 1. Lifestyle Modification — First Line
+
+The evidence for lifestyle modification in ED is substantial and underappreciated:
+
+- **Regular aerobic exercise** (30 minutes, 5 days/week): improves endothelial function, reduces weight, lowers blood pressure, and raises testosterone — one of the most effective ED interventions; some studies show benefit comparable to PDE5 inhibitors
+- **Weight loss**: 10% weight reduction improves erectile function significantly in obese men; results are independent of testosterone change
+- **Smoking cessation**: penile blood flow improves measurably within months; effect is dose-dependent with the number of years smoked
+- **Reduced alcohol**: chronic heavy alcohol consumption suppresses testosterone and impairs neurological function; moderate reduction shows rapid benefit
+- **Blood pressure and glucose control**: slows vascular and neuropathic damage
+- **Sleep apnoea treatment**: CPAP improves ED in many men with sleep-disordered breathing
+
+### 2. PDE5 Inhibitors — First-Line Medical Treatment
+
+Phosphodiesterase type 5 (PDE5) inhibitors work by blocking the enzyme that breaks down cGMP, prolonging smooth muscle relaxation in penile vessels. They require sexual stimulation and do not produce erection independently.
+
+| Drug | Duration of action | Key notes |
+|---|---|---|
+| Sildenafil (Viagra, generic) | 4–6 hours | Take 1 hour before; high-fat meals delay absorption |
+| Tadalafil (Cialis, generic) | 24–36 hours | Available as daily low-dose (5 mg) for continuous coverage |
+| Vardenafil (Levitra) | 4–6 hours | Similar efficacy and profile to sildenafil |
+| Avanafil (Spedra) | 2–4 hours | Fastest onset; fewer colour-vision side effects |
+
+**Absolute contraindication:** PDE5 inhibitors combined with **nitrate medications** (GTN spray, nitrate patches, isosorbide mononitrate/dinitrate) cause potentially fatal hypotension. Men taking nitrates for angina cannot safely use PDE5 inhibitors.
+
+**Caution with:** alpha-blockers (hypotension risk), grapefruit juice (increases drug levels), recent stroke or MI.
+
+Approximately 70% of men respond to PDE5 inhibitors. Response rates are lower in diabetic neuropathy, severe vascular disease, and post-prostatectomy ED. Men who do not respond to one agent may respond to another or to a higher dose.
+
+Generic sildenafil and tadalafil are widely available in Australia at significantly lower cost than branded versions.
+
+### 3. Testosterone Therapy
+
+For men with confirmed hypogonadism (low morning testosterone on two separate tests), testosterone therapy improves libido and often improves erectile function. In men with borderline testosterone, the combination of testosterone supplementation with a PDE5 inhibitor may be more effective than either alone.
+
+Testosterone therapy is not appropriate for men with normal testosterone levels, and does not replace assessment of vascular risk factors — in many men, treating the underlying cause of testosterone suppression (obesity, sleep apnoea) restores both testosterone and erectile function without supplementation.
+
+### 4. Psychological Therapy
+
+Psychosexual therapy and cognitive-behavioural therapy (CBT) are effective for ED with a significant psychological component, particularly performance anxiety. Therapy may be delivered individually or with a partner. Even where ED has a physical cause, psychological support helps manage the anxiety and relationship stress that frequently develop secondarily.
+
+### 5. Vacuum Erection Device
+
+A vacuum erection device uses negative pressure to draw blood into the penis, followed by a constriction ring to maintain rigidity. Non-invasive, medication-free, and effective in approximately 90% of men regardless of cause. Particularly useful when PDE5 inhibitors are contraindicated (e.g. nitrate use) or poorly tolerated.
+
+### 6. Intracavernosal Injection Therapy
+
+Alprostadil (prostaglandin E1) injected directly into the corpora cavernosa produces erection within 10–15 minutes, independent of arousal. Highly effective (80–90% of men) and preferred for neurogenic and severe vasculogenic ED where oral therapy is insufficient. Requires instruction in self-injection technique. Priapism (erection lasting more than 4 hours) is a rare but serious complication requiring emergency treatment.
+
+### 7. Intraurethral Alprostadil (MUSE)
+
+A small alprostadil pellet inserted into the urethra is absorbed locally. Less effective than injection therapy; preferred by men who cannot tolerate needles. Often used with a constriction ring to improve retention.
+
+### 8. Penile Prosthesis
+
+Surgical implantation of a penile prosthesis (inflatable or semi-rigid) is the definitive treatment for severe, medication-refractory ED. Patient satisfaction rates are very high (>90%) despite the irreversible nature of the procedure. Appropriate for men in whom all other approaches have failed.
+
+### 9. Low-Intensity Shockwave Therapy (LI-ESWT)
+
+A non-invasive treatment delivering low-energy acoustic waves to penile tissue to stimulate neovascularisation and endothelial repair. Growing evidence for mild to moderate vasculogenic ED, particularly in men who respond poorly to PDE5 inhibitors. Not widely available in Australia and not covered by Medicare. May offer benefit in selected men as a complement or alternative to oral therapy.
+
+---
+
+## ED After Prostate Cancer Treatment
+
+Erectile dysfunction following radical prostatectomy occurs in 30–90% of men at 12 months, even with nerve-sparing techniques. Recovery of function, where it occurs, takes 12–24 months. Penile rehabilitation — early use of low-dose daily PDE5 inhibitors (tadalafil 5 mg daily) to maintain tissue oxygenation and smooth muscle integrity during nerve recovery — is recommended by most urological guidelines and should be initiated within weeks of surgery. See [Prostate Cancer — Guide Hub](/guides/prostate-cancer).
+
+---
+
+## Related Guides
+
+- [Men's Health Hub](/guides/mens-health-hub)
+- [Heart Health Hub](/guides/heart-health-hub)
+- [Cardiovascular Risk Assessment — Beyond Cholesterol](/guides/cardiovascular-risk-assessment)
+- [Preventing Heart Disease](/guides/preventing-heart-disease)
+- [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes)
+- [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+- [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub)
+- [Testosterone Replacement Therapy](/guides/testosterone-replacement-therapy)
+- [Natural Testosterone Optimisation for Men](/guides/natural-testosterone-optimisation)
+- [Male Mental Health — Depression, Help-Seeking, and Wellbeing](/guides/male-mental-health)
+- [Prostate Cancer — Guide Hub](/guides/prostate-cancer)
+- [Prostate Cancer Screening and PSA Testing](/guides/prostate-cancer-screening-and-psa-testing)
+
+---
+
+*Educational only; not a substitute for professional medical advice.*

--- a/src/content/guides/mens-health-hub.md
+++ b/src/content/guides/mens-health-hub.md
@@ -1,0 +1,152 @@
+---
+title: "Men's Health Hub"
+slug: "mens-health-hub"
+description: "Your central guide to men's health — covering testosterone, erectile dysfunction, prostate health, testicular cancer, men's mental health, cardiovascular disease, sleep apnoea, metabolic health, and the key screenings every man should know about."
+category: "Guide Hubs"
+publishDate: "2026-06-02"
+updatedDate: "2026-06-02"
+draft: false
+tags:
+  - men's health
+  - testosterone
+  - erectile dysfunction
+  - prostate
+  - PSA
+  - testicular cancer
+  - male mental health
+  - cardiovascular disease
+  - sleep apnoea
+  - metabolic health
+  - screening
+  - men's cancer
+faq:
+  - q: "What are the most important health screenings for men?"
+    a: "Key screenings include blood pressure (from early adulthood), cholesterol and cardiovascular risk assessment (from age 35–40), blood glucose for diabetes (from age 40, earlier if overweight or with a family history), bowel cancer screening (from age 45–50 via the National Bowel Cancer Screening Program), and PSA testing for prostate cancer — after an informed conversation with your GP about benefits and limitations — from age 50 (or 40–45 if there is a family history or African ancestry). Testicular self-examination is advisable for all men from adolescence to detect changes early."
+  - q: "What are the warning signs of low testosterone?"
+    a: "Low testosterone can cause fatigue, reduced libido, erectile dysfunction, reduced muscle mass, increased body fat, low mood or depression, poor concentration, and reduced body hair. These symptoms overlap with many other conditions — including sleep apnoea, obesity, depression, and thyroid disease — so a blood test measuring morning testosterone is needed for diagnosis. Do not self-treat before getting tested."
+  - q: "Is erectile dysfunction a sign of heart disease?"
+    a: "Often, yes. Erectile dysfunction (ED) is frequently a vascular issue — the penile arteries are smaller than coronary arteries, so atherosclerosis affects them earlier. In many men, ED precedes a cardiac event by 3–5 years. ED and heart disease share the same underlying risk factors: atherosclerosis, high blood pressure, diabetes, obesity, and smoking. New or worsening ED in a man under 60 should prompt a cardiovascular risk assessment, not just a prescription."
+  - q: "Why don't men seek help for mental health problems?"
+    a: "Men are less likely to seek help for depression and anxiety due to social norms around stoicism, difficulty recognising or naming emotional distress, and fear of stigma. Men's depression often presents differently — as irritability, anger, risk-taking, or increased alcohol use rather than overt sadness — which can delay both self-recognition and clinical diagnosis. In Australia, men account for approximately 75% of suicide deaths."
+---
+
+## Introduction
+
+Men's health is shaped by biology, behaviour, and how health systems are used — or avoided. Men are more likely than women to delay seeking care, skip preventive screening, and underreport symptoms. The consequences are measurable: men die earlier, experience more preventable cardiovascular events, and account for the large majority of suicide deaths.
+
+At the same time, the medical landscape has expanded. Evidence-based approaches to testosterone management and prostate cancer screening, a clearer understanding of how erectile dysfunction signals cardiovascular risk, and better frameworks for men's mental health all offer genuine opportunities to detect and prevent serious illness earlier.
+
+This hub centralises PatientGuide's evidence-based content on men's health — from hormones and sexual function to mental health, cancer, sleep, and metabolic disease.
+
+---
+
+## Hormonal and Sexual Health
+
+Testosterone is central to men's metabolic health, mood, muscle mass, sexual function, and energy — but levels decline with age, obesity, poor sleep, and chronic illness. Understanding when low testosterone is clinically significant, and when it is not, matters before pursuing treatment.
+
+### [Testosterone Replacement Therapy — Diagnosis and Treatment](/guides/testosterone-replacement-therapy)
+A clinical overview of hypogonadism: what low testosterone means, how it is diagnosed with morning serum testosterone, LH, and FSH, what levels warrant treatment, and the evidence for different delivery methods — injections, gels, patches, and oral preparations. Covers risks including fertility suppression, polycythaemia, and cardiovascular considerations.
+
+### [Natural Testosterone Optimisation for Men](/guides/natural-testosterone-optimisation)
+An evidence-based, drug-free guide to improving testosterone through lifestyle: resistance training, body composition, sleep quality, stress management, micronutrient support (zinc, vitamin D), and dietary strategies. Most relevant for men with secondary lifestyle-driven decline rather than primary hypogonadism.
+
+### [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)
+A comprehensive guide to ED framed as a vascular and metabolic issue, not merely a sexual one. Covers the cardiovascular connection, how erections work, the full range of causes (vascular, diabetic, hormonal, medication-related, psychological, sleep apnoea), assessment, and the full spectrum of treatments from lifestyle change to PDE5 inhibitors and beyond.
+
+---
+
+## Prostate Health
+
+The prostate gland is central to men's health from midlife onward — subject to benign enlargement, infection, and cancer. Understanding the difference between these conditions, and the nuances of prostate cancer screening, is essential for informed decision-making.
+
+### [Prostate Cancer Screening and PSA Testing](/guides/prostate-cancer-screening-and-psa-testing)
+What PSA testing measures, what it can and cannot tell you, the evidence on benefits and limitations, the risk of false positives and overdiagnosis, active surveillance, and the case for shared decision-making rather than universal population screening. Includes Australian guideline context.
+
+### [Benign Prostatic Hyperplasia (BPH) — Symptoms and Treatment](/guides/benign-prostatic-hyperplasia-bph)
+Non-cancerous prostate enlargement affects more than half of men by age 60 and is the most common cause of urinary symptoms in older men. Covers lower urinary tract symptoms (LUTS), lifestyle measures, medications (alpha blockers, 5-alpha reductase inhibitors), and surgical options.
+
+### [Prostate Cancer — Guide Hub](/guides/prostate-cancer)
+Central hub for prostate cancer resources: risk factors, staging, treatment options (active surveillance, surgery, radiation, hormone therapy), survivorship, and sexual function after treatment.
+
+---
+
+## Testicular Health and Cancer
+
+Testicular cancer is the most common cancer in men aged 15–35 — yet it is one of the most curable cancers when detected early. Awareness of normal anatomy and how to detect changes is essential.
+
+### [Testicular Cancer — Symptoms, Diagnosis, and Prognosis](/guides/testicular-cancer-overview)
+An evidence-based guide covering the most common presentations (painless lump, change in size or texture, scrotal heaviness), how testicular cancer is diagnosed (ultrasound, tumour markers — AFP, hCG, LDH), staging, treatment (orchidectomy, chemotherapy, surveillance), and prognosis. Cure rates exceed 95% when treated appropriately. Includes guidance on sperm banking and fertility preservation before chemotherapy.
+
+**Testicular self-awareness:** Men should familiarise themselves with the normal feel of their testicles — ideally after a warm shower when the scrotum is relaxed — so that any new lump, firmness, swelling, or change in size is noticeable. Any new or persistent change warrants prompt medical review, even without pain.
+
+---
+
+## Men's Mental Health
+
+Mental health disorders in men are underdiagnosed, undertreated, and underreported — in part because men's distress often manifests differently, and in part because help-seeking barriers remain significant.
+
+### [Male Mental Health — Depression, Help-Seeking, and Wellbeing](/guides/male-mental-health)
+How depression and anxiety present in men (irritability, anger, risk-taking, substance use rather than overt sadness), why men seek help less, the evidence on what actually works (exercise, CBT, social connection, peer support), and crisis resources. Men account for approximately 75% of suicide deaths in Australia.
+
+### [Depression — Symptoms, Causes, and Treatment](/guides/depression)
+A comprehensive guide to depression, including clinical criteria, evidence-based treatments (CBT, antidepressants, exercise, lifestyle), and when to seek urgent help.
+
+### [Suicide Prevention — Resources and Warning Signs](/guides/suicide-prevention)
+Warning signs of suicidal crisis, how to start a conversation, and Australian crisis support resources including Lifeline (13 11 14) and Beyond Blue (1300 22 4636).
+
+---
+
+## Screening and Prevention
+
+Men engage with preventive health far less often than women. Closing this gap requires understanding what screening is recommended, when, and why.
+
+### Bowel Cancer Screening
+Bowel cancer is the second most common cancer in Australian men. The [National Bowel Cancer Screening Program](/guides/bowel-cancer-screening) offers a free immunochemical faecal occult blood test (iFOBT) from age 45. Participation rates in men are lower than in women despite equivalent risk. See also [Understanding Bowel Cancer Screening](/guides/bowel-cancer-screening-explained) and [Bowel Cancer — Overview](/guides/bowel-cancer).
+
+### Blood Pressure and Cardiovascular Risk
+Hypertension has no symptoms — routine measurement is the only way to detect it. Men's cardiovascular risk is higher than women's at every age until the menopausal transition. See [High Blood Pressure — What It Means and What to Do](/guides/high-blood-pressure) and [Cardiovascular Risk Assessment — Beyond Cholesterol](/guides/cardiovascular-risk-assessment).
+
+### Diabetes and Prediabetes
+Type 2 diabetes affects around 1 in 20 Australian adults, and up to half are undiagnosed. Men with obesity, inactivity, or family history should test from age 40. See [Prediabetes — Recognising and Reversing Early Risk](/guides/prediabetes) and [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes).
+
+### Skin Cancer
+Australia has among the highest rates of skin cancer in the world. Men are more likely to develop and die from melanoma than women, and are less likely to use sun protection. See [Skin Cancer — Signs, Prevention, and When to Act](/guides/skin-cancer-signs-prevention).
+
+---
+
+## Sleep and Metabolic Health
+
+Sleep apnoea is two to three times more common in men than women, and is strongly linked to obesity, cardiovascular disease, erectile dysfunction, and testosterone suppression. Metabolic health — the interplay of weight, insulin resistance, inflammation, and hormones — underpins many of the most common men's health problems.
+
+### [Sleep Health Hub](/guides/sleep-health-hub)
+Central hub for all sleep content. Men with snoring, witnessed apnoeas, excessive daytime sleepiness, or unrefreshing sleep should consider sleep apnoea assessment. Sleep quality is one of the most important and underappreciated determinants of testosterone levels, cardiovascular health, and mental wellbeing.
+
+### [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+Sleep apnoea is independently associated with hypertension, heart disease, stroke, type 2 diabetes, and erectile dysfunction — all treatable with appropriate management. Covers CPAP, oral devices, positional therapy, and lifestyle changes.
+
+### [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub)
+Obesity is the single largest modifiable contributor to low testosterone, erectile dysfunction, sleep apnoea, type 2 diabetes, and cardiovascular disease in men. Comprehensive resources on weight management, GLP-1 medications, bariatric surgery, and metabolic health.
+
+### [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes)
+Diabetes doubles cardiovascular risk, causes erectile dysfunction, and accelerates kidney and nerve damage. A comprehensive guide to diagnosis, management, and prevention.
+
+### [Insulin Resistance — What It Is and Why It Matters](/guides/insulin-resistance)
+Insulin resistance underlies type 2 diabetes, obesity, and metabolic syndrome — and is strongly modifiable through diet and exercise.
+
+---
+
+## Related Health Topics
+
+- [Heart Health Hub](/guides/heart-health-hub) — Cardiovascular disease kills more Australian men than any other cause; heart attack risk is higher and occurs earlier in men than women
+- [Preventing Heart Disease](/guides/preventing-heart-disease) — Evidence-based lifestyle and medical strategies for primary prevention of cardiovascular events
+- [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — Understanding absolute risk: cholesterol, blood pressure, smoking, diabetes, and advanced biomarkers (ApoB, Lp(a), CAC score)
+- [Stroke — What You Need to Know](/guides/stroke) — Stroke risk is higher in men; recognising symptoms and acting fast determines outcome
+- [Sleep Health Hub](/guides/sleep-health-hub) — Sleep apnoea, shift work, and chronic sleep deprivation disproportionately affect men and compound cardiovascular and metabolic risk
+- [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub) — Visceral obesity is central to many men's health problems; evidence-based weight management changes outcomes
+- [Brain Health Hub](/guides/brain-health-hub) — Cognitive health, dementia prevention, and mental performance
+- [Alcohol and Health](/guides/alcohol-and-health) — Men drink more than women on average; alcohol contributes to liver disease, cancer, injury, and mental health disorders
+- [Smoking Cessation](/guides/smoking-cessation) — Smoking is a major cause of erectile dysfunction, cardiovascular disease, and lung cancer in men; the benefits of quitting are rapid
+
+---
+
+*Educational only; not a substitute for professional medical advice.*

--- a/src/content/guides/prostate-cancer-screening-and-psa-testing.md
+++ b/src/content/guides/prostate-cancer-screening-and-psa-testing.md
@@ -1,0 +1,197 @@
+---
+title: "Prostate Cancer Screening and PSA Testing — A Balanced Guide"
+slug: "prostate-cancer-screening-and-psa-testing"
+description: "A clear, evidence-based guide to PSA testing and prostate cancer screening — what PSA measures, its benefits and limitations, false positives, overdiagnosis, active surveillance, and how to make a shared decision with your GP. Includes Australian guideline context."
+category: "Men's Health"
+publishDate: "2026-06-02"
+updatedDate: "2026-06-02"
+draft: false
+tags:
+  - prostate cancer
+  - PSA
+  - PSA testing
+  - prostate cancer screening
+  - men's health
+  - cancer screening
+  - shared decision-making
+  - prostate
+  - active surveillance
+  - overdiagnosis
+faq:
+  - q: "Should I get a PSA test?"
+    a: "There is no single correct answer for all men. PSA testing can detect prostate cancer early, but it also carries a real risk of overdiagnosis — detecting slow-growing cancers that would never have caused symptoms or death, leading to unnecessary treatment with lasting side effects. Australian guidelines recommend informed decision-making: men aged 50–69 should discuss the benefits and limitations of PSA testing with their GP before deciding. Men with a first-degree family history of prostate cancer or African ancestry should consider starting that conversation from age 40–45."
+  - q: "What is a normal PSA level?"
+    a: "PSA is measured in nanograms per millilitre (ng/mL). A result below 4 ng/mL is traditionally considered normal, but this threshold has important limitations — some prostate cancers produce normal PSA, and many men with elevated PSA do not have cancer. Age-adjusted reference ranges and changes in PSA over time (PSA velocity) give more information than a single number."
+  - q: "What happens if my PSA is elevated?"
+    a: "An elevated PSA result does not mean you have prostate cancer. Common non-cancer causes include benign prostatic hyperplasia (BPH), prostatitis, recent ejaculation, vigorous exercise, and recent catheterisation. Your doctor will review the result in context — your age, symptoms, PSA trajectory, and digital rectal examination — before recommending any further steps such as a repeat test, MRI, or urology referral."
+  - q: "Does Australia have a national prostate cancer screening program?"
+    a: "No. Unlike the National Bowel Cancer Screening Program, Australia does not have a population-based prostate cancer screening program. The Cancer Council Australia and the RACGP recommend against routine universal PSA screening, but support informed, individualised decision-making between men and their GPs — particularly for men aged 50–69. The key is that men understand the trade-offs before testing."
+---
+
+## What Is PSA Testing?
+
+Prostate-Specific Antigen (PSA) is a protein produced by prostate cells. Small quantities enter the bloodstream and can be measured with a simple blood test. PSA levels rise when the prostate is enlarged, inflamed, or cancerous — but PSA is not a cancer test. It is a marker of prostate activity, and many things cause it to rise.
+
+PSA testing is simple, inexpensive, and widely accessible in Australia via GP referral. But whether a given man should test, and what to do with the result, requires careful consideration of the evidence — and of personal values.
+
+---
+
+## Why PSA Testing Is Complicated
+
+Unlike bowel cancer screening (iFOBT) or cervical screening (HPV test), PSA testing has a genuinely contested evidence base. The debate turns on two specific problems: **overdiagnosis** and **overtreatment**.
+
+**The benefit:** PSA testing can detect prostate cancer before it causes symptoms. For men with fast-growing, aggressive cancer, early detection and treatment can save lives.
+
+**The problem:** The prostate commonly develops slow-growing cancers that would never cause symptoms or death within a man's expected lifespan. Biopsy and pathology cannot always reliably distinguish these indolent cancers from aggressive ones at the time of diagnosis. Many men identified through PSA screening are treated for cancers they would have died *with*, not *from*.
+
+**The consequence:** Prostate cancer treatment — whether radical prostatectomy or radiation — carries real risks of permanent urinary incontinence and erectile dysfunction. A man treated for an indolent cancer that would never have harmed him has experienced real harm with no benefit. This is the central ethical problem of prostate cancer screening.
+
+This is why major guidelines worldwide have moved away from universal population screening toward informed, individualised decision-making.
+
+---
+
+## What PSA Can and Cannot Tell You
+
+### PSA rises for many non-cancer reasons
+
+PSA is elevated by:
+- **Benign prostatic hyperplasia (BPH)** — very common, affects more than half of men over 60
+- **Prostatitis** — inflammation or infection of the prostate
+- **Recent ejaculation** — allow 48 hours before testing
+- **Vigorous exercise, especially cycling** — allow 48–72 hours
+- **Digital rectal examination (DRE)** — avoid performing just before the blood draw
+- **Urinary tract infection**
+- **Urinary catheter or recent cystoscopy**
+
+### PSA does not detect all prostate cancers
+
+Around 15% of men with prostate cancer have a PSA below 4 ng/mL. High-grade, aggressive cancers sometimes produce less PSA than lower-grade tumours. A "normal" PSA does not exclude prostate cancer in a symptomatic man.
+
+### A single reading is less informative than the trend
+
+PSA velocity — the rate of change over time — is more informative than any single reading. A PSA that rises from 1.5 to 3.5 ng/mL over two years is more concerning than a stable PSA of 4.5 ng/mL. Regular monitoring over time, once a man and his doctor decide to test, provides more useful information than a one-off check.
+
+---
+
+## Understanding Your PSA Result
+
+| PSA Level (ng/mL) | Approximate interpretation |
+|---|---|
+| < 2.5 | Low risk (reassuring, especially under 60) |
+| 2.5–4.0 | Intermediate; context and PSA velocity matter |
+| 4.0–10.0 | Elevated; approximately 25% probability of prostate cancer on biopsy |
+| > 10.0 | Significantly elevated; approximately 50% probability of prostate cancer |
+
+These probabilities vary considerably with age, prostate size, ethnicity, and family history. The table provides approximate guidance only — the decision about next steps belongs with your doctor, who can interpret the result in full context.
+
+### What happens after an elevated result
+
+An elevated PSA typically triggers further assessment, not immediate biopsy. Your GP or urologist may:
+
+1. **Repeat the PSA** after 6–8 weeks, avoiding factors that artificially raise it
+2. **Order a multiparametric prostate MRI (mpMRI)** — now the standard first step before biopsy in many centres; identifies suspicious areas and guides biopsy, reducing unnecessary sampling of low-risk tissue
+3. **Perform or review a digital rectal examination (DRE)** — detects hardness, asymmetry, or nodules alongside the PSA
+4. **Consider PSA density** (PSA adjusted for prostate volume on MRI) — a more specific marker than PSA alone
+5. **Refer to a urologist** if results remain concerning or if MRI shows a suspicious lesion
+
+---
+
+## PSA Thresholds and Age
+
+The traditional threshold of 4 ng/mL was derived from older studies and has important limitations. Younger men typically have lower PSA; a level of 2.5 ng/mL may warrant further assessment in a 45-year-old. Older men often have higher PSA due to BPH; slightly elevated results require age-appropriate interpretation.
+
+Age-adjusted reference ranges used in some Australian laboratories:
+
+| Age range | Upper reference limit |
+|---|---|
+| 40–49 years | 2.5 ng/mL |
+| 50–59 years | 3.5 ng/mL |
+| 60–69 years | 4.5 ng/mL |
+| 70 years and over | 6.5 ng/mL |
+
+These are guidelines, not hard cutoffs. Clinical context always takes precedence.
+
+---
+
+## Who Should Consider PSA Testing?
+
+### Australian guideline position
+
+The **Cancer Council Australia** and the **Royal Australian College of General Practitioners (RACGP)** do not recommend routine universal PSA screening — but they support informed, shared decision-making for men who wish to be tested.
+
+**Current Australian guidance:**
+- Men aged **50–69** should be offered the opportunity to discuss PSA testing with their GP — with clear information about benefits and limitations
+- Men with a **first-degree relative** (father or brother) diagnosed with prostate cancer under age 65 should consider starting this discussion from **age 40–45**
+- Men with **multiple family members** with prostate cancer, a known **BRCA2 gene mutation**, or **African ancestry** (higher background risk) should also consider earlier discussion
+
+### Symptoms that always warrant assessment, regardless of screening preference
+
+- Difficulty initiating urination, weak or intermittent stream
+- Frequent need to urinate overnight (nocturia)
+- Blood in urine or semen
+- Bone pain, particularly lower back, hips, or pelvis
+- Unexplained weight loss
+
+These symptoms require clinical evaluation regardless of a man's stance on PSA screening.
+
+---
+
+## Shared Decision-Making: What to Discuss With Your GP
+
+A good PSA conversation with your GP should cover:
+
+- What is my background risk of prostate cancer based on age, family history, and ethnicity?
+- If my PSA is elevated, what would the investigation pathway look like?
+- What are the realistic risks of prostate biopsy (infection, bleeding, pain)?
+- If cancer is found at an early stage, will it always need treatment — or could active surveillance be appropriate?
+- What are the likely outcomes and side effects of treatment?
+- What happens if I choose not to test, and what monitoring would be appropriate if I decline?
+
+There is no universally correct answer. Some men place great weight on detecting any cancer early; others, knowing the overdiagnosis data, place greater weight on avoiding the risk of unnecessary treatment. Both positions are reasonable.
+
+---
+
+## Active Surveillance: When Early Prostate Cancer Doesn't Need Treatment
+
+For men diagnosed with low-grade, low-volume prostate cancer (Gleason grade group 1, organ-confined), **active surveillance** — regular monitoring without immediate treatment — is now the standard recommended approach in most Australian and international guidelines.
+
+Active surveillance typically involves:
+- PSA testing every 3–6 months
+- Repeat mpMRI at defined intervals
+- Repeat biopsy (often targeted by MRI findings) every 1–3 years
+- Transition to treatment only if there is evidence of disease reclassification (higher grade or greater volume)
+
+Active surveillance has substantially reduced overtreatment of clinically insignificant prostate cancer, allowing men to preserve urinary and sexual function for years or decades while being closely monitored.
+
+---
+
+## Digital Rectal Examination (DRE)
+
+A DRE — the doctor inserting a gloved finger into the rectum to assess the prostate — can detect firmness, nodularity, or asymmetry. As a standalone screening test, DRE has poor sensitivity; most early prostate cancers are not palpable. But it adds information alongside PSA interpretation, particularly when PSA is in the 4–10 ng/mL range or when urinary symptoms are present.
+
+---
+
+## After Treatment: Managing Long-Term Effects
+
+The most common side effects of prostate cancer treatment — radical prostatectomy and radiation — include:
+
+- **Erectile dysfunction** — common after both surgery and radiation; more likely after nerve-involving surgery
+- **Urinary incontinence** — most common after radical prostatectomy; usually improves over 12 months with pelvic floor physiotherapy
+- **Bowel changes** — more common after radiation therapy
+
+Awareness of these risks is a central part of informed decision-making before treatment. See [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment) for management options after prostate cancer treatment.
+
+---
+
+## Related Guides
+
+- [Men's Health Hub](/guides/mens-health-hub)
+- [Prostate Cancer — Guide Hub](/guides/prostate-cancer)
+- [Benign Prostatic Hyperplasia (BPH) — Symptoms and Treatment](/guides/benign-prostatic-hyperplasia-bph)
+- [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)
+- [Bowel Cancer Screening — What You Need to Know](/guides/bowel-cancer-screening)
+- [Cardiovascular Risk Assessment — Beyond Cholesterol](/guides/cardiovascular-risk-assessment)
+
+---
+
+*Educational only; not a substitute for professional medical advice. Speak with your GP before starting or stopping any screening program.*


### PR DESCRIPTION
## Summary

- mens-health-hub.md - Guide Hub page centralising all men's health content: testosterone, prostate, testicular cancer, mental health, sleep and metabolic health, and screening; bidirectional links to Sleep Hub, Heart Hub, Metabolic Hub, and existing Men's Health guides
- prostate-cancer-screening-and-psa-testing.md - Balanced, Australian-context PSA guide covering what PSA measures, false positives, overdiagnosis, active surveillance, age-adjusted thresholds, and shared decision-making
- erectile-dysfunction-causes-and-treatment.md - Comprehensive ED guide framed as a vascular issue; covers cardiovascular disease, diabetes, obesity, sleep apnoea, testosterone, medications, psychological causes, and the full treatment spectrum; strong bidirectional links to Heart Hub, diabetes, sleep apnoea, and obesity content

## Integration decisions

- Low testosterone: three existing guides adequately cover symptoms, causes, and treatment; integrated via hub cross-links rather than duplicated
- Testicular cancer: testicular-cancer-overview.md already exists and is comprehensive; linked from hub
- Men's mental health: male-mental-health.md already exists and is comprehensive; linked from hub

## Test plan

- [x] npm run content:check - 0 errors, 212 warnings (all pre-existing, none in new files)
- [x] npm run build - successful; all three pages rendered at /guides/mens-health-hub/, /guides/prostate-cancer-screening-and-psa-testing/, /guides/erectile-dysfunction-causes-and-treatment/
- [x] All internal links verified against existing file list - no broken routes
- [x] Valid category enums used: Guide Hubs, Men's Health
- [x] publishDate and updatedDate: 2026-06-02, draft: false

## Phase 2 recommendations

- natural-testosterone-guide.mdx vs natural-testosterone-optimisation.mdx - near-duplicate pair; consolidate into one canonical guide
- erectile-dysfunction.md (basic stub) - now superseded by the comprehensive new guide; consider redirecting or removing
- Men's fertility - no dedicated guide exists (sperm count, varicocoele, male-factor infertility); high-value gap
- Cardiovascular disease in men - no men-specific CV guide; a Heart Disease in Men guide with sex-specific risk data would strengthen the cluster
- Andropause / male hormonal ageing - no guide on gradual testosterone decline of healthy ageing vs pathological hypogonadism

Generated with Claude Code (https://claude.com/claude-code)