### PR TITLE
feat(screening): add PSA and DEXA screening guides

### DIFF
--- a/src/content/guides/bone-density-osteoporosis.mdx
+++ b/src/content/guides/bone-density-osteoporosis.mdx
@@ -209,6 +209,7 @@ A: Treatment can increase bone density and substantially reduce fracture risk, b
 
 ## Related Guides
 
+- [Bone Density Testing (DEXA): Who Should Be Screened and When](/guides/bone-density-testing-dexa-screening) — practical guide to who needs a DEXA scan, what to expect, and how to interpret results
 - [Aging and Longevity Basics](/guides/aging-and-longevity-basics)
 - [Sarcopenia: Age-Related Muscle Loss](/guides/sarcopenia-aging)
 - [Longevity Lifestyle Basics](/guides/longevity-lifestyle-basics)

--- a/src/content/guides/bone-density-testing-dexa-screening.md
+++ b/src/content/guides/bone-density-testing-dexa-screening.md
@@ -1,0 +1,261 @@
+---
+title: "Bone Density Testing (DEXA): Who Should Be Screened and When"
+slug: "bone-density-testing-dexa-screening"
+description: "A practical patient guide to bone density scanning — how DEXA works, how to interpret T-scores, who should be screened, what osteoporosis and osteopenia mean, and what to do after your results."
+category: "Aging & Longevity"
+publishDate: "2026-06-05"
+updatedDate: "2026-06-05"
+draft: false
+tags:
+  - DEXA
+  - bone density
+  - osteoporosis
+  - osteopenia
+  - fracture risk
+  - bone density testing
+  - menopause
+  - aging
+  - preventive screening
+  - T-score
+schema:
+  medicalCondition:
+    name: "DEXA Bone Density Scanning"
+    description: "Dual-energy X-ray absorptiometry (DEXA) is the standard method for measuring bone mineral density (BMD). It is painless, uses very low radiation, and takes approximately 10–20 minutes. Results are expressed as T-scores compared to WHO thresholds to identify osteoporosis and osteopenia. DEXA is recommended for all women aged 65 and over, postmenopausal women under 65 with risk factors, men aged 70 and over, and anyone who has sustained a fragility fracture."
+    alternateName:
+      - "dual-energy X-ray absorptiometry"
+      - "bone density scan"
+      - "DXA scan"
+      - "bone mineral density test"
+      - "BMD scan"
+    contagious: false
+    sameAs:
+      - "https://www.healthybones.com.au/"
+      - "https://www.sheffield.ac.uk/FRAX/"
+      - "https://www.niams.nih.gov/health-topics/osteoporosis"
+faq:
+  - q: "What is a DEXA scan?"
+    a: "DEXA (dual-energy X-ray absorptiometry) is a type of X-ray that measures bone mineral density (BMD). It uses two low-energy X-ray beams to assess how dense your bones are. The scan is quick, painless, and uses very little radiation. Results are expressed as T-scores — a comparison against peak bone density in healthy young adults — to determine whether bone density is normal, reduced (osteopenia), or in the osteoporosis range."
+  - q: "Does a DEXA scan hurt?"
+    a: "No. A DEXA scan is completely painless. You lie on a flat table, fully clothed, while a scanning arm passes slowly over you. The scan takes around 10–20 minutes. No needle, contrast agent, or preparation is required. Radiation exposure is very low — roughly equivalent to a few hours of natural background radiation."
+  - q: "What does my T-score mean?"
+    a: "Your T-score compares your bone density to a young adult of the same sex at their peak bone mass. A T-score above −1.0 is normal. Between −1.0 and −2.5 indicates osteopenia — below-average bone density but not yet in the osteoporosis range. A T-score of −2.5 or below indicates osteoporosis. Your clinician will interpret the T-score alongside your other risk factors — a T-score alone does not determine whether treatment is needed."
+  - q: "Who should have a DEXA scan?"
+    a: "Recommended groups include women aged 65 and over, postmenopausal women under 65 with risk factors such as family history, low body weight, or prior fracture, men aged 70 and over, and anyone who has had a fragility fracture (a fracture from a minor fall or without significant trauma). People taking long-term corticosteroids and those with conditions that affect bone health should also be assessed. If you are unsure, ask your GP."
+  - q: "How often should I have a DEXA scan?"
+    a: "Frequency depends on your results and risk profile. If your first scan is normal and risk is low, a repeat in 5–10 years may be sufficient. If you are being treated for osteoporosis, monitoring every 1–2 years is typical to assess treatment response. Follow your clinician's advice on timing."
+  - q: "Can osteoporosis be treated?"
+    a: "Yes. Treatment can increase bone density and substantially reduce fracture risk. Options include weight-bearing exercise, adequate calcium and vitamin D, fall prevention strategies, bisphosphonate medications, denosumab, hormone therapy, and — for severe cases — anabolic agents. Earlier detection and treatment lead to better outcomes."
+---
+
+## What Is DEXA?
+
+DEXA — dual-energy X-ray absorptiometry — is the internationally accepted standard for measuring bone mineral density (BMD). It uses two low-energy X-ray beams at different energy levels that pass through bone and soft tissue. Because bone and soft tissue absorb these energies at different rates, the scanner can calculate precisely how much mineral (primarily calcium phosphate) is contained within the bone — separately from the surrounding muscle and fat.
+
+DEXA is **painless, quick, and uses very little radiation** — approximately 1–6 microsieverts per scan. For comparison, a chest X-ray delivers around 100 microsieverts and an abdominal CT scan around 10,000–50,000 microsieverts. Flying from Sydney to London delivers approximately 80–100 microsieverts.
+
+The scan is typically performed on two sites:
+- **Lumbar spine (lower back, L1–L4)** — the most sensitive site for detecting early bone loss and monitoring treatment response
+- **Proximal hip (femoral neck and total hip)** — the most clinically important site for fracture risk and the most reproducible between different scanners
+
+---
+
+## Key Points
+
+- DEXA is the standard test for measuring bone mineral density and diagnosing osteoporosis.
+- The scan is painless, takes 10–20 minutes, and uses very low radiation — far less than a chest X-ray.
+- Results are expressed as T-scores compared to a young-adult reference population.
+- WHO diagnostic categories: normal (T-score above −1.0), osteopenia (−1.0 to −2.5), osteoporosis (−2.5 or below).
+- All women aged 65 and over and all men aged 70 and over should be offered DEXA; earlier screening applies when significant risk factors are present.
+- Women experience the most rapid bone loss in the first 5–10 years after menopause — this is the period of highest risk.
+- A T-score alone does not determine treatment; the FRAX fracture risk calculator combines T-score with clinical risk factors.
+- Osteoporotic fractures — particularly hip fractures — carry a one-year mortality of around 20–30%.
+- Treatment is effective: bisphosphonates reduce vertebral fracture risk by 40–70% and hip fracture risk by approximately 40%.
+
+---
+
+## How DEXA Works
+
+When the two X-ray beams pass through your body, a detector measures how much of each beam is absorbed. Bone attenuates (absorbs) the beams differently from soft tissue, and the higher-energy beam differentiates bone from fat more precisely. Software processes these differences to calculate bone mineral content (BMC, in grams) and areal bone mineral density (BMD, in grams per square centimetre) at each site measured.
+
+The scanner then compares your BMD against a stored reference population to produce two scores:
+
+**T-score** — compares your BMD to the average BMD of a healthy young adult of the same sex at their peak bone mass (typically around ages 25–30). This is the score used to diagnose osteoporosis according to WHO criteria.
+
+**Z-score** — compares your BMD to age-matched peers (people of the same age, sex, and sometimes ethnicity). A Z-score below −2.0 suggests bone loss greater than expected for your age and prompts investigation for secondary causes of bone loss, such as long-term steroid use, coeliac disease, hyperparathyroidism, or other conditions.
+
+---
+
+## What to Expect During the Scan
+
+- Wear comfortable, loose clothing without metal fixtures in the scan area; a hospital gown is sometimes provided
+- Remove belt buckles, zips, and underwire in the area to be scanned
+- Lie flat on a padded table; the scanning arm passes slowly over your lower back and hip
+- Each site takes approximately 3–7 minutes; total scan time is usually 10–20 minutes
+- No needles, contrast agents, claustrophobia, or special preparation required
+- If you have recently had a barium study, nuclear medicine scan, or intravenous contrast, inform the radiographer — some agents can temporarily affect DEXA accuracy
+- Inform the radiographer if there is any possibility of pregnancy
+
+Results are reported by a radiologist, and a written report is sent to your referring clinician.
+
+---
+
+## Understanding Your Results
+
+### WHO Diagnostic Categories (Based on T-score)
+
+| T-score | Diagnosis | Implications |
+|---|---|---|
+| **Above −1.0** | Normal | Bone density within the expected range for a young adult |
+| **−1.0 to −2.5** | Osteopenia | Below-average bone density; elevated fracture risk compared with normal, but not in the osteoporosis range |
+| **−2.5 or below** | Osteoporosis | Significantly reduced bone density; high fracture risk; treatment discussion warranted |
+| **−2.5 or below + fragility fracture** | Severe osteoporosis | Highest risk category; fracture has already occurred |
+
+**Important:** A T-score in the osteopenia range does not automatically mean treatment is required. Many people with osteopenia have a low absolute fracture risk and are managed well with lifestyle measures and monitoring. Treatment decisions are based on overall fracture probability, not T-score alone.
+
+### The FRAX Fracture Risk Tool
+
+FRAX (Fracture Risk Assessment Tool) is a WHO-developed calculator that estimates a person's **10-year probability of a major osteoporotic fracture** (spine, forearm, hip, or shoulder) and hip fracture specifically.
+
+FRAX incorporates:
+- Age, sex, and body weight
+- Femoral neck T-score (from DEXA)
+- Prior fragility fracture
+- Parental history of hip fracture
+- Current smoking and alcohol use
+- Glucocorticoid use
+- Rheumatoid arthritis
+- Secondary causes of osteoporosis
+
+A FRAX probability above a locally defined intervention threshold is used to guide treatment decisions, particularly for people with osteopenia whose T-score alone does not meet the treatment threshold. Your clinician can calculate FRAX alongside your DEXA result.
+
+---
+
+## Who Should Be Screened
+
+| Group | Recommendation |
+|---|---|
+| **Women aged 65+** | DEXA recommended for all |
+| **Men aged 70+** | DEXA recommended for all |
+| **Postmenopausal women under 65 with risk factors** | Discuss with GP; risk factors include prior fracture, family history, low body weight, early menopause |
+| **Men aged 50–69 with multiple risk factors** | Discuss with GP |
+| **Anyone with a fragility fracture** (low-trauma fracture) | DEXA recommended regardless of age |
+| **Long-term corticosteroid use** (≥3 months at ≥7.5 mg/day prednisone equivalent) | DEXA recommended; steroids are the most common drug cause of osteoporosis |
+| **Early menopause (before age 45)** — natural, surgical, or chemotherapy-induced | Earlier DEXA warranted; earlier oestrogen loss means earlier bone loss |
+| **Aromatase inhibitor therapy** (used in breast cancer) | Assess bone density; these agents accelerate bone loss |
+| **Androgen deprivation therapy** (used in prostate cancer) | DEXA recommended; significant bone loss occurs with testosterone suppression |
+| **Conditions associated with bone loss** — coeliac disease, inflammatory bowel disease, hyperparathyroidism, chronic kidney disease, eating disorders | Discuss with GP |
+
+In Australia, Medicare provides a rebate for DEXA scanning in eligible patients. Your GP can determine eligibility and provide a referral.
+
+---
+
+## Risk Factors for Low Bone Density
+
+Understanding risk factors helps identify who needs earlier or more frequent screening.
+
+**Non-modifiable:**
+- Female sex — women have lower peak bone mass and experience rapid bone loss after menopause
+- Increasing age
+- White or Asian ethnicity
+- Family history of osteoporosis or hip fracture
+- Prior fragility fracture — itself the single strongest predictor of future fracture
+- Early menopause (before age 45), whether natural, surgical, or chemotherapy-induced
+
+**Modifiable:**
+- Physical inactivity — particularly lack of weight-bearing and resistance exercise
+- Low dietary calcium intake
+- Vitamin D deficiency — common in older adults with limited sun exposure
+- Smoking
+- Excess alcohol (more than 2 standard drinks per day on average)
+- Low body weight (BMI below 20)
+- Prolonged bed rest or immobility
+
+**Medical conditions and medications:**
+- Long-term corticosteroid use — the most common drug cause of secondary osteoporosis
+- Aromatase inhibitors (breast cancer treatment)
+- Androgen deprivation therapy (prostate cancer treatment)
+- Anticonvulsants (some accelerate vitamin D metabolism)
+- Coeliac disease, Crohn's disease, other malabsorption syndromes
+- Hyperparathyroidism, hyperthyroidism
+- Chronic kidney disease
+- Hypogonadism (low sex hormones in men or women)
+- Rheumatoid arthritis
+- Eating disorders, particularly anorexia nervosa
+
+---
+
+## Menopause and Bone Loss
+
+Bone loss accelerates dramatically in the years following menopause — this is the period of greatest risk for most women, and the strongest clinical rationale for DEXA screening in women before age 65 when risk factors are present.
+
+**Why menopause affects bones:**
+
+Oestrogen is essential for maintaining the balance between bone formation (osteoblasts) and bone resorption (osteoclasts). As oestrogen levels fall at menopause, osteoclast activity increases without a compensating rise in osteoblast activity. The result is net bone loss.
+
+- Women lose approximately **1–3% of bone mass per year** in the first 5–10 years after menopause
+- Cumulative bone loss over this period can reach 15–20%
+- By age 70, a woman may have lost 30–40% of her peak bone mass
+
+**Implications for screening:**
+
+- Women with early menopause (before age 45) begin bone loss earlier, have a longer exposure window, and should be screened earlier
+- Women approaching or recently past menopause with additional risk factors should not wait until age 65 for their first DEXA
+- Hormone therapy (HRT/MHT) can prevent menopausal bone loss and reduce fracture risk; this is an individualised decision made with a clinician, balancing bone protection against other considerations
+
+---
+
+## After Your Results — What Happens Next
+
+**Normal result (T-score above −1.0):**
+Reassurance and lifestyle reinforcement — adequate calcium, vitamin D, weight-bearing exercise. A follow-up DEXA in 5–10 years is usually appropriate depending on age and risk profile.
+
+**Osteopenia (T-score −1.0 to −2.5):**
+FRAX calculation to determine absolute 10-year fracture risk. If risk is low, lifestyle measures, calcium and vitamin D optimisation, and a follow-up DEXA in 2–5 years. If FRAX risk exceeds the intervention threshold, pharmacological treatment is discussed.
+
+**Osteoporosis (T-score −2.5 or below):**
+Treatment discussion. First-line pharmacological options include bisphosphonates (alendronate, risedronate, zoledronic acid). Additional measures include calcium and vitamin D supplementation, resistance and balance exercise, fall prevention review, and specialist referral in complex cases. Monitoring DEXA every 1–2 years during treatment assesses response.
+
+**Fragility fracture — regardless of T-score:**
+A fracture from a minor fall or without trauma is itself a medical priority. A fracture liaison service (FLS) — where available — coordinates post-fracture bone health assessment and treatment to prevent subsequent fractures. The risk of a second fracture is highest in the 1–2 years immediately following the first.
+
+---
+
+## Limitations of DEXA
+
+DEXA is the best available clinical tool for bone density measurement, but it does not capture everything:
+
+- **Bone quality and microarchitecture** — T-score reflects density but not the internal trabecular structure of bone. Two people with identical T-scores can have different fracture resistance depending on bone geometry and microstructure.
+- **Vertebral fractures are not always detected** — standard DEXA does not diagnose vertebral compression fractures, which are often silent. Vertebral fracture assessment (VFA) can be added to most modern DEXA scans and is worth requesting if vertebral fracture is suspected.
+- **Peripheral DEXA (wrist, heel)** — portable devices scanning peripheral sites are less accurate and not used for definitive diagnosis or treatment decisions; full spine and hip DEXA is required.
+- **Machine variability** — T-score results can vary between different DEXA machines. For serial monitoring, ideally use the same machine at the same facility to ensure comparability.
+- **Artefacts** — severe scoliosis, calcified aorta, or degenerative disc disease can falsely elevate lumbar spine T-scores. Hip measurements are usually more reliable when spinal artefact is present.
+- **Severe obesity** — very high body weight may reduce scan accuracy; the hip is typically more reliable than the spine in this situation.
+
+---
+
+## Further Reading
+
+- [Healthy Bones Australia](https://www.healthybones.com.au/) — Australian consumer resource on bone health and osteoporosis (formerly Osteoporosis Australia)
+- [FRAX — Fracture Risk Assessment Tool](https://www.sheffield.ac.uk/FRAX/) — WHO-developed 10-year fracture probability calculator
+- [International Osteoporosis Foundation](https://www.osteoporosis.foundation/) — global clinical guidelines and patient resources
+- [Bone Health and Osteoporosis Foundation (US)](https://www.bonehealthandosteoporosis.org/) — comprehensive patient and clinician resources
+- [NIH — Osteoporosis Overview](https://www.niams.nih.gov/health-topics/osteoporosis) — US National Institutes of Health patient information
+
+---
+
+## Related Guides
+
+- [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Bone Density and Osteoporosis: What You Need to Know](/guides/bone-density-osteoporosis)
+- [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause)
+- [Women's Health Hub](/guides/womens-health-hub)
+- [Falls and Functional Decline](/guides/fractures-and-falls)
+- [Aging and Longevity Basics](/guides/aging-and-longevity-basics)
+
+---
+
+_Last updated: June 2026_
+
+---
+
+_This guide is for educational purposes only and is not a substitute for professional medical advice. Screening recommendations and Medicare eligibility criteria may vary. Speak with your GP about whether a DEXA scan is appropriate for you._

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -130,6 +130,7 @@ Bowel cancer is one of the most common cancers in high-income countries and one 
 Prostate-specific antigen (PSA) testing is more complex than most cancer screens. It can detect cancer early, but also leads to overdiagnosis and overtreatment of cancers that would never cause harm.
 
 - [Prostate Cancer — Guide Hub](/guides/prostate-cancer) — risk factors, the role of PSA, what an abnormal result means, and treatment decisions
+- [PSA Screening: Benefits, Risks, and Shared Decision-Making](/guides/psa-screening-benefits-risks-and-shared-decision-making) — a balanced, evidence-based guide to what PSA measures, the decision framework, false positives, overdiagnosis, and navigating an elevated result
 
 **Who should screen:** There is no universal programme for PSA screening. Most guidelines recommend an informed discussion between men aged 50–70 (or 45+ with elevated family risk or African heritage) and their clinician, weighing benefits and potential harms. PSA screening is not appropriate as a routine check without that conversation.
 
@@ -217,7 +218,7 @@ Screening needs change across the lifespan. This table summarises the most evide
 
 - Mammography screening (most national programs start at 50)
 - Bowel cancer screening begins (FIT test from 45–50)
-- Bone density testing for women (earlier after early menopause or fracture)
+- [Bone density testing (DEXA)](/guides/bone-density-testing-dexa-screening) for women (earlier after early menopause or fracture)
 - Cardiovascular risk assessment — Lp(a) testing if not done
 - PSA discussion for men
 - Annual blood pressure and cholesterol
@@ -226,7 +227,7 @@ Screening needs change across the lifespan. This table summarises the most evide
 
 - Continue all established screening (bowel, breast, cervical as appropriate)
 - Cardiovascular risk review — consider coronary artery calcium scoring
-- Bone density (DXA scan) for women and high-risk men
+- [Bone density scan (DEXA)](/guides/bone-density-testing-dexa-screening) for women and high-risk men
 - Hearing and vision checks
 - Lung cancer screening discussion for long-term smokers (low-dose CT; eligibility criteria vary by country)
 - Pneumococcal and shingles vaccination if not yet received
@@ -241,6 +242,7 @@ Women face specific screening requirements across the reproductive years, the me
 - [Cervical Screening by Age](/guides/cervical-screening-by-age) — age-specific guidance
 - [Mammography and Breast Cancer Screening](/guides/mammography-breast-screening) — when to start, what results mean
 - [Bone Density and Osteoporosis: What You Need to Know](/guides/bone-density-osteoporosis) — bone loss accelerates at menopause; DXA scanning and prevention
+- [Bone Density Testing (DEXA): Who Should Be Screened and When](/guides/bone-density-testing-dexa-screening) — how DEXA works, T-score interpretation, screening eligibility, and what to do after results
 - [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause) — cardiovascular risk rises after menopause; prevention implications
 - [Women's Health Hub](/guides/womens-health-hub) — centralised hub for all women's health content
 
@@ -251,6 +253,7 @@ Women face specific screening requirements across the reproductive years, the me
 Men face underdiagnosis across many conditions — lower rates of healthcare engagement lead to later detection of cardiovascular disease, diabetes, and prostate cancer.
 
 - [Prostate Cancer — Guide Hub](/guides/prostate-cancer) — PSA testing, what a raised result means, and how to navigate the decision
+- [PSA Screening: Benefits, Risks, and Shared Decision-Making](/guides/psa-screening-benefits-risks-and-shared-decision-making) — balanced guide to PSA testing, shared decision-making, and navigating an elevated result
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — men have higher baseline cardiovascular risk and earlier onset of disease
 - [Preventing Heart Disease](/guides/preventing-heart-disease) — practical lifestyle and screening steps
 - [Prediabetes](/guides/prediabetes) — men with abdominal obesity have high metabolic risk; fasting glucose and HbA1c

--- a/src/content/guides/prostate-cancer.md
+++ b/src/content/guides/prostate-cancer.md
@@ -76,6 +76,7 @@ A: Not completely, but lifestyle changes and regular screening help.
 ---
 
 ## Related Guides
+- [PSA Screening: Benefits, Risks, and Shared Decision-Making](/guides/psa-screening-benefits-risks-and-shared-decision-making) — detailed guide to PSA testing, overdiagnosis, shared decision-making, and navigating an elevated result.
 - [Cancer — Guide Hub](/guides/cancer) — overview of cancer types, treatment approaches, and survivorship.
 - [Genetic Testing](/guides/genetic-testing) — BRCA2 mutations are a known risk factor for prostate cancer; hereditary testing context.
 - [Testing and Screening](/guides/testing-and-screening) — PSA testing, biopsy, and how to interpret cancer screening results.

--- a/src/content/guides/psa-screening-benefits-risks-and-shared-decision-making.md
+++ b/src/content/guides/psa-screening-benefits-risks-and-shared-decision-making.md
@@ -1,0 +1,257 @@
+---
+title: "PSA Screening: Benefits, Risks, and Shared Decision-Making"
+slug: "psa-screening-benefits-risks-and-shared-decision-making"
+description: "A balanced, evidence-based guide to PSA testing for prostate cancer — covering what the test measures, potential benefits, false positives, overdiagnosis, high-risk groups, and how to approach the decision with your clinician."
+category: "Men's Health"
+publishDate: "2026-06-05"
+updatedDate: "2026-06-05"
+draft: false
+tags:
+  - PSA
+  - prostate cancer screening
+  - prostate-specific antigen
+  - shared decision-making
+  - men's health
+  - cancer screening
+  - preventive health
+  - overdiagnosis
+schema:
+  medicalCondition:
+    name: "PSA Screening"
+    description: "PSA (prostate-specific antigen) testing is a blood test used in prostate cancer screening. It measures the level of PSA — a protein produced by both normal and abnormal prostate cells — to identify men who may benefit from further investigation. PSA testing does not diagnose cancer; it indicates when further evaluation is warranted. No national screening programme for PSA exists in Australia; guidelines recommend an informed, individualised discussion between each man and his clinician."
+    alternateName:
+      - "prostate-specific antigen test"
+      - "PSA blood test"
+      - "prostate cancer screening test"
+    contagious: false
+    sameAs:
+      - "https://www.cancer.org.au/cancer-information/types-of-cancer/prostate-cancer"
+      - "https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/prostate-cancer-screening"
+faq:
+  - q: "What is a PSA test?"
+    a: "A PSA test is a simple blood test that measures the level of prostate-specific antigen — a protein produced by prostate tissue. Elevated PSA can be caused by prostate cancer, but also by benign prostate enlargement, prostate inflammation, and other factors. PSA alone does not diagnose cancer; it identifies men who may benefit from further investigation."
+  - q: "What is a normal PSA level?"
+    a: "There is no single universal 'normal' PSA threshold. PSA levels rise naturally with age. A PSA above 3–4 ng/mL is commonly used as a threshold for further assessment in Australian practice. Age-specific reference ranges are sometimes applied. A raised PSA does not confirm cancer — most men with a raised PSA do not have prostate cancer."
+  - q: "Should all men get a PSA test?"
+    a: "No national screening programme exists for PSA testing in Australia. Most guidelines recommend an informed, individual discussion with a GP — typically from age 50 for average-risk men, or from 40–45 for those with a first-degree family history of prostate cancer or African ancestry. The decision should weigh potential benefits against the risk of false positives, unnecessary procedures, and overdiagnosis."
+  - q: "What happens if my PSA is elevated?"
+    a: "An elevated PSA does not mean you have prostate cancer. Your clinician will typically consider repeating the test, reviewing contributing factors such as prostatitis or benign prostatic hyperplasia, and discussing further investigation. MRI of the prostate is now commonly used before biopsy to improve targeting and reduce unnecessary procedures. If biopsy confirms cancer, the grade and extent guide treatment decisions."
+  - q: "What is overdiagnosis in prostate cancer?"
+    a: "Overdiagnosis occurs when a cancer is detected that would never have caused symptoms or shortened the person's life. Because many prostate cancers are slow-growing, some screen-detected cancers may fall into this category. Overdiagnosed cancers, when treated, expose men to side effects — including incontinence and erectile dysfunction — without benefit. Active surveillance is now the recommended approach for many low-risk cancers."
+  - q: "Can I choose not to have a PSA test?"
+    a: "Yes. PSA testing is a personal decision that you make with your clinician after understanding the trade-offs. If you decide not to be tested, that is a valid choice. Some men prefer to wait until symptoms arise. Shared decision-making means the decision belongs to you, informed by your risk profile, values, and the best available evidence."
+---
+
+## What Is PSA?
+
+Prostate-specific antigen (PSA) is a protein produced by cells in the prostate gland — both normal cells and cancerous ones. A small amount of PSA normally enters the bloodstream. A blood test measures this level in nanograms per millilitre (ng/mL).
+
+PSA is not specific to cancer. It can be elevated by a range of conditions:
+
+- Benign prostatic hyperplasia (BPH — non-cancerous prostate enlargement)
+- Prostatitis (prostate inflammation or infection)
+- Prostate cancer
+- Recent ejaculation (within 24–48 hours)
+- Vigorous exercise, particularly cycling
+- Urinary tract infection
+- Recent prostate biopsy or urinary instrumentation
+
+Because of this, PSA is a **marker for further investigation**, not a diagnostic test. A raised PSA tells you something may need looking at — it does not tell you what that something is.
+
+---
+
+## Key Points
+
+- PSA is a protein produced by the prostate; elevated levels may indicate cancer but also many benign conditions.
+- No national PSA screening programme exists in Australia; testing is based on informed individual discussion with a clinician.
+- Average-risk men are generally advised to consider the discussion from age 50; earlier for those with a family history of prostate cancer or African ancestry.
+- PSA screening can detect prostate cancer earlier — but also leads to overdiagnosis of cancers that would never cause harm.
+- Most men with a raised PSA do not have prostate cancer on biopsy.
+- Overtreatment of low-risk cancers causes significant side effects — incontinence and erectile dysfunction — without survival benefit.
+- Active surveillance — monitoring without immediate treatment — is now standard for many low-risk prostate cancers.
+- Shared decision-making, not universal recommendation, is the appropriate framework for PSA screening.
+
+---
+
+## What the PSA Test Involves
+
+The PSA test is a simple blood draw. No special preparation is required beyond avoiding vigorous exercise and sexual activity in the 24–48 hours beforehand. Results are typically available within a few days.
+
+**Factors that can falsely elevate PSA:**
+- Recent ejaculation
+- Recent vigorous cycling or perineal pressure
+- Digital rectal examination (DRE) within 24–48 hours of the test
+- Prostatitis or urinary tract infection
+- Urinary catheterisation or recent prostate procedure
+
+If any of these apply, the test may be deferred or the result interpreted with that context noted.
+
+---
+
+## PSA Levels and Age
+
+There is no universal cut-off for a "normal" PSA. PSA rises naturally as the prostate enlarges with age. Most Australian and international guidelines use **3.0–4.0 ng/mL** as a common threshold for further investigation, though interpretation is always clinical and individualised.
+
+| Age | PSA Level Where Further Assessment Is Often Considered |
+|---|---|
+| Under 50 | > 2.5 ng/mL |
+| 50–59 | > 3.0 ng/mL |
+| 60–69 | > 4.0 ng/mL |
+| 70 and over | Individualised; benefits of further investigation weigh less with advancing age |
+
+These figures are approximate guides, not diagnostic cut-offs. A PSA just below these levels does not exclude cancer; a PSA just above does not confirm it.
+
+---
+
+## Benefits of PSA Screening
+
+The European Randomised Study of Screening for Prostate Cancer (ERSPC) — one of the largest and longest-running trials — demonstrated that PSA screening can reduce prostate cancer mortality. At median follow-up of approximately 16 years, men in the screened group had around a **20% lower risk of dying from prostate cancer** compared with the unscreened group.
+
+Observational data from countries with widely adopted PSA testing have documented declines in late-stage prostate cancer diagnoses and prostate cancer deaths over time.
+
+**Specific potential benefits:**
+- Detection of cancer while it is still localised to the prostate, when curative treatment is most effective
+- Greater treatment options for organ-confined disease
+- Earlier identification of men with aggressive cancer who benefit most from treatment
+- Potential reduction in prostate cancer-specific mortality for men who would otherwise progress to advanced disease
+
+---
+
+## Risks and Limitations
+
+PSA screening is more complex than most cancer screening tests because the balance between benefits and harms is narrower and more contested.
+
+### False Positives
+
+A PSA above the threshold does not mean cancer is present. Most men with an elevated PSA do not have cancer on biopsy. False positives:
+
+- Cause significant anxiety
+- Lead to repeat blood tests and MRI
+- May result in prostate biopsy, which carries risks including infection, bleeding, and discomfort
+- In major screening trials, approximately **70–75% of men who underwent biopsy for elevated PSA did not have cancer**
+
+### Overdiagnosis
+
+Not all prostate cancers detected through PSA screening are clinically important. Autopsy studies have found prostate cancer in up to 40–60% of men who died of unrelated causes — meaning many prostate cancers never progress to cause symptoms or death.
+
+Estimates suggest that **20–50% of screen-detected prostate cancers** may represent overdiagnosis — cancers that would never have become symptomatic in the person's lifetime. The range is wide because defining overdiagnosis precisely is methodologically difficult.
+
+### Overtreatment
+
+When a cancer is detected, treatment has historically tended to follow — even for low-risk disease. Surgery (radical prostatectomy) and radiotherapy both carry meaningful side effect risks:
+
+- **Urinary incontinence:** affects 10–30% of men after radical surgery
+- **Erectile dysfunction:** affects 40–70% of men after surgery or radiotherapy
+- Bowel symptoms after pelvic radiotherapy
+- Anaesthetic and surgical complications
+
+Active surveillance has substantially reduced overtreatment of low-risk cancers, but overtreatment remains a recognised harm of the screening pathway.
+
+### Placing the Numbers in Context
+
+Using ERSPC trial data, for every 1,000 men screened over 13–16 years:
+- Approximately **1–2 prostate cancer deaths** may be prevented
+- Approximately **100–200 men** will have at least one false-positive PSA requiring further investigation
+- Approximately **5–10 men** will be diagnosed with a cancer that would never have caused harm (overdiagnosis)
+- Approximately **2–5 men** may experience lasting side effects from treatment of an overdiagnosed cancer
+
+These figures explain why PSA screening is not straightforwardly beneficial or harmful — and why the decision genuinely belongs to the individual, not to population-wide guidance.
+
+---
+
+## Understanding the Pathway After an Elevated PSA
+
+A single elevated PSA does not immediately lead to biopsy. The modern pathway is more nuanced:
+
+1. **Repeat PSA** — typically repeated after 4–6 weeks, avoiding confounding factors listed above
+2. **Clinical assessment** — digital rectal examination, symptom review, assessment for prostatitis or BPH
+3. **Multiparametric MRI (mpMRI)** — now commonly recommended before biopsy; identifies suspicious areas, reduces unnecessary biopsies, and improves targeting
+4. **PSA variants** — free-to-total PSA ratio, PSA density (PSA adjusted for prostate volume), and PSA velocity may add information; higher free PSA proportion is associated with benign disease
+5. **Targeted biopsy** — if MRI identifies a suspicious lesion, MRI-guided biopsy improves accuracy over systematic sampling alone
+6. **Grading** — if cancer is found, the Gleason score (or ISUP grade group) classifies aggressiveness and guides management decisions
+
+---
+
+## High-Risk Groups
+
+Certain men face a substantially higher lifetime risk of prostate cancer and benefit from earlier, more proactive discussion about PSA testing:
+
+| Group | Risk Consideration |
+|---|---|
+| **First-degree family history** (father or brother diagnosed with prostate cancer) | Approximately 2–3× increased lifetime risk; discussion from age 45 |
+| **Two or more affected first-degree relatives** | Higher cumulative risk; discussion from age 40–45 |
+| **African or African-Caribbean ancestry** | Higher incidence and higher risk of aggressive disease; discussion from age 40–45 |
+| **BRCA2 pathogenic variant carriers** | Significantly elevated risk of aggressive prostate cancer; specialist review recommended |
+| **BRCA1 pathogenic variant carriers** | Moderately elevated risk; individualised discussion warranted |
+
+Men in these groups benefit from a specific, proactive discussion with their GP or a urologist — not simply opportunistic testing without context.
+
+---
+
+## Shared Decision-Making
+
+PSA screening is one of medicine's clearest examples of a test that requires genuine informed choice rather than a straightforward recommendation to act or to abstain.
+
+A useful shared decision-making conversation covers:
+
+**What you are hoping to achieve:**
+- Reassurance that cancer is not present?
+- Earlier detection to maximise treatment options if cancer is found?
+- A baseline PSA to monitor over time?
+
+**What you are weighing:**
+- Comfort with uncertainty and follow-up procedures if PSA is elevated
+- Attitude to the possibility of finding a cancer that may never have caused harm
+- Awareness of treatment side effects if early-stage cancer is found and treated
+
+**A practical framework for the conversation:**
+1. Understand what a raised PSA result would trigger — repeat test, MRI, possible biopsy
+2. Understand the likelihood that a raised result will not be cancer
+3. Understand active surveillance as the standard approach for low-risk, localised disease
+4. Make the decision in light of your values and risk tolerance, not just statistics alone
+
+PSA screening is neither universally beneficial nor universally harmful. An informed, individual conversation with a GP who takes the time to explain the evidence is the appropriate standard — not a rushed blood test order, and not a dismissive refusal to discuss it.
+
+---
+
+## Australian Context
+
+Australia has **no national organised PSA screening programme**. PSA testing occurs opportunistically — initiated by the man, their GP, or as part of a broader men's health check.
+
+**Key guidance in Australia:**
+
+- The **RACGP** (Royal Australian College of General Practitioners) recommends that GPs neither routinely offer nor routinely discourage PSA testing. It supports an informed discussion for men aged 50–69 who wish to consider testing, and from age 45 for men with elevated family risk or African ancestry.
+- **Cancer Council Australia** does not recommend population-wide PSA screening. It supports informed decision-making, noting that the available evidence shows a modest reduction in prostate cancer mortality balanced against significant potential harms.
+- **Cancer Australia** endorses the shared decision-making model and does not recommend universal testing.
+
+**Medicare:** A Medicare rebate applies to PSA testing in Australia. Testing is available through your GP as part of a standard consultation and pathology request.
+
+---
+
+## Further Reading
+
+- [Cancer Council Australia — Prostate Cancer](https://www.cancer.org.au/cancer-information/types-of-cancer/prostate-cancer) — Australian patient information on prostate cancer and PSA testing
+- [Cancer Australia — Prostate Cancer](https://www.canceraustralia.gov.au/cancer-types/prostate-cancer/) — Australian government cancer authority guidance
+- [RACGP — Guidelines for Preventive Activities in General Practice](https://www.racgp.org.au/clinical-resources/clinical-guidelines/key-racgp-guidelines/view-all-racgp-guidelines/red-book) — Australian general practice preventive care guidance (Red Book)
+- [USPSTF — Prostate Cancer Screening (2018)](https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/prostate-cancer-screening) — US Preventive Services Task Force recommendation (grade C for men aged 55–69)
+- [NCI — Prostate Cancer Screening (PDQ)](https://www.cancer.gov/types/prostate/patient/prostate-screening-pdq) — US National Cancer Institute patient information
+- [Prostate Cancer Foundation of Australia](https://www.pcfa.org.au/) — Australian patient support and advocacy
+
+---
+
+## Related Guides
+
+- [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Prostate Cancer — Guide Hub](/guides/prostate-cancer)
+- [Benign Prostatic Hyperplasia (BPH): Symptoms, Diagnosis, and Treatment](/guides/benign-prostatic-hyperplasia-bph)
+- [Cancer — Guide Hub](/guides/cancer)
+- [Genetic Testing: What It Can and Can't Tell You](/guides/genetic-testing)
+- [Testing and Screening — Guide Hub](/guides/testing-and-screening)
+
+---
+
+_Last updated: June 2026_
+
+---
+
+_This guide is for educational purposes only and is not a substitute for professional medical advice. PSA screening decisions are highly individual. Speak with your GP about whether PSA testing is appropriate for you._

--- a/src/content/guides/womens-health-hub.md
+++ b/src/content/guides/womens-health-hub.md
@@ -95,6 +95,9 @@ Ovarian cancer is often diagnosed late because its symptoms are non-specific. Co
 ### [Bone Density and Osteoporosis: What You Need to Know](/guides/bone-density-osteoporosis)
 Bone loss accelerates dramatically at menopause, with women losing 10–20% of bone mineral density in the decade around the transition. Covers bone density testing (DEXA), interpreting your T-score, and preventing and treating osteoporosis.
 
+### [Bone Density Testing (DEXA): Who Should Be Screened and When](/guides/bone-density-testing-dexa-screening)
+A practical guide to the DEXA scan itself — how it works, what T-scores mean, which women should be screened and at what age, risk factors that bring forward the recommended age, and what to do after your results.
+
 ### [Bone Health Basics](/guides/bone-health-basics)
 The nutritional, hormonal, and physical activity foundations of lifelong bone health — most relevant for women approaching and beyond menopause.
 


### PR DESCRIPTION
## Summary

- Adds PSA Screening: Benefits, Risks, and Shared Decision-Making (Men's Health) — covers PSA biology, ERSPC evidence, false positives, overdiagnosis, biopsy pathway, high-risk groups, shared decision-making, and Australian context (RACGP, Cancer Council Australia, Cancer Australia)
- Adds Bone Density Testing (DEXA): Who Should Be Screened and When (Aging and Longevity) — covers how DEXA works, T-score/Z-score interpretation, WHO diagnostic categories, FRAX tool, screening eligibility, menopausal bone loss, steroid risk, and Healthy Bones Australia guidance
- Cross-links added to: preventive-screening-hub (5 additions), prostate-cancer, bone-density-osteoporosis, womens-health-hub

## Test plan

- npm run content:check passed — 0 errors
- npm run build succeeded — 723 pages built, 725 indexed
- Both slugs confirmed unique before creation
- Valid category enums: Men's Health and Aging and Longevity
- publishDate and updatedDate: 2026-06-05, draft: false on both
- All cross-links verified against existing slug paths
- Australian English throughout
- FAQ items in frontmatter on both guides

Generated with Claude Code https://claude.com/claude-code