### PR TITLE
feat(posts): add primary-sourced daraxonrasib pancreatic cancer analysis

### DIFF
--- a/src/content/guides/brain-health-hub.mdx
+++ b/src/content/guides/brain-health-hub.mdx
@@ -221,6 +221,7 @@ A: Yes — stroke symptoms appear abruptly. If symptoms pass quickly, that may b
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Stroke](/guides/stroke-symptoms-fast-response)
 - [Recognising Stroke](/guides/recognizing-stroke)
 - [Stroke Prevention](/guides/stroke-prevention)

--- a/src/content/guides/dementia-overview.mdx
+++ b/src/content/guides/dementia-overview.mdx
@@ -289,6 +289,7 @@ A: See your doctor if symptoms are getting worse over time, affecting daily acti
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Brain Health Hub](/guides/brain-health-hub)
 - [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment)
 - [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)

--- a/src/content/guides/epilepsy-overview.md
+++ b/src/content/guides/epilepsy-overview.md
@@ -245,9 +245,14 @@ Mental health should be actively assessed and treated — not accepted as inevit
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Seizures — First Aid and Emergency Management](/guides/seizures)
+- [Parkinson's Disease](/guides/parkinsons-disease-overview)
+- [Multiple Sclerosis (MS)](/guides/multiple-sclerosis-overview)
+- [Stroke](/guides/stroke-symptoms-fast-response)
 - [Dementia Overview](/guides/dementia-overview)
 - [Sleep and Health](/guides/sleep)
+- [Sleep Health Hub](/guides/sleep-health-hub)
 - [Depression](/guides/depression)
 - [Anxiety](/guides/anxiety)
 - [Mental Health — Guide Hub](/guides/mental-health)

--- a/src/content/guides/huntingtons-disease.mdx
+++ b/src/content/guides/huntingtons-disease.mdx
@@ -102,5 +102,8 @@ A: Exercise, physical therapy, and supportive care can help maintain independenc
 - [European Huntington’s Disease Network](https://www.euro-hd.net/)  
 
 ## Related Guides
-- [Gene Therapy for Huntington’s Disease](/guides/huntingtons-disease-gene-therapy)  
+- [Neurology Hub](/guides/neurology-hub)
+- [Gene Therapy for Huntington’s Disease](/guides/huntingtons-disease-gene-therapy)
+- [Parkinson’s Disease](/guides/parkinsons-disease-overview)
+- [Brain Health Hub](/guides/brain-health-hub)
 - [Genetic Testing and Counseling](/guides/genetic-testing)  

--- a/src/content/guides/mild-cognitive-impairment.mdx
+++ b/src/content/guides/mild-cognitive-impairment.mdx
@@ -297,6 +297,7 @@ A: Amnestic MCI primarily affects memory and is more strongly linked to Alzheime
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Brain Health Hub](/guides/brain-health-hub)
 - [Dementia: Early Signs, Types, Causes, and Prevention](/guides/dementia-overview)
 - [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)

--- a/src/content/guides/multiple-sclerosis-overview.md
+++ b/src/content/guides/multiple-sclerosis-overview.md
@@ -239,9 +239,15 @@ Modern DMTs, when started early, have substantially improved long-term outcomes 
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
+- [Brain Health Hub](/guides/brain-health-hub)
+- [Parkinson's Disease](/guides/parkinsons-disease-overview)
+- [Epilepsy](/guides/epilepsy-overview)
+- [Huntington's Disease](/guides/huntingtons-disease)
 - [Dementia Overview](/guides/dementia-overview)
 - [Cognitive Testing and Memory Assessment](/guides/cognitive-testing-memory-assessment)
 - [Sleep and Health](/guides/sleep)
+- [Sleep Health Hub](/guides/sleep-health-hub)
 - [Exercise and Health](/guides/exercise)
 - [Depression](/guides/depression)
 - [Anxiety](/guides/anxiety)

--- a/src/content/guides/neurology-hub.md
+++ b/src/content/guides/neurology-hub.md
@@ -1,0 +1,185 @@
+---
+title: "Neurology Hub: Brain, Nerves, and Neurological Conditions"
+description: "Central navigation for all PatientGuide neurology content — covering stroke, dementia, movement disorders, epilepsy, multiple sclerosis, and neurological symptoms."
+category: "Guide Hubs"
+publishDate: "2026-06-02"
+updatedDate: "2026-06-02"
+slug: "neurology-hub"
+draft: false
+tags: ["neurology", "brain health", "stroke", "dementia", "Parkinson's disease", "multiple sclerosis", "epilepsy", "seizures", "TIA", "Huntington's disease", "neuropathy", "headache", "cognitive decline", "movement disorders"]
+faq:
+  - q: "What conditions are covered in neurology?"
+    a: "Neurology covers conditions affecting the brain, spinal cord, and peripheral nerves. This includes stroke, dementia and Alzheimer's disease, Parkinson's disease, multiple sclerosis, epilepsy, Huntington's disease, TIA (mini-stroke), and symptoms such as headache, dizziness, seizures, memory problems, and weakness."
+  - q: "What is the most common neurological condition?"
+    a: "By global prevalence, tension headache and migraine affect the most people. Among serious neurological conditions, dementia affects over 55 million people worldwide, and stroke is the second leading cause of death globally. Epilepsy affects approximately 50 million people and Parkinson's disease affects 10 million."
+  - q: "When should I seek emergency care for a neurological symptom?"
+    a: "Call emergency services immediately for: sudden face drooping, arm weakness, or speech difficulty (stroke signs); a sudden severe headache unlike any before (thunderclap headache — possible subarachnoid haemorrhage); sudden loss of vision; a seizure lasting more than 5 minutes; or sudden loss of consciousness. Do not wait to see if symptoms pass."
+  - q: "What is the difference between a stroke and a TIA?"
+    a: "Both are caused by interrupted blood flow to the brain. A stroke causes lasting brain damage. A TIA (transient ischaemic attack) produces identical symptoms that resolve fully within minutes to hours without permanent damage — but stroke risk is highest in the days immediately after a TIA. Both require emergency assessment."
+  - q: "Can neurological conditions be prevented?"
+    a: "Many can. Up to 80% of strokes are preventable through blood pressure control, treating atrial fibrillation, not smoking, managing diabetes, and reducing other vascular risk factors. Up to 45% of dementia cases are attributable to modifiable risk factors including hypertension, physical inactivity, poor sleep, and low cognitive engagement. Exercise meaningfully reduces Parkinson's symptoms and slows decline."
+  - q: "How does sleep affect neurological health?"
+    a: "Sleep is critical for brain health. During deep sleep, the brain's glymphatic system clears metabolic waste including amyloid-beta and tau proteins implicated in Alzheimer's disease. Chronic poor sleep independently raises dementia risk, and sleep deprivation is one of the most consistent seizure triggers in epilepsy. Parkinson's disease also causes significant sleep disturbance. Sleep disorders should be treated as a neurological priority."
+jsonLd:
+  - "@context": "https://schema.org"
+    "@type": "Article"
+    headline: "Neurology Hub: Brain, Nerves, and Neurological Conditions"
+    description: "Central navigation for all PatientGuide neurology content — covering stroke, dementia, movement disorders, epilepsy, multiple sclerosis, and neurological symptoms."
+    datePublished: "2026-06-02"
+    dateModified: "2026-06-02"
+    inLanguage: "en"
+    mainEntityOfPage:
+      "@type": "WebPage"
+      "@id": "https://patientguide.io/guides/neurology-hub"
+    author:
+      "@type": "Organization"
+      name: "PatientGuide"
+    publisher:
+      "@type": "Organization"
+      name: "PatientGuide"
+    keywords: ["neurology", "stroke", "dementia", "Parkinson's disease", "multiple sclerosis", "epilepsy", "TIA", "brain health", "cognitive decline", "movement disorders"]
+  - "@context": "https://schema.org"
+    "@type": "BreadcrumbList"
+    itemListElement:
+      - "@type": "ListItem"
+        position: 1
+        name: "Guides"
+        item: "https://patientguide.io/guides"
+      - "@type": "ListItem"
+        position: 2
+        name: "Neurology Hub"
+        item: "https://patientguide.io/guides/neurology-hub"
+---
+
+## Introduction
+
+The nervous system — brain, spinal cord, and peripheral nerves — controls every voluntary and involuntary function in the body: movement, sensation, speech, memory, consciousness, and emotion. Neurological conditions are among the leading causes of disability and death worldwide.
+
+This hub is the central navigation point for all PatientGuide neurology content. Whether you are looking for emergency recognition of stroke, understanding a diagnosis of Parkinson's disease or multiple sclerosis, navigating memory concerns, or learning to manage epilepsy — this is the starting point.
+
+The brain is shaped by genetics and ageing, but also by modifiable factors: blood pressure, sleep, physical activity, metabolic health, and cognitive engagement. Many of the most disabling neurological conditions are meaningfully preventable or slowed.
+
+---
+
+## Emergency Neurological Symptoms
+
+Some neurological symptoms require immediate emergency response.
+
+<div class="bg-red-50 border border-red-200 rounded-2xl p-4 my-6">
+
+**Call emergency services immediately for:**
+
+- Sudden face drooping, arm weakness, or speech difficulty — stroke signs. Use **FAST** (Face, Arms, Speech, Time).
+- A sudden, severe "thunderclap" headache unlike any previous headache — possible subarachnoid haemorrhage.
+- Sudden loss of vision in one or both eyes.
+- A seizure lasting more than 5 minutes.
+- Sudden unexplained loss of consciousness.
+- New sudden weakness, numbness, or paralysis.
+
+[Recognising Stroke — FAST Guide](/guides/recognizing-stroke) · [TIA Warning Signs](/guides/tia-warning-signs) · [Seizures — First Aid](/guides/seizures)
+
+</div>
+
+---
+
+## Memory and Cognition
+
+Memory and cognitive function sit at the core of how we experience the world. Decline can be a symptom of many conditions — some reversible, some progressive.
+
+- [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview) — types (Alzheimer's, vascular, Lewy body, frontotemporal), risk factors, prevention evidence, and when to seek help
+- [Alzheimer's Disease Overview](/guides/alzheimers-disease-overview) — the most common dementia: pathology, staging, and current treatment
+- [Alzheimer's Prevention and Exercise](/guides/alzheimers-prevention-and-exercise) — the role of physical activity as one of the strongest known strategies for reducing Alzheimer's risk
+- [Can a Blood Test Predict When Alzheimer's Symptoms Will Begin?](/guides/blood-test-predict-alzheimers-symptom-onset) — plasma p-tau217 biomarkers and what they mean for early diagnosis
+- [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment) — the intermediate state between normal ageing and dementia: recognition, risk, and what helps
+- [Cognitive Testing and Memory Assessment](/guides/cognitive-testing-memory-assessment) — how doctors assess memory and thinking: from GP screening to specialist evaluation
+- [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia) — acute confusion (delirium) is an emergency; distinguishing it from progressive dementia is critical
+
+**See also:** [Brain Health Hub](/guides/brain-health-hub) — focused coverage of brain health, vascular risk, and cognition with sleep and prevention emphasis.
+
+---
+
+## Stroke and Vascular Neurology
+
+Stroke is the second leading cause of death worldwide and the leading cause of adult-acquired disability. Most strokes are preventable.
+
+- [Stroke — Symptoms, Emergency Response, and Treatment](/guides/stroke-symptoms-fast-response) — causes, types (ischaemic vs haemorrhagic), what happens during a stroke event, and treatment windows
+- [Recognising Stroke — FAST Guide](/guides/recognizing-stroke) — practical identification using the FAST criteria; when to call emergency services
+- [Stroke Prevention — How to Reduce Your Risk](/guides/stroke-prevention) — the modifiable risk factors that account for most strokes, and evidence-based strategies for reducing them
+- [Transient Ischaemic Attack (TIA) — Warning Signs](/guides/tia-warning-signs) — the warning stroke: identical symptoms that resolve fully, but stroke risk is highest in the days after; same-day assessment is essential
+
+**Vascular risk links:** [High Blood Pressure](/guides/high-blood-pressure) · [Atrial Fibrillation](/guides/atrial-fibrillation) · [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) · [Heart & Circulation Hub](/guides/heart-circulation)
+
+---
+
+## Movement Disorders
+
+Movement disorders affect the smooth coordination and control of voluntary movement, caused primarily by dysfunction in the brain's basal ganglia circuits.
+
+- [Parkinson's Disease: Symptoms, Diagnosis, and Treatment](/guides/parkinsons-disease-overview) — resting tremor, bradykinesia, rigidity; levodopa, dopamine agonists, and deep brain stimulation; non-motor features including sleep and cognition; evidence on exercise
+- [Huntington's Disease](/guides/huntingtons-disease) — the hereditary neurological condition caused by a CAG repeat expansion: progressive motor, cognitive, and psychiatric decline
+- [Gene Therapy for Huntington's Disease](/guides/huntingtons-disease-gene-therapy) — early trial results and what they mean for disease modification
+
+---
+
+## Autoimmune and Demyelinating Disease
+
+- [Multiple Sclerosis (MS): Symptoms, Diagnosis, and Treatment](/guides/multiple-sclerosis-overview) — optic neuritis, fatigue, relapsing-remitting and progressive forms, MRI, disease-modifying therapies (DMTs), and living well with MS
+
+---
+
+## Seizure Disorders
+
+- [Epilepsy: Seizures, Diagnosis, Treatment, and Living Safely](/guides/epilepsy-overview) — seizure types (focal, generalised), EEG and MRI, antiseizure medications, triggers, surgery, driving regulations, SUDEP
+- [Seizures — First Aid Guide](/guides/seizures) — what to do if someone is having a seizure, when to call emergency services
+
+---
+
+## Neurological Symptoms
+
+Symptoms can be the entry point for neurological concern. These guides address common presenting problems.
+
+- [Dizziness: When to Worry](/guides/dizziness-when-to-worry) — distinguishing benign causes from neurological red flags; when dizziness requires urgent assessment
+- [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia) — sudden confusion in an older person is a medical emergency until proven otherwise
+
+---
+
+## Key Shared Risk Factors
+
+Many neurological conditions share the same modifiable drivers:
+
+| Risk Factor | Most Relevant Conditions |
+|---|---|
+| High blood pressure | Stroke, vascular dementia |
+| Poor sleep | Dementia, Parkinson's disease, seizure threshold, cognitive decline |
+| Physical inactivity | Stroke, dementia, Parkinson's progression |
+| Diabetes | Stroke, vascular dementia, peripheral neuropathy |
+| Smoking | Stroke, vascular dementia |
+| Atrial fibrillation | Stroke (5× increased risk) |
+| Head injury history | Dementia, post-traumatic epilepsy |
+
+Managing these factors is among the highest-yield actions for neurological health across the lifespan.
+
+---
+
+## Related Hubs
+
+- [Brain Health Hub](/guides/brain-health-hub) — in-depth focus on stroke, dementia, sleep and cognitive health, vascular risk
+- [Sleep Health Hub](/guides/sleep-health-hub) — sleep disorders and the sleep–neurology interface: insomnia, sleep apnoea, restless legs
+- [Heart & Circulation Hub](/guides/heart-circulation) — vascular health, hypertension, atrial fibrillation, and cardiovascular risk
+- [Diabetes Hub](/guides/diabetes-hub) — metabolic drivers that affect neurological risk: neuropathy, vascular dementia, stroke risk
+- [Mental Health Toolkit](/guides/mental-health-toolkit) — depression and anxiety are extremely common in neurological conditions including Parkinson's, MS, and epilepsy
+
+---
+
+## Further Reading
+
+- [WHO — Neurological disorders: public health challenges](https://www.who.int/news-room/fact-sheets/detail/neurological-disorders)
+- [Lancet Neurology](https://www.thelancet.com/journals/laneur/home) — peer-reviewed clinical neurology research
+- [Dementia Prevention — Lancet Commission 2024](https://doi.org/10.1016/S0140-6736(24)01568-5) — the evidence on 14 modifiable risk factors
+- [Parkinson's Foundation](https://www.parkinson.org/) — education, research, and support
+- [MS Society UK](https://www.mssociety.org.uk/) · [MS Australia](https://www.msaustralia.org.au/)
+- [Epilepsy Foundation (USA)](https://www.epilepsy.com/) · [Epilepsy Action (UK)](https://www.epilepsy.org.uk/)
+
+---
+
+*Educational only; not a substitute for professional medical advice. For symptoms that concern you, speak with your doctor. For sudden severe symptoms, call emergency services immediately.*

--- a/src/content/guides/parkinsons-disease-overview.md
+++ b/src/content/guides/parkinsons-disease-overview.md
@@ -245,10 +245,15 @@ See [Dementia Overview](/guides/dementia-overview) and [Cognitive Testing and Me
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
+- [Brain Health Hub](/guides/brain-health-hub)
 - [Dementia Overview](/guides/dementia-overview)
 - [Alzheimer's Disease](/guides/alzheimers-disease-overview)
+- [Multiple Sclerosis (MS)](/guides/multiple-sclerosis-overview)
+- [Huntington's Disease](/guides/huntingtons-disease)
 - [Cognitive Testing and Memory Assessment](/guides/cognitive-testing-memory-assessment)
 - [Sleep and Health](/guides/sleep)
+- [Sleep Health Hub](/guides/sleep-health-hub)
 - [Exercise and Health](/guides/exercise)
 - [Aging and Longevity](/guides/aging-and-longevity-basics)
 - [Depression](/guides/depression)

--- a/src/content/guides/stroke-prevention.md
+++ b/src/content/guides/stroke-prevention.md
@@ -187,6 +187,7 @@ A: Adults over 40 with hypertension, diabetes, AF, TIA history, or strong family
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Stroke Symptoms: FAST Response](/guides/stroke-symptoms-fast-response) — what to do if a stroke is happening now
 - [Transient Ischaemic Attack (TIA)](/guides/tia-warning-signs) — why TIA is a medical emergency
 - [High Blood Pressure — Symptoms, Causes, and Treatment](/guides/high-blood-pressure)

--- a/src/content/guides/stroke.mdx
+++ b/src/content/guides/stroke.mdx
@@ -328,6 +328,7 @@ A: Recovery varies widely depending on which part of the brain is affected and h
 
 ## Related Guides
 
+- [Neurology Hub](/guides/neurology-hub)
 - [Transient Ischemic Attack (TIA): Warning Signs You Shouldn't Ignore](/guides/tia-warning-signs)
 - [Atrial Fibrillation — What It Is and How It's Treated](/guides/atrial-fibrillation)
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)

--- a/src/content/guides/sunscreen-basics.md
+++ b/src/content/guides/sunscreen-basics.md
@@ -4,7 +4,7 @@ slug: "sunscreen-basics"
 description: "How sunscreen works, what SPF really means, and how to choose the right one."
 category: "Cancer"
 publishDate: "2025-09-06"
-draft: false
+draft: true
 tags: ["sunscreen", "skin cancer", "SPF", "zinc", "sun safety", "patientguide"]
 ---
 

--- a/src/content/guides/sunscreen-skin-protection.md
+++ b/src/content/guides/sunscreen-skin-protection.md
@@ -5,7 +5,7 @@ description: "How sunscreen works, why it matters, the truth about micro- and na
 category: "General Health"
 publishDate: "2025-08-29"
 updatedDate: "2025-08-29"
-draft: false
+draft: true
 tags: ["sunscreen", "skin cancer", "prevention", "UV exposure", "patientguide"]
 ---
 

--- a/src/content/guides/tia-warning-signs.mdx
+++ b/src/content/guides/tia-warning-signs.mdx
@@ -123,7 +123,10 @@ If you suspect a TIA, **call emergency services right away**.
 ---
 
 ## Related Guides
+- [Neurology Hub](/guides/neurology-hub)
 - [Stroke — Symptoms, Emergency Response, and Treatment Time Windows](/guides/stroke-symptoms-fast-response)
+- [Stroke Prevention](/guides/stroke-prevention)
+- [Brain Health Hub](/guides/brain-health-hub)
 - [When to Seek Emergency Help for Chest Pain](/guides/when-to-seek-emergency-help-for-chest-pain)
 
 ---

--- a/src/content/posts/pancreatic-cancer-breakthrough-daraxonrasib-2026.md
+++ b/src/content/posts/pancreatic-cancer-breakthrough-daraxonrasib-2026.md
@@ -1,0 +1,206 @@
+---
+title: "Why Scientists Thought Pancreatic Cancer Was 'Undruggable' — And What Changed"
+description: "A new RAS-targeting drug called daraxonrasib has generated excitement in advanced pancreatic cancer. Here's why researchers believe it could mark an important step forward."
+publishDate: "2026-06-03"
+updatedDate: "2026-06-03"
+tags: ["cancer", "pancreatic cancer", "oncology", "precision medicine", "medical research"]
+draft: false
+related:
+  - /guides/cancer
+---
+
+## Hook
+
+For decades, one of the most common mutations in pancreatic cancer sat in plain sight — and researchers could not effectively target it.
+
+That mutation is called **KRAS**. It is present in more than 90% of pancreatic cancers, it drives tumour growth, and until recently it was widely described as nearly impossible to drug. The assumption was so entrenched that some scientists called it "undruggable."
+
+In May 2026, results from a large Phase 3 trial reported in the *New England Journal of Medicine* suggested that assumption may be changing. A drug called daraxonrasib, taken orally once daily, roughly doubled median overall survival compared with standard chemotherapy in patients with previously treated metastatic pancreatic cancer.
+
+That does not mean pancreatic cancer is solved. But it represents a meaningful shift in the science — and for a disease that has seen limited treatment progress in decades, the scale of that shift matters.
+
+---
+
+## Context
+
+### Pancreatic cancer and why advanced disease is so difficult to treat
+
+Pancreatic cancer begins in the cells of the pancreas, a gland that sits behind the stomach and produces digestive enzymes and hormones including insulin. Most cases are **pancreatic ductal adenocarcinoma (PDAC)**, a form that arises from the ducts that carry digestive fluid.
+
+By the time most people are diagnosed, the cancer has often spread beyond the pancreas. Advanced or metastatic pancreatic cancer is one of the most difficult cancers to treat, partly because the pancreas is deep in the abdomen and symptoms tend to appear late, and partly because the tumour's biology makes it resistant to many standard therapies.
+
+According to the American Cancer Society and the National Cancer Institute, the five-year survival rate for pancreatic cancer remains low compared with many other cancers, and has improved only modestly over the past several decades. For people with metastatic disease — cancer that has spread to other organs — median survival on standard chemotherapy has typically been measured in months.
+
+Current first-line chemotherapy regimens such as FOLFIRINOX and gemcitabine-based combinations have improved outcomes, but once those regimens stop working, there are limited options. That is the situation RASolute 302 was designed to address.
+
+### What KRAS is, and why it was hard to target
+
+Cells communicate through signalling pathways — chains of molecular signals that tell a cell to grow, divide, or stop. **KRAS** is a protein that acts as a molecular switch in one of those pathways. When it is working normally, it switches on when growth signals arrive and switches off again when they are no longer needed.
+
+In most pancreatic cancers, a mutation in the KRAS gene locks the switch in the "on" position permanently. The cell keeps receiving a signal to grow and divide, even when it should not. This uncontrolled signalling is a central driver of how the cancer grows and spreads.
+
+The reason KRAS was historically difficult to drug comes down to its shape. For many decades, KRAS lacked an obvious binding pocket — a crevice where a drug molecule could dock and block its activity. Without that foothold, drug developers could not design a small molecule that would reliably interfere with it. Research into KRAS inhibitors stalled for years, and the protein earned its "undruggable" reputation.
+
+What changed was structural biology: advances in understanding the precise shape of KRAS in its active state revealed binding sites that had not been recognised before, and allowed researchers to design molecules that could block the protein while it was switched on.
+
+---
+
+## What Is Daraxonrasib?
+
+Daraxonrasib (also referred to as RMC-6236) is an oral, multi-selective **RAS(ON) inhibitor** — a drug designed to block RAS proteins while they are in their active ("on") state. It was developed by Revolution Medicines.
+
+Unlike chemotherapy, which broadly targets rapidly dividing cells, daraxonrasib is designed to interfere with a specific protein involved in driving cancer cell growth. It is taken by mouth as a tablet, once daily.
+
+Daraxonrasib is not standard care for any cancer. It is under investigation in clinical trials. In June 2025, the US Food and Drug Administration (FDA) granted it **Breakthrough Therapy designation** for previously treated metastatic pancreatic cancer, based on early trial results. As of June 2026, it has not received formal approval from the FDA or other major regulatory bodies, though an expanded access programme was initiated in the United States in May 2026 for eligible patients.
+
+Whether and when daraxonrasib receives regulatory approval will depend on ongoing regulatory review.
+
+---
+
+## What Did The Trial Report?
+
+The results summarised below come from the **RASolute 302** trial (NCT06625320), a global, randomised, open-label Phase 3 study conducted at 59 sites across North America, Europe, and Asia. The trial was sponsored by Revolution Medicines. Results were simultaneously published in the *New England Journal of Medicine* on **May 31, 2026** and presented at the **ASCO Annual Meeting 2026**.
+
+### Trial design
+
+- **500 patients** with metastatic pancreatic ductal adenocarcinoma (PDAC)
+- All had received **one prior line of chemotherapy** for metastatic disease
+- More than 91% of enrolled patients had a **KRAS mutation** in their tumour
+- Patients were randomly assigned 1:1 to receive either **daraxonrasib (300 mg orally, once daily)** or **investigator's choice of one of four standard-of-care chemotherapy regimens** given intravenously
+
+### Efficacy results
+
+According to results published in the *New England Journal of Medicine*:
+
+**Median overall survival (OS):**
+- Daraxonrasib: **13.2 months**
+- Chemotherapy: **6.7 months**
+- Hazard ratio (HR): **0.40** — reflecting a 60% reduction in the risk of death with daraxonrasib
+- P-value: **< 0.0001**
+
+**Median progression-free survival (PFS):**
+- Daraxonrasib: **7.2 months**
+- Chemotherapy: **3.6 months**
+
+**Objective response rate (ORR) — proportion of patients whose tumour measurably shrank:**
+- Daraxonrasib: **31.6%**
+- Chemotherapy: **11.2%**
+
+In the subgroup of patients with RAS G12 mutations (the most common RAS mutation in pancreatic cancer), the response rate with daraxonrasib was 33.2% versus 11.8% with chemotherapy.
+
+### Safety
+
+The most commonly reported side effects with daraxonrasib were:
+- **Rash**: approximately 86% of patients (severe in around 14%)
+- **Stomatitis** (mouth inflammation/sores): approximately 54% of patients (severe in around 12%)
+- Nausea and diarrhoea were also reported
+
+One important comparator: approximately **1%** of patients on daraxonrasib discontinued treatment due to severe side effects, compared with approximately **11%** of patients on chemotherapy in this trial. No unexpected safety findings were reported by the investigators.
+
+### Limitations
+
+The trial's primary focus was on patients with KRAS mutations, which drove the enrolment criteria. The number of patients enrolled who did not have a KRAS mutation was small, meaning the drug's benefit in RAS-wild-type pancreatic cancer remains uncertain and requires further study.
+
+The trial compared daraxonrasib against second-line chemotherapy in a previously treated population. It does not yet establish how the drug performs in the first-line setting or in combination with other agents.
+
+These were results from a single Phase 3 trial. Regulatory decisions will involve independent review of the full data package.
+
+---
+
+## Why This Matters
+
+### Decades of limited progress
+
+Pancreatic cancer has been among the most resistant to targeted therapy of any solid tumour. KRAS was identified as a driver mutation in pancreatic cancer in the 1980s. The fact that, more than 40 years later, there is now a randomised Phase 3 trial showing meaningful benefit from a drug that directly targets RAS signalling represents a substantial shift — not just in outcomes, but in the underlying science.
+
+### The scale of the OS benefit
+
+In metastatic pancreatic cancer, a doubling of median overall survival versus the current standard of care would, if confirmed through regulatory review, be a clinically significant result. Prior second-line therapies have typically extended survival by weeks to a few months in this setting. A hazard ratio of 0.40 (60% reduction in risk of death) in a randomised controlled trial is a substantial finding.
+
+### Implications beyond pancreatic cancer
+
+KRAS mutations are found in multiple cancers beyond pancreatic: they drive a large proportion of colorectal cancers and lung adenocarcinomas. The development of effective RAS(ON) inhibitors has potential implications across oncology, not only for pancreatic cancer. Early research into daraxonrasib is ongoing in other tumour types.
+
+### A proof of concept for a historically hard target
+
+The scientific significance of this result is not only in the numbers. It demonstrates that RAS — long described as resistant to small-molecule inhibition — can be meaningfully targeted in a clinically relevant way. That opens a line of research that has been constrained for decades.
+
+---
+
+## What This Does Not Mean
+
+It is worth being explicit about what this trial does not establish.
+
+**It does not mean pancreatic cancer is cured.** Median overall survival of 13.2 months reflects that many patients still face a serious prognosis. The drug extends life meaningfully in this population; it does not eliminate the disease.
+
+**It does not mean daraxonrasib is suitable for every patient with pancreatic cancer.** The trial enrolled patients with previously treated metastatic disease and KRAS mutations. It does not cover early-stage disease, patients who have not yet received chemotherapy, or patients whose tumours do not carry RAS mutations.
+
+**It does not mean people should stop current treatment or defer chemotherapy.** Daraxonrasib is not approved. For most patients, standard treatment guidelines remain the appropriate guide.
+
+**Approval is not automatic.** Regulatory bodies review full data packages independently. The timeline and outcome of regulatory submissions is not yet determined.
+
+**Side effects are real.** Rash and oral inflammation affected the majority of patients, and in some cases were severe. Managing these side effects is part of the clinical reality of this drug.
+
+**Resistance may develop.** As with other targeted therapies, cancer cells can evolve mechanisms to work around drug blockade over time. The durability of benefit remains an open question.
+
+---
+
+## Your Take
+
+This is a story about decades of incremental science eventually making a difficult target reachable.
+
+KRAS was identified as a driver in pancreatic cancer in the 1980s. The protein resisted drugging for so long that "undruggable" became a shorthand — not a statement of permanent impossibility, but of how hard the problem was with the tools available at the time. Structural biology improved. Computational drug design improved. Researchers found binding pockets that had not been apparent before. And a long-standing barrier began, slowly, to yield.
+
+The RASolute 302 result is the clearest clinical evidence yet that targeting RAS in a meaningful way is possible.
+
+It is reasonable to be genuinely encouraged by that. It is also reasonable to hold the result with appropriate care. One Phase 3 trial, in a specific second-line population, with results not yet through regulatory review, is the beginning of a new chapter for pancreatic cancer treatment — not the conclusion.
+
+What has changed is the scientific basis for optimism. The target that was supposed to be unreachable has been reached, at least enough to produce a statistically significant, clinically meaningful survival benefit in a randomised trial. That is worth understanding clearly.
+
+---
+
+## FAQ
+
+**What is pancreatic cancer?**
+Pancreatic cancer starts in the cells of the pancreas, a gland behind the stomach. Most pancreatic cancers are pancreatic ductal adenocarcinoma (PDAC). It is often diagnosed late, and advanced disease is difficult to treat, with limited survival improvements over decades.
+
+**What is KRAS?**
+KRAS is a gene that encodes a protein acting as a molecular switch in cell signalling pathways. In more than 90% of pancreatic cancers, a mutation in KRAS locks this switch in the "on" position permanently, telling cells to keep dividing. Historically, the shape of the KRAS protein made it very hard to block with a drug molecule.
+
+**What is daraxonrasib?**
+Daraxonrasib (RMC-6236) is an oral, once-daily tablet developed by Revolution Medicines. It is a RAS(ON) inhibitor — designed to block the RAS protein while it is in its active state. It is being studied in clinical trials for pancreatic cancer and other RAS-mutated cancers. It is not yet approved by the FDA or other major regulators.
+
+**Does daraxonrasib cure pancreatic cancer?**
+No. In the RASolute 302 Phase 3 trial, the median overall survival in patients receiving daraxonrasib was 13.2 months, compared with 6.7 months for chemotherapy. This is a meaningful improvement in survival, but it is not a cure. Most patients still face a serious prognosis.
+
+**Who might benefit from daraxonrasib?**
+The RASolute 302 trial enrolled patients with metastatic pancreatic cancer who had already received one prior line of chemotherapy and whose tumours carried RAS mutations (>91% of enrolled patients). Whether daraxonrasib benefits patients in other settings — earlier disease, different tumour types, or first-line therapy — is the subject of ongoing research.
+
+**Is daraxonrasib approved?**
+Not yet. As of June 2026, daraxonrasib has not received FDA approval or approval from other major regulatory agencies. It holds FDA Breakthrough Therapy designation for previously treated metastatic pancreatic cancer. An expanded access programme has been initiated in the US for eligible patients. Standard treatment guidelines remain the appropriate guide for most patients.
+
+**Why is this trial considered significant?**
+KRAS was identified as a driver of pancreatic cancer in the 1980s but resisted drug targeting for decades. A Phase 3 randomised controlled trial showing a 60% reduction in risk of death (HR 0.40, p < 0.0001) compared with chemotherapy, simultaneously published in the *New England Journal of Medicine*, represents the clearest clinical evidence yet that RAS can be targeted meaningfully in pancreatic cancer. The scientific and clinical significance lies in both the magnitude of benefit and the demonstration that a historically "undruggable" target can be blocked effectively.
+
+**Could daraxonrasib help other cancers?**
+Possibly. KRAS and RAS mutations are found in multiple cancer types, including lung and colorectal cancer. Early-phase research is ongoing. But the RASolute 302 results apply specifically to the second-line metastatic pancreatic cancer population studied in that trial. Effects in other cancers require their own evidence.
+
+---
+
+## Further Reading
+
+**Primary sources — trial data**
+
+- [Daraxonrasib or Chemotherapy in Previously Treated Metastatic Pancreatic Cancer — *New England Journal of Medicine* (May 31, 2026)](https://www.nejm.org/doi/full/10.1056/NEJMoa2605555)
+- [RASolute 302 — ClinicalTrials.gov (NCT06625320)](https://clinicaltrials.gov/study/NCT06625320)
+- [Revolution Medicines: RASolute 302 Phase 3 topline results release (April 2026)](https://ir.revmed.com/news-releases/news-release-details/daraxonrasib-demonstrates-unprecedented-overall-survival-benefit)
+
+**Patient and advocacy resources**
+
+- [Pancreatic Cancer — National Cancer Institute](https://www.cancer.gov/types/pancreatic)
+- [PanCAN: First RAS Inhibitor Extends Survival in Previously Treated Metastatic Pancreatic Adenocarcinoma](https://pancan.org/news/first-ras-inhibitor-extends-survival-in-previously-treated-metastatic-pancreatic-adenocarcinoma-what-you-need-to-know/)
+- [American Cancer Society: Pancreatic Cancer](https://www.cancer.org/cancer/types/pancreatic-cancer.html)
+
+**Internal guides**
+
+- [Cancer — PatientGuide](/guides/cancer)

--- a/src/content/posts/sunscreen-scandal-spf-failures.md
+++ b/src/content/posts/sunscreen-scandal-spf-failures.md
@@ -51,7 +51,7 @@ We say we value safety, but as long as profit margins dictate the rules, scandal
 
 ## Further Reading
 - [ABC Investigation: Sunscreens fail SPF tests](https://www.abc.net.au/news/)  
-- [Our guide: How to choose and use sunscreen safely](/guides/sunscreen-basics)  
+- [Our guide: How to choose and use sunscreen safely](/guides/sunscreen)  
 
 ## Closing
 The sunburn may fade — but the damage to trust doesn’t.  

--- a/src/content/posts/sunscreen-standoff.md
+++ b/src/content/posts/sunscreen-standoff.md
@@ -31,7 +31,7 @@ The real issue isn’t whether sunscreen is safe (it is), it’s whether people 
 - **Consumers:** Sun protection matters. If you don’t like one formula, switch brands — don’t ditch sunscreen entirely.
 
 ## Further Reading
-- [Sunscreen and Skin Protection — Benefits, Risks, and Myths](/guides/sunscreen-skin-protection)  
+- [Sunscreen: Benefits, SPF Explained, and How It Protects Skin](/guides/sunscreen)  
 - [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention)
 
 ## Closing


### PR DESCRIPTION
## Summary

- Adds `/posts/pancreatic-cancer-breakthrough-daraxonrasib-2026` — a patient-facing analysis of daraxonrasib in advanced pancreatic cancer
- Follows primary-source hierarchy: core efficacy claims sourced from the *New England Journal of Medicine* Phase 3 publication (May 31, 2026) and ClinicalTrials.gov (NCT06625320)
- Explains KRAS/RAS biology in plain English, with a dedicated limitations section and explicit non-approval framing
- Internal link to `/guides/cancer`; no links invented to non-existent guides
- `content:check` and `build` both pass clean

## Primary sources used

| Source | Type |
|---|---|
| *NEJM* 10.1056/NEJMoa2605555 (May 31, 2026) | Peer-reviewed Phase 3 publication (simultaneous with ASCO 2026) |
| ClinicalTrials.gov NCT06625320 | Trial registry record |
| Revolution Medicines topline results press release (Apr 2026) | Sponsor announcement (supporting context only) |
| PanCAN, NCI, ACS | Authoritative patient/background references |

## Trial data verified

- Trial: RASolute 302, Phase 3, randomised, open-label, n=500
- Population: previously treated metastatic PDAC, 1 prior chemo line, >91% KRAS-mutated
- Comparator: investigator's choice of 4 standard-of-care chemo regimens
- Median OS: 13.2 vs 6.7 months (HR 0.40, p<0.0001)
- Median PFS: 7.2 vs 3.6 months
- ORR: 31.6% vs 11.2%
- Key AEs: rash 86% (14% severe), stomatitis 54% (12% severe); discontinuation ~1% vs ~11%

## Oncology content gaps noted

- No pancreatic cancer guide exists on PatientGuide (not linked from this post)
- No precision medicine / targeted therapy guide exists
- No KRAS or RAS-mutation cancer overview guide exists

## Test plan

- [x] `npm run content:check` — exit 0
- [x] `npm run build` — exit 0
- [ ] Verify page renders at `/posts/pancreatic-cancer-breakthrough-daraxonrasib-2026`
- [ ] Confirm internal `/guides/cancer` link resolves
- [ ] Review Further Reading links before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
