### PR TITLE
fix(content): consolidate duplicate guides and strengthen hub links

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -68,6 +68,14 @@
 /guides/prostate-cancer-survivorship    /guides/prostate-cancer           301!
 /guides/prostate-cancer-survivorship/   /guides/prostate-cancer           301!
 
+# Testosterone guide deduplication — canonical is /guides/natural-testosterone-optimisation
+/guides/natural-testosterone-guide        /guides/natural-testosterone-optimisation      301!
+/guides/natural-testosterone-guide/       /guides/natural-testosterone-optimisation      301!
+
+# ED stub deduplication — canonical is /guides/erectile-dysfunction-causes-and-treatment
+/guides/erectile-dysfunction              /guides/erectile-dysfunction-causes-and-treatment   301!
+/guides/erectile-dysfunction/             /guides/erectile-dysfunction-causes-and-treatment   301!
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Gone for good
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/content/guides/benign-prostatic-hyperplasia-bph.md
+++ b/src/content/guides/benign-prostatic-hyperplasia-bph.md
@@ -158,7 +158,7 @@ Side effects: reduced libido, erectile dysfunction, decreased ejaculate volume; 
 **Combination therapy** (alpha-blocker + 5-ARI) provides greater symptom relief and slows disease progression in men with larger prostates.
 
 #### Phosphodiesterase-5 (PDE5) inhibitors
-**Tadalafil** (used for erectile dysfunction) is also approved for BPH-related LUTS. Useful when both BPH and [erectile dysfunction](/guides/erectile-dysfunction) are present.
+**Tadalafil** (used for erectile dysfunction) is also approved for BPH-related LUTS. Useful when both BPH and [erectile dysfunction](/guides/erectile-dysfunction-causes-and-treatment) are present.
 
 ### 3. Minimally invasive procedures
 
@@ -209,8 +209,9 @@ Regular monitoring is appropriate to detect symptom progression or rising PSA.
 
 ## Related Guides
 
+- [Men's Health Hub](/guides/mens-health-hub)
 - [Prostate Cancer Overview](/guides/prostate-cancer)
-- [Erectile Dysfunction](/guides/erectile-dysfunction)
+- [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)
 - [Sleep and Nocturia](/guides/sleep)
 - [Aging and Longevity](/guides/aging-and-longevity-basics)
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)

--- a/src/content/guides/diabetes-hormones.md
+++ b/src/content/guides/diabetes-hormones.md
@@ -76,5 +76,5 @@ A: Insulin itself doesn’t lower testosterone, but diabetes-related metabolic c
 
 ## Related Guides
 - [Testosterone Replacement Therapy](/guides/testosterone-replacement-therapy)  
-- [Erectile Dysfunction](/guides/erectile-dysfunction)  
+- [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)  
 - [Heart & Circulation Overview](/guides/heart-circulation-overview)  

--- a/src/content/guides/erectile-dysfunction.md
+++ b/src/content/guides/erectile-dysfunction.md
@@ -5,7 +5,7 @@ description: "Overview of erectile dysfunction: causes, diagnosis, and treatment
 category: "Men's Health"
 publishDate: "2025-09-11"
 tags: ["erectile dysfunction", "sexual health", "men's health"]
-draft: false
+draft: true
 schema:
   medicalCondition:
     name: "Erectile Dysfunction"

--- a/src/content/guides/male-mental-health.md
+++ b/src/content/guides/male-mental-health.md
@@ -159,7 +159,7 @@ Heavy alcohol use and depression are deeply intertwined — alcohol is a depress
 
 Low testosterone is associated with low mood, fatigue, poor concentration, and reduced libido — symptoms that can overlap with depression. Testosterone levels decline gradually from the 30s onwards. If these symptoms are present alongside other signs of testosterone deficiency, evaluation is worthwhile.
 
-However, testosterone is not a treatment for primary depression. See [Natural Testosterone Optimisation](/guides/natural-testosterone-guide) for lifestyle-first approaches, and discuss clinical assessment with a doctor if needed.
+However, testosterone is not a treatment for primary depression. See [Natural Testosterone Optimisation](/guides/natural-testosterone-optimisation) for lifestyle-first approaches, and discuss clinical assessment with a doctor if needed.
 
 ---
 
@@ -169,7 +169,7 @@ Mental and physical health are closely linked in men:
 
 - Depression increases the risk of [cardiovascular disease](/guides/cardiovascular-risk-assessment) — an important reason to treat it
 - Physical illness, particularly chronic pain or serious diagnosis, substantially increases depression risk
-- [Erectile dysfunction](/guides/erectile-dysfunction) is both a cause and consequence of anxiety and depression in men
+- [Erectile dysfunction](/guides/erectile-dysfunction-causes-and-treatment) is both a cause and consequence of anxiety and depression in men
 
 ---
 
@@ -194,6 +194,7 @@ Mental and physical health are closely linked in men:
 
 ## Related Guides
 
+- [Men's Health Hub](/guides/mens-health-hub)
 - [Depression](/guides/depression)
 - [Anxiety](/guides/anxiety)
 - [Social Connection and Health](/guides/social-connection)
@@ -201,5 +202,5 @@ Mental and physical health are closely linked in men:
 - [Sleep and Health](/guides/sleep)
 - [Suicide Prevention](/guides/suicide-prevention)
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
-- [Natural Testosterone Optimisation](/guides/natural-testosterone-guide)
+- [Natural Testosterone Optimisation](/guides/natural-testosterone-optimisation)
 - [Alcohol and Health](/guides/alcohol-and-health)

--- a/src/content/guides/natural-testosterone-guide.mdx
+++ b/src/content/guides/natural-testosterone-guide.mdx
@@ -6,7 +6,7 @@ publishDate: "2025-12-05"
 updatedDate: "2025-12-05"
 category: "Men's Health"
 tags: ["testosterone", "hormones", "men's health", "strength", "metabolism"]
-draft: false
+draft: true
 schema:
   medicalCondition:
     name: "Low Testosterone"

--- a/src/content/guides/natural-testosterone-optimisation.mdx
+++ b/src/content/guides/natural-testosterone-optimisation.mdx
@@ -339,3 +339,13 @@ Natural testosterone optimisation is not about chasing a single number on a lab 
 
 These changes improve testosterone, but more importantly, they improve energy, resilience and overall health as you age.
 
+---
+
+## Related Guides
+
+- [Men's Health Hub](/guides/mens-health-hub)
+- [Testosterone Replacement Therapy](/guides/testosterone-replacement-therapy)
+- [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)
+- [Sleep Health Hub](/guides/sleep-health-hub)
+- [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub)
+

--- a/src/content/guides/testicular-cancer-overview.md
+++ b/src/content/guides/testicular-cancer-overview.md
@@ -138,7 +138,7 @@ Most men receive **BEP chemotherapy** (typically 3–4 cycles). This regimen ach
 - **Sperm banking before treatment** is strongly recommended for any man who may want to father children in the future
 - Testosterone levels should be monitored after treatment, particularly if both testes are affected or in men with pre-existing low testosterone
 
-See [Natural Testosterone Optimisation](/guides/natural-testosterone-guide) for context on hormone health in men.
+See [Natural Testosterone Optimisation](/guides/natural-testosterone-optimisation) for context on hormone health in men.
 
 ---
 
@@ -178,7 +178,8 @@ Regular monitoring continues for 5+ years after treatment completion:
 
 ## Related Guides
 
+- [Men's Health Hub](/guides/mens-health-hub)
 - [Prostate Cancer](/guides/prostate-cancer)
 - [Male Mental Health](/guides/male-mental-health)
-- [Natural Testosterone Optimisation](/guides/natural-testosterone-guide)
+- [Natural Testosterone Optimisation](/guides/natural-testosterone-optimisation)
 - [Cancer Overview](/guides/cancer)

--- a/src/content/guides/testosterone-replacement-therapy.md
+++ b/src/content/guides/testosterone-replacement-therapy.md
@@ -66,6 +66,8 @@ A: For most carefully selected men, TRT can be safe with appropriate monitoring.
 - [Mayo Clinic: Testosterone therapy — potential benefits and risks](https://www.mayoclinic.org/healthy-lifestyle/sexual-health/in-depth/testosterone-therapy/art-20045728)  
 
 ## Related Guides
-- [Erectile Dysfunction](/guides/erectile-dysfunction)  
+- [Men's Health Hub](/guides/mens-health-hub)
+- [Erectile Dysfunction — Causes, Cardiovascular Risk, and Treatment](/guides/erectile-dysfunction-causes-and-treatment)  
+- [Natural Testosterone Optimisation for Men](/guides/natural-testosterone-optimisation)  
 - [Heart & Circulation Overview](/guides/heart-circulation-overview)  
 - [Diabetes and Hormones](/guides/diabetes-hormones)  

--- a/src/lib/hero-pages.ts
+++ b/src/lib/hero-pages.ts
@@ -497,7 +497,7 @@ export const HERO_PAGES: Record<string, HeroPageConfig> = {
       {
         title: "Erectile Dysfunction",
         description: "Causes, evaluation, and treatment.",
-        href: "/guides/erectile-dysfunction",
+        href: "/guides/erectile-dysfunction-causes-and-treatment",
       },
       {
         title: "Testosterone Replacement",


### PR DESCRIPTION
## Summary

### Duplicate guides resolved
- **Testosterone natural optimisation**: `natural-testosterone-guide.mdx` was a near-identical duplicate of `natural-testosterone-optimisation.mdx`. The shorter bullet-point version is now `draft:true`; canonical is `natural-testosterone-optimisation.mdx`. 301 redirect added.
- **Erectile dysfunction**: `erectile-dysfunction.md` (82-line stub, Sep 2025) superseded by `erectile-dysfunction-causes-and-treatment.md` (285-line comprehensive guide, Jun 2026). Stub is now `draft:true`. 301 redirect added.

### Internal links fixed
- `male-mental-health.md` — 2 links updated (testosterone guide slug, ED stub)
- `testicular-cancer-overview.md` — 2 links updated (testosterone guide slug)
- `benign-prostatic-hyperplasia-bph.md` — 1 link updated (ED stub)
- `diabetes-hormones.md` — 1 link updated (ED stub)
- `testosterone-replacement-therapy.md` — 1 link updated (ED stub)
- `src/lib/hero-pages.ts` — 1 link updated (ED stub)

### Hub back-links added (Men's Health Hub)
Five guides that were hub-less now carry a return link to `/guides/mens-health-hub`:
- `testosterone-replacement-therapy.md`
- `natural-testosterone-optimisation.mdx`
- `male-mental-health.md`
- `testicular-cancer-overview.md`
- `benign-prostatic-hyperplasia-bph.md`

## Quality checks
- `npm run content:check` — 0 errors, 212 warnings (all pre-existing)
- `npm run build` — 718 pages, no errors

## Chatbot index
No rebuild needed — no new content added; only slug and link changes. The canonical pages were already indexed.

## Recommended next sprint
See PR description notes below.

---

### Flagged for future sprints (not touched — audit findings)

**Lower-priority duplicates found:**
- `coronary-angiography.md` vs `understanding-coronary-angiography.md` — both live stubs covering the same topic with cross-linked pages; requires content merge decision before action
- `sunscreen.mdx` (2026, comprehensive) vs `sunscreen-basics.md` (2025 stub, Cancer category) vs `sunscreen-skin-protection.md` (2025 stub, General Health category) — `sunscreen.mdx` is canonical; other two should be drafted in next cleanup sprint

**Recommended next sprint priority:**
1. **Sunscreen stub cleanup** (quick win: 2 stubs to retire, low risk)
2. **TRT guide expansion** — `testosterone-replacement-therapy.md` is still a medium-length guide; the Men's Health Hub now links it prominently but it deserves a fuller rewrite to match the quality of `erectile-dysfunction-causes-and-treatment.md`
3. **Neurology Hub** — epilepsy, Parkinson's, MS all present but no hub page; second-largest orphaned cluster
4. **Men's Health Phase 2** — male fertility, scrotal pain, vasectomy counselling
5. **Preventive Screening Hub** — testing-and-screening.md is a stub; content exists (PSA, bowel screening, mammography, cervical screening) but no unifying hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)