### PR TITLE
feat(heart): add cardiomyopathy and valve disease guides

### DIFF
--- a/src/content/guides/atrial-fibrillation.md
+++ b/src/content/guides/atrial-fibrillation.md
@@ -161,6 +161,8 @@ Catheter ablation restores normal rhythm in many people, particularly with parox
 ## Related Guides
 
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
 - [Common Heart Medications and Their Side Effects](/guides/common-heart-medications)
 - [Heart Attack Treatment — Emergency Care, Procedures, and Recovery](/guides/heart-attack-treatment)
 - [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)

--- a/src/content/guides/cardiac-rehabilitation.md
+++ b/src/content/guides/cardiac-rehabilitation.md
@@ -438,10 +438,13 @@ will advise individually.
 - [Heart Attack Treatment — What to Expect](/guides/heart-attack-treatment)
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
 - [Living With Heart Failure: Daily Care, Medicines, and Monitoring](/guides/living-with-heart-failure)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
 - [Heart Circulation and Coronary Artery Disease](/guides/heart-circulation)
 - [Common Heart Medications and Their Side Effects](/guides/common-heart-medications)
 - [Preventing Heart Disease — Lifestyle and Medical Screening](/guides/preventing-heart-disease)
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
+- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
 - [Stroke Recovery](/guides/stroke-symptoms-fast-response)
 
 ---

--- a/src/content/guides/cardiomyopathy-overview.md
+++ b/src/content/guides/cardiomyopathy-overview.md
@@ -1,0 +1,368 @@
+---
+title: "Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment"
+slug: "cardiomyopathy-overview"
+description: "A patient guide to cardiomyopathy — disease of the heart muscle. Covers dilated, hypertrophic, and restrictive types, common symptoms, causes including genetics and alcohol, diagnosis with ECG and cardiac MRI, and treatment options including medicines and ICDs."
+category: "Heart & Circulation"
+publishDate: "2026-06-07"
+updatedDate: "2026-06-07"
+draft: false
+tags:
+  - cardiomyopathy
+  - dilated cardiomyopathy
+  - hypertrophic cardiomyopathy
+  - heart failure
+  - cardiology
+  - arrhythmia
+  - ICD
+  - patientguide
+schema:
+  medicalCondition:
+    name: "Cardiomyopathy"
+    description: "Cardiomyopathy is a group of diseases of the heart muscle in which the myocardium becomes structurally and functionally abnormal, impairing the heart's ability to pump blood effectively. It may cause heart failure, arrhythmias, and sudden cardiac death."
+    alternateName:
+      - "Dilated cardiomyopathy"
+      - "Hypertrophic cardiomyopathy"
+      - "Restrictive cardiomyopathy"
+      - "DCM"
+      - "HCM"
+    riskFactors:
+      - "Family history of cardiomyopathy or sudden cardiac death"
+      - "Genetic mutations affecting heart muscle proteins"
+      - "Excessive alcohol use"
+      - "Viral myocarditis"
+      - "Chemotherapy (anthracyclines, trastuzumab)"
+      - "Autoimmune and inflammatory diseases"
+      - "Uncontrolled hypertension"
+    symptoms:
+      - "Shortness of breath on exertion or at rest"
+      - "Fatigue and reduced exercise tolerance"
+      - "Palpitations (irregular or rapid heartbeat)"
+      - "Dizziness or light-headedness"
+      - "Ankle and leg swelling"
+      - "Chest pain or pressure"
+      - "Fainting or near-fainting"
+    possibleComplication:
+      - "Heart failure"
+      - "Atrial fibrillation and other arrhythmias"
+      - "Sudden cardiac death"
+      - "Blood clots and stroke"
+      - "Cardiac transplantation in advanced disease"
+    contagious: false
+    sameAs:
+      - "https://www.nhs.uk/conditions/cardiomyopathy/"
+      - "https://medlineplus.gov/cardiomyopathy.html"
+faq:
+  - q: "What is cardiomyopathy?"
+    a: "Cardiomyopathy is a disease of the heart muscle itself. Unlike heart disease caused by blocked coronary arteries, cardiomyopathy arises from structural and functional problems within the heart muscle — making it enlarged, thickened, or stiff. This impairs the heart's ability to pump blood efficiently and can lead to heart failure and dangerous arrhythmias."
+  - q: "Is cardiomyopathy the same as heart failure?"
+    a: "They are closely related but not the same. Cardiomyopathy is a disease of the heart muscle; heart failure is the clinical syndrome that results when the heart cannot pump enough blood to meet the body's needs. Cardiomyopathy is one of the most common causes of heart failure — but heart failure can also be caused by coronary artery disease, high blood pressure, and valve disease."
+  - q: "Is cardiomyopathy hereditary?"
+    a: "Many forms have a genetic component. Hypertrophic cardiomyopathy is caused by inherited mutations in cardiac sarcomere protein genes in around 50–60% of cases. Dilated cardiomyopathy is familial in at least 30–40% of cases. If you are diagnosed with cardiomyopathy, your doctor may recommend genetic testing and screening of first-degree family members."
+  - q: "Can cardiomyopathy be cured?"
+    a: "In some cases the cause can be treated and the heart muscle partially or fully recovers — for example, cardiomyopathy caused by alcohol, chemotherapy, or tachycardia. In most cases cardiomyopathy is managed rather than cured — the goal is to relieve symptoms, prevent complications, and slow disease progression. Some people require heart transplantation in advanced disease."
+  - q: "What is the difference between dilated and hypertrophic cardiomyopathy?"
+    a: "In dilated cardiomyopathy (DCM), the left ventricle becomes enlarged and weakened, reducing ejection fraction. In hypertrophic cardiomyopathy (HCM), the heart muscle — particularly the interventricular septum — becomes abnormally thickened, impairing filling and pumping. DCM commonly causes heart failure with reduced ejection fraction; HCM more typically causes outflow obstruction and risk of sudden cardiac death."
+  - q: "Who needs an implantable defibrillator (ICD) for cardiomyopathy?"
+    a: "An ICD is recommended for people with cardiomyopathy who have a significantly reduced ejection fraction (typically below 35%) despite optimal medical therapy, and for those who have survived a life-threatening arrhythmia. In hypertrophic cardiomyopathy, ICD implantation is considered for those at high estimated risk of sudden cardiac death based on a guideline-based risk score. Your cardiologist will determine whether an ICD is appropriate for your situation."
+---
+
+# Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment
+
+**Cardiomyopathy** is a disease of the heart muscle — a condition in which the heart muscle itself becomes structurally or functionally abnormal, impairing the heart's ability to pump blood effectively. It is one of the most important causes of [heart failure](/guides/heart-failure-overview), arrhythmias, and sudden cardiac death, and can affect people of all ages, including children and young adults.
+
+Unlike coronary artery disease — which is caused by blockages in the arteries supplying the heart — cardiomyopathy arises from within the heart muscle itself. Understanding which type you have, and why it has developed, is central to getting the right treatment.
+
+---
+
+## What Is Cardiomyopathy?
+
+The heart is a muscular pump. In cardiomyopathy, that muscle becomes diseased — whether by becoming enlarged and weak, excessively thickened, or abnormally stiff. Each of these changes impairs how efficiently the heart pumps blood to the body and lungs.
+
+Cardiomyopathy is classified into three main types based on the structural change in the heart muscle.
+
+---
+
+## Types of Cardiomyopathy
+
+### Dilated Cardiomyopathy (DCM)
+
+The most common type. The left ventricle (the main pumping chamber) becomes enlarged and weakened, losing its ability to contract powerfully. The ejection fraction — the percentage of blood pumped out with each beat — is reduced, typically below 40%.
+
+**Key features:**
+- Enlarged, poorly contracting left ventricle
+- Reduced ejection fraction, classified as heart failure with reduced ejection fraction (HFrEF)
+- Risk of blood clot formation within the dilated chamber
+- Progressive heart failure symptoms: breathlessness, fatigue, ankle swelling
+
+**Common causes:**
+- Genetic mutations (familial DCM — present in 30–40% of cases)
+- Prior viral myocarditis (inflammation of the heart muscle following infection)
+- Excessive alcohol use (alcoholic cardiomyopathy)
+- Chemotherapy — particularly anthracyclines (doxorubicin, epirubicin) and trastuzumab (Herceptin)
+- Peripartum cardiomyopathy (developing in late pregnancy or within five months of delivery)
+- Idiopathic (no identifiable cause found, in approximately a third of cases)
+
+---
+
+### Hypertrophic Cardiomyopathy (HCM)
+
+The second most common type and the most common inherited heart disease, affecting approximately 1 in 500 people. The heart muscle — particularly the interventricular septum (the wall between the two ventricles) — becomes abnormally thickened. This makes it harder for the heart to fill and, in some cases, creates obstruction to blood flowing out of the heart.
+
+**Key features:**
+- Thickened heart muscle, typically the septum
+- Usually normal or elevated ejection fraction — the heart contracts well but fills poorly
+- Outflow obstruction in approximately two-thirds of people (hypertrophic obstructive cardiomyopathy, HOCM)
+- Risk of dangerous arrhythmias and sudden cardiac death, particularly in young people and athletes
+- Frequently runs in families; often first detected in adolescence or early adulthood
+
+**Causes:**
+- Mutations in genes encoding sarcomere proteins (the contractile machinery of heart muscle cells) — identified in approximately 50–60% of cases
+- In many cases a genetic mutation is found and targeted family screening becomes possible
+
+---
+
+### Restrictive Cardiomyopathy
+
+The least common of the primary types. The heart muscle becomes abnormally stiff, limiting its ability to relax and fill properly between beats. Ejection fraction may be initially preserved, but the high filling pressures cause symptoms similar to heart failure.
+
+**Key features:**
+- Stiff, non-compliant heart muscle
+- Impaired filling — high pressures behind the heart, causing fluid back-up into the lungs
+- Symptoms of heart failure despite relatively normal ejection fraction
+- Can be difficult to distinguish from constrictive pericarditis
+
+**Common causes:**
+- Cardiac amyloidosis — accumulation of abnormal protein (amyloid) deposits in the heart muscle; cardiac transthyretin amyloidosis (ATTR-CM) is increasingly recognised in older adults with unexplained thickened heart walls and is now a focus of specific drug therapy
+- Haemochromatosis (iron overload)
+- Sarcoidosis (inflammatory disease affecting multiple organs)
+- Post-radiotherapy cardiac fibrosis
+
+---
+
+### Other Types
+
+- **Arrhythmogenic cardiomyopathy (ACM)** — fatty or fibrous tissue replaces heart muscle, predominantly in the right ventricle, causing arrhythmias and risk of sudden cardiac death; strongly associated with mutations in desmosomal protein genes
+- **Peripartum cardiomyopathy** — dilated cardiomyopathy presenting in late pregnancy or within five months of delivery; many women recover fully with early treatment, but some develop persistent heart failure
+- **Left ventricular non-compaction (LVNC)** — a developmental abnormality producing an abnormal spongy appearance of the heart muscle; can cause heart failure and arrhythmias
+
+---
+
+## Symptoms
+
+Cardiomyopathy can be present for years before symptoms develop. When they appear, they reflect the heart's reduced ability to pump efficiently.
+
+**Common symptoms include:**
+
+- **Shortness of breath** — on exertion initially, progressing to breathlessness at rest in advanced disease; waking at night breathless (paroxysmal nocturnal dyspnoea); needing extra pillows to sleep (orthopnoea)
+- **Fatigue and reduced exercise tolerance** — persistent tiredness, inability to sustain physical activity
+- **Palpitations** — an awareness of the heartbeat; may represent atrial fibrillation, benign ectopic beats, or more dangerous ventricular arrhythmias
+- **Dizziness or light-headedness** — particularly on exertion or standing; may reflect low blood pressure or arrhythmia
+- **Ankle and leg swelling** — fluid accumulation (oedema) from heart failure
+- **Chest pain or pressure** — can occur in hypertrophic cardiomyopathy due to increased wall stress and impaired filling
+- **Fainting (syncope) or near-fainting** — particularly important in hypertrophic cardiomyopathy; may indicate a dangerous arrhythmia and warrants urgent assessment
+
+**In hypertrophic cardiomyopathy:** symptoms often worsen with exertion or after meals. Some people experience exertional chest pain mimicking angina.
+
+**Seek emergency care immediately** for sudden collapse, loss of consciousness, severe chest pain, or a rapid pounding heartbeat with dizziness.
+
+---
+
+## Causes
+
+### Genetic Causes
+
+- **Hypertrophic cardiomyopathy:** most commonly caused by inherited mutations in sarcomere protein genes (MYH7, MYBPC3, and others); autosomal dominant pattern — a 50% chance of passing the mutation to each child
+- **Dilated cardiomyopathy:** familial in at least 30–40% of cases; multiple genes implicated (TTN, LMNA, SCN5A, and others); family screening is recommended after diagnosis
+- **Arrhythmogenic cardiomyopathy:** strongly genetic (PKP2 and other desmosomal protein genes)
+
+### Lifestyle and Acquired Causes
+
+- **Excessive alcohol use** — one of the most common reversible causes of dilated cardiomyopathy; alcoholic cardiomyopathy can improve significantly with abstinence
+- **Viral myocarditis** — inflammation of the heart muscle following viral infection (including enteroviruses, parvovirus B19); may progress to dilated cardiomyopathy
+- **Chemotherapy and cardiotoxic medicines** — anthracycline chemotherapy, trastuzumab, and certain other cancer drugs can cause dilated cardiomyopathy; risk is related to cumulative dose and is monitored with echocardiography during and after treatment
+
+### Infiltrative and Inflammatory Causes
+
+- **Cardiac amyloidosis** — accumulation of misfolded protein in the heart muscle; increasingly recognised in older adults with unexplained thickened heart walls and heart failure; tafamidis (for ATTR type) is now an approved treatment
+- **Sarcoidosis** — granulomatous inflammation affecting the heart; can cause arrhythmias, heart block, and heart failure
+- **Haemochromatosis** — iron overload causing restrictive cardiomyopathy; treatable with phlebotomy
+
+---
+
+## Diagnosis
+
+Cardiomyopathy is diagnosed using a combination of clinical assessment and investigations. If cardiomyopathy is suspected — from symptoms, family history, or an abnormal ECG — referral to a cardiologist is appropriate.
+
+### ECG (Electrocardiogram)
+Often abnormal, though findings are non-specific and vary by type:
+- Hypertrophic cardiomyopathy: commonly shows ST changes, deep Q waves, and signs of left ventricular hypertrophy
+- Dilated cardiomyopathy: may show bundle branch block, ST changes, or atrial fibrillation
+- Arrhythmogenic cardiomyopathy: may show epsilon waves or right bundle branch block
+
+### Echocardiogram (Heart Ultrasound)
+The most important initial investigation:
+- Measures the size and function of the heart chambers
+- Assesses ejection fraction (reduced vs preserved)
+- Measures wall thickness, identifying hypertrophy characteristic of HCM
+- Detects outflow tract obstruction in hypertrophic cardiomyopathy
+- Assesses valve function and filling pressures
+
+### Cardiac MRI
+The gold standard for characterising heart muscle abnormalities:
+- Provides detailed assessment of wall motion, fibrosis, and infiltration
+- Gadolinium late enhancement identifies areas of scarring — important for risk stratification in HCM and DCM
+- Distinguishes between different causes (amyloid, sarcoidosis, myocarditis, HCM)
+- Used in arrhythmogenic cardiomyopathy diagnosis and monitoring
+
+### Blood Tests
+- BNP or NT-proBNP — markers of heart strain, elevated in heart failure caused by cardiomyopathy
+- Full blood count, renal and liver function, thyroid function
+- Iron studies and ferritin — to exclude haemochromatosis
+- Troponin — elevated in myocarditis and some restrictive cardiomyopathies
+- Specific tests for amyloidosis (TTR gene analysis, technetium pyrophosphate scintigraphy)
+
+### Genetic Testing
+Genetic testing is increasingly used to:
+- Identify the underlying mutation in hypertrophic or dilated cardiomyopathy
+- Guide family screening
+- Assist risk stratification (some mutations in DCM, such as LMNA, carry higher arrhythmia risk)
+
+If a pathogenic mutation is confirmed, first-degree relatives (parents, siblings, children) should be offered screening — each has up to a 50% chance of carrying the same variant.
+
+### Holter Monitor / Event Recorder
+Continuous ECG recording over 24–48 hours or longer — detects arrhythmias not captured on a standard resting ECG. Important in HCM (arrhythmia risk assessment) and arrhythmogenic cardiomyopathy.
+
+### Exercise Stress Testing
+- Assesses functional capacity
+- In HCM: measures blood pressure response to exercise (an abnormal response signals higher risk)
+- Detects exercise-induced arrhythmias
+
+---
+
+## Treatment
+
+Treatment depends on the type of cardiomyopathy, its severity, and the underlying cause.
+
+### Medicines
+
+**For dilated cardiomyopathy with reduced ejection fraction:**
+The same evidence-based heart failure medicines apply:
+- **ACE inhibitors or ARBs** (e.g. ramipril, candesartan) — reduce cardiac workload, protect heart function, and reduce fibrosis
+- **Beta blockers** (e.g. bisoprolol, carvedilol) — reduce heart rate, protect against arrhythmias, and improve ejection fraction over time
+- **Mineralocorticoid receptor antagonists (MRAs)** (e.g. spironolactone, eplerenone) — reduce fluid retention and cardiac fibrosis
+- **SGLT2 inhibitors** (e.g. dapagliflozin, empagliflozin) — proven to reduce hospitalisations and improve outcomes in heart failure
+- **Diuretics** — relieve fluid build-up and breathlessness (symptom control)
+
+See also: [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+
+**For hypertrophic cardiomyopathy:**
+- **Beta blockers** — reduce heart rate, improve filling time, and reduce outflow obstruction
+- **Non-dihydropyridine calcium channel blockers** (e.g. verapamil) — alternative for those who cannot tolerate beta blockers
+- **Mavacamten** — a novel cardiac myosin inhibitor approved specifically for obstructive HCM (HOCM); reduces outflow obstruction and improves symptoms and exercise capacity; available in Australia under specific criteria
+
+**For cardiac amyloidosis (ATTR type):**
+- **Tafamidis** — a TTR stabiliser proven to reduce mortality and hospitalisation in ATTR cardiomyopathy; available in Australia under specific criteria
+- Other emerging agents (diflunisal, patisiran, RNA interference therapies) are available in specialist centres
+
+**For alcoholic cardiomyopathy:**
+- **Alcohol abstinence** — the most important intervention; the heart muscle can recover substantially if alcohol use is stopped early
+
+### Implantable Cardioverter-Defibrillator (ICD)
+
+An ICD is a device implanted under the skin that continuously monitors heart rhythm and delivers a shock to restore normal rhythm if a dangerous arrhythmia is detected.
+
+ICDs are recommended for:
+- Dilated or other cardiomyopathies with severely reduced ejection fraction (typically below 35%) after at least three months of optimal medical therapy
+- Survivors of sudden cardiac arrest or sustained ventricular tachycardia
+- Hypertrophic cardiomyopathy with high estimated five-year risk of sudden cardiac death (calculated using an ESC risk model incorporating family history, degree of hypertrophy, and arrhythmia history)
+- Arrhythmogenic cardiomyopathy with significant structural involvement or sustained arrhythmias
+
+### Cardiac Resynchronisation Therapy (CRT)
+
+In dilated cardiomyopathy with bundle branch block, where the two ventricles contract out of sync, CRT uses a specialised pacemaker to coordinate ventricular contraction. This improves ejection fraction, reduces symptoms, and reduces mortality. It is often combined with ICD function (CRT-D).
+
+### Septal Reduction for Obstructive Hypertrophic Cardiomyopathy
+
+When symptoms persist in hypertrophic obstructive cardiomyopathy despite medicines, two procedures can reduce the outflow obstruction:
+- **Surgical myectomy** — surgical removal of excess septal muscle; the preferred option at specialist centres and in younger patients
+- **Alcohol septal ablation** — controlled injection of alcohol into a septal artery causing localised infarction of the obstructing muscle; an alternative for patients unsuitable for surgery
+
+### Lifestyle
+
+- **Alcohol abstinence** — essential in alcoholic cardiomyopathy; important across all types as alcohol worsens heart muscle function
+- **Exercise** — generally encouraged in dilated cardiomyopathy with appropriate guidance; [cardiac rehabilitation](/guides/cardiac-rehabilitation) programmes are highly recommended. In hypertrophic cardiomyopathy, competitive sport and high-intensity exercise are typically restricted due to arrhythmia risk; discuss your specific limits with your cardiologist
+- **Salt and fluid restriction** — as for heart failure, when fluid retention is present
+- **Genetic counselling** — for those with inherited cardiomyopathies; important for family planning and family screening decisions
+
+### Heart Transplantation
+
+In advanced cardiomyopathy not responding to medical and device therapy, heart transplantation may be considered. Left ventricular assist devices (LVADs) can bridge patients to transplantation or serve as long-term destination therapy.
+
+---
+
+## Relationship to Heart Failure
+
+Cardiomyopathy is one of the most common causes of heart failure. When the heart muscle is diseased:
+- In dilated cardiomyopathy, the weakened ventricle cannot pump enough blood → heart failure with reduced ejection fraction (HFrEF)
+- In hypertrophic and restrictive cardiomyopathy, the stiff or poorly-filling ventricle leads to raised filling pressures → heart failure symptoms despite normal or preserved ejection fraction
+
+The treatment overlap is substantial — medicines proven to reduce mortality in heart failure (ACE inhibitors, beta blockers, MRAs, SGLT2 inhibitors) are also the main pharmacological treatment for dilated cardiomyopathy.
+
+See: [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+
+---
+
+## Relationship to Arrhythmias
+
+Cardiomyopathy significantly increases the risk of:
+- **Atrial fibrillation (AF)** — very common in both dilated and hypertrophic cardiomyopathy; the dilated, fibrotic atria provide the substrate for AF, which in turn worsens heart failure
+- **Ventricular tachycardia and fibrillation** — life-threatening arrhythmias that can cause sudden cardiac death; particularly important in arrhythmogenic cardiomyopathy and HCM
+- **Sudden cardiac death** — HCM is the most common cause of sudden cardiac death in young people and competitive athletes
+
+In all types of cardiomyopathy, arrhythmia monitoring and individualised risk assessment are important parts of ongoing management.
+
+See: [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
+
+---
+
+## FAQ
+
+**Q: Can cardiomyopathy go away?**
+Some types can substantially improve with treatment. Alcoholic cardiomyopathy often recovers significantly with abstinence. Peripartum cardiomyopathy recovers fully in around 50% of cases. Myocarditis-related cardiomyopathy can also resolve. However, genetic forms of HCM and many cases of DCM are lifelong conditions requiring ongoing management.
+
+**Q: Can I exercise with cardiomyopathy?**
+This depends on the type and severity. For dilated cardiomyopathy, supervised exercise and cardiac rehabilitation are generally recommended and improve outcomes. For hypertrophic cardiomyopathy, competitive sport and high-intensity exercise are typically restricted due to arrhythmia risk. Always discuss your specific exercise plan with your cardiologist before changing your activity.
+
+**Q: Should my family be tested if I have cardiomyopathy?**
+If a genetic cause is identified, first-degree relatives — parents, siblings, and children — should be offered clinical and, where appropriate, genetic screening. Even if no genetic cause is found, clinical screening of close family members is recommended for dilated and hypertrophic cardiomyopathy. Your cardiologist will guide the screening process.
+
+**Q: What happens at a cardiomyopathy specialist appointment?**
+Your cardiologist will review symptoms, medications, and recent investigations. For HCM, this typically includes a repeat echocardiogram, a Holter monitor, and exercise testing to assess arrhythmia risk. For DCM, follow-up focuses on echocardiographic response to treatment, medication optimisation, and ICD review if applicable. Specialist cardiomyopathy centres provide multidisciplinary review including genetic counselling services.
+
+**Q: Is pregnancy safe with cardiomyopathy?**
+Pregnancy places significant additional demands on the heart. Women with dilated cardiomyopathy or prior peripartum cardiomyopathy with incomplete recovery require pre-conception counselling and specialist cardio-obstetric monitoring throughout pregnancy. In hypertrophic cardiomyopathy, most women tolerate pregnancy well with appropriate monitoring. Individual risk varies — always discuss pregnancy planning with your cardiologist.
+
+---
+
+## Further Reading
+
+- [ESC 2023 Guidelines for the Management of Cardiomyopathies](https://www.escardio.org/Guidelines/Clinical-Practice-Guidelines/Cardiomyopathies) — European Society of Cardiology comprehensive cardiomyopathy guidelines
+- [AHA/ACC 2020 Guideline for the Diagnosis and Treatment of Patients with Hypertrophic Cardiomyopathy](https://www.ahajournals.org/doi/10.1161/CIR.0000000000000937) — American guidelines on hypertrophic cardiomyopathy management
+- [NHS — Cardiomyopathy](https://www.nhs.uk/conditions/cardiomyopathy/) — UK patient information on symptoms, diagnosis, and treatment
+- [Heart Foundation Australia](https://www.heartfoundation.org.au/) — Australian patient resources and support
+- [Cardiomyopathy Australia](https://www.cardiomyopathy.org.au/) — Australian patient support organisation for people living with cardiomyopathy
+
+---
+
+## Related Guides
+
+- [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+- [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
+- [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)
+- [Common Heart Medications and Their Side Effects](/guides/common-heart-medications)
+- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
+
+---
+
+*Educational only — not a substitute for professional medical advice. Always speak with your cardiologist or GP about your specific situation.*

--- a/src/content/guides/heart-circulation.md
+++ b/src/content/guides/heart-circulation.md
@@ -110,6 +110,10 @@ See also: [Early Warning Signs of a Heart Attack](/guides/early-warning-signs-of
 - [Heart Palpitations: When to Worry](/guides/heart-palpitations) — Which palpitations are benign and which need investigation.
 - [Heart Attacks in Younger Adults: Hidden Causes](/guides/heart-attacks-younger-adults-causes) — Why heart attacks happen in people under 50, especially women.
 
+### Structural Heart Disease
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview) — Disease of the heart muscle itself: dilated, hypertrophic, and restrictive types, causes including genetics and alcohol, and treatments including ICDs.
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview) — Aortic stenosis, mitral regurgitation, valve repair and replacement, and TAVI explained for patients.
+
 ### Diagnosis and Procedures
 - [Understanding Coronary Angiography](/guides/understanding-coronary-angiography) — How cardiac catheterisation works, what to expect on the day, and interpreting results.
 - [Coronary Artery Calcium Score](/guides/coronary-artery-calcium-score) — A CT scan that measures calcium deposits in coronary arteries, providing an early indicator of plaque burden and heart attack risk.

--- a/src/content/guides/heart-failure-overview.md
+++ b/src/content/guides/heart-failure-overview.md
@@ -160,8 +160,8 @@ Heart failure results from conditions that damage or overwork the heart over tim
 
 **Other important causes:**
 - **Diabetes** — independently damages heart muscle and blood vessels
-- **Valve disease** — leaking or narrowed valves place extra strain on the heart
-- **Cardiomyopathy** — disease of the heart muscle itself (including dilated, hypertrophic, and peripartum cardiomyopathy)
+- **[Valve disease](/guides/heart-valve-disease-overview)** — leaking or narrowed valves place extra strain on the heart
+- **[Cardiomyopathy](/guides/cardiomyopathy-overview)** — disease of the heart muscle itself (including dilated, hypertrophic, and peripartum cardiomyopathy)
 - **Chronic kidney disease** — cardiorenal syndrome: heart and kidney disease worsen each other
 - **Excessive alcohol use** — alcoholic cardiomyopathy
 - **Certain chemotherapy drugs** — anthracyclines and other cardiotoxic agents
@@ -351,12 +351,14 @@ Yes, for most people with stable heart failure. Supervised exercise — particul
 
 - [Heart Failure Warning Signs: When Symptoms Need Urgent Care](/guides/heart-failure-warning-signs)
 - [Living With Heart Failure: Daily Care, Medicines, and Monitoring](/guides/living-with-heart-failure)
-- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
 - [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
+- [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)
 - [High Blood Pressure (Hypertension): Symptoms, Causes, and Treatment](/guides/high-blood-pressure)
 - [Heart Attack Treatment — Emergency Care, Procedures, and Recovery](/guides/heart-attack-treatment)
 - [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
-- [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)
+- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
 - [Palliative Care — Guide Hub](/guides/palliative-care)
 
 ---

--- a/src/content/guides/heart-failure-warning-signs.md
+++ b/src/content/guides/heart-failure-warning-signs.md
@@ -251,6 +251,8 @@ If you cannot reach your usual care team and your symptoms are worsening signifi
 
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
 - [Living With Heart Failure: Daily Care, Medicines, and Monitoring](/guides/living-with-heart-failure)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
 - [Early Warning Signs of a Heart Attack](/guides/early-warning-signs-of-a-heart-attack)
 - [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)

--- a/src/content/guides/heart-valve-disease-overview.md
+++ b/src/content/guides/heart-valve-disease-overview.md
@@ -1,0 +1,367 @@
+---
+title: "Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment"
+slug: "heart-valve-disease-overview"
+description: "A patient guide to heart valve disease — covering how valves work, stenosis vs regurgitation, aortic stenosis, mitral regurgitation, heart murmurs, valve repair, mechanical and tissue replacement, TAVI, and the relationship to heart failure and atrial fibrillation."
+category: "Heart & Circulation"
+publishDate: "2026-06-07"
+updatedDate: "2026-06-07"
+draft: false
+tags:
+  - heart valve disease
+  - aortic stenosis
+  - mitral regurgitation
+  - TAVI
+  - TAVR
+  - valve replacement
+  - heart murmur
+  - cardiology
+  - patientguide
+schema:
+  medicalCondition:
+    name: "Heart Valve Disease"
+    description: "Heart valve disease refers to conditions in which one or more of the four cardiac valves — aortic, mitral, tricuspid, or pulmonary — fails to open or close properly, impairing blood flow through the heart and placing it under increased strain. It can cause heart failure, atrial fibrillation, and, if untreated, premature death."
+    alternateName:
+      - "Valvular heart disease"
+      - "Aortic stenosis"
+      - "Mitral regurgitation"
+      - "Aortic regurgitation"
+      - "Mitral stenosis"
+    riskFactors:
+      - "Age (degenerative calcific valve disease is most common in older adults)"
+      - "Congenital bicuspid aortic valve"
+      - "Rheumatic fever in childhood"
+      - "High blood pressure"
+      - "Coronary artery disease and prior heart attack"
+      - "History of infective endocarditis"
+      - "Cardiomyopathy (functional mitral regurgitation)"
+      - "Connective tissue disorders (Marfan syndrome, Ehlers-Danlos syndrome)"
+    symptoms:
+      - "Heart murmur detected on examination"
+      - "Shortness of breath on exertion or at rest"
+      - "Fatigue and reduced exercise tolerance"
+      - "Dizziness or light-headedness"
+      - "Ankle and leg swelling"
+      - "Palpitations"
+      - "Chest pain on exertion"
+      - "Fainting on exertion (particularly in aortic stenosis)"
+    possibleComplication:
+      - "Heart failure"
+      - "Atrial fibrillation"
+      - "Infective endocarditis"
+      - "Stroke (embolic)"
+      - "Sudden cardiac death (particularly in severe aortic stenosis)"
+    contagious: false
+    sameAs:
+      - "https://www.nhs.uk/conditions/heart-valve-disease/"
+      - "https://medlineplus.gov/heartvalvediseases.html"
+faq:
+  - q: "What is heart valve disease?"
+    a: "Heart valve disease means that one or more of the heart's four valves — the doors that control blood flow through the heart — are not working properly. A valve may be narrowed (stenosis), preventing blood from flowing through freely, or it may leak (regurgitation), allowing blood to flow in the wrong direction. Both types increase the heart's workload and can lead to heart failure if untreated."
+  - q: "What is a heart murmur?"
+    a: "A heart murmur is an extra sound heard through a stethoscope when blood flows turbulently through the heart. Many murmurs are harmless (innocent or functional murmurs, common in children and pregnancy). However, some murmurs indicate valve disease — particularly when they are loud, occur in a specific pattern, or are accompanied by symptoms. A murmur that needs investigation is followed up with an echocardiogram."
+  - q: "Does heart valve disease always need surgery?"
+    a: "No. Many people with mild or moderate valve disease require monitoring rather than immediate intervention. The decision about whether and when to intervene depends on the severity of the valve problem, whether the heart is under significant strain, the presence of symptoms, and individual factors such as age and fitness. Your cardiologist will advise based on your specific echocardiogram results and regular surveillance."
+  - q: "What is the difference between valve repair and valve replacement?"
+    a: "Valve repair preserves the natural valve — a surgeon repairs the damaged structure rather than removing it. This is preferred when technically feasible, especially for mitral valve disease. Valve replacement involves removing the diseased valve and replacing it with a mechanical valve (durable but requiring lifelong warfarin) or a tissue valve (does not require long-term warfarin but deteriorates over time). The choice depends on the valve affected, the patient's age, and other medical factors."
+  - q: "What is TAVI (or TAVR)?"
+    a: "TAVI — Transcatheter Aortic Valve Implantation — is a minimally invasive procedure to replace a diseased aortic valve without open-heart surgery. A new tissue valve is delivered through a catheter inserted via the femoral artery in the groin and deployed inside the diseased native valve. TAVI is now the standard treatment for severe symptomatic aortic stenosis in high- and intermediate-risk patients, and is increasingly used in lower-risk patients."
+  - q: "Can valve disease cause atrial fibrillation?"
+    a: "Yes. Valve disease — particularly mitral valve disease — is a common cause of atrial fibrillation. The enlarged left atrium that develops as a consequence of mitral regurgitation or stenosis creates an abnormal electrical environment that promotes AF. AF in turn worsens heart function and increases stroke risk. Treatment of the valve problem may reduce AF burden, though established AF usually requires separate management."
+---
+
+# Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment
+
+The heart has four valves — the **aortic, mitral, tricuspid, and pulmonary** valves — that act as one-way doors controlling the flow of blood through the heart's chambers and out to the body and lungs. When a valve does not open or close properly, blood flow becomes inefficient and the heart must work harder to compensate.
+
+**Heart valve disease** is common. Mild valve abnormalities are present in a significant proportion of the adult population and often require only monitoring. Moderate-to-severe valve disease, however, can progressively weaken the heart, lead to [heart failure](/guides/heart-failure-overview) and arrhythmias, and — without treatment — can be life-threatening.
+
+---
+
+## How the Heart Valves Work
+
+The heart beats in a coordinated sequence:
+
+1. **Right heart:** Deoxygenated blood returns from the body to the right atrium → flows through the **tricuspid valve** into the right ventricle → pumped through the **pulmonary valve** into the lungs to receive oxygen.
+2. **Left heart:** Oxygenated blood returns from the lungs into the left atrium → flows through the **mitral valve** into the left ventricle → pumped through the **aortic valve** out to the body via the aorta.
+
+Each valve opens to allow forward flow and closes firmly to prevent backflow. Valve disease disrupts this mechanism in two principal ways.
+
+---
+
+## Stenosis vs Regurgitation
+
+**Stenosis** — the valve opening is narrowed and stiff, restricting forward blood flow. The heart must generate higher pressure to force blood through the narrowed valve, increasing its workload. Over time, the heart muscle thickens and eventually may weaken and fail.
+
+**Regurgitation (or insufficiency)** — the valve does not close properly, allowing blood to leak backwards. The chamber behind the leaking valve must handle an extra volume of blood on every beat. This volume overload causes progressive chamber enlargement and, eventually, weakening.
+
+A valve may have both stenosis and regurgitation simultaneously (mixed valve disease).
+
+---
+
+## Aortic Stenosis
+
+The most common significant valve disease in developed countries, particularly in older adults.
+
+### What it is
+The aortic valve — between the left ventricle and the aorta — becomes narrowed due to progressive calcification and thickening of the valve leaflets. The most common cause in adults over 65 is degenerative calcification (a process similar to calcium deposits in arteries). In younger adults, aortic stenosis more commonly results from a **bicuspid aortic valve** — a congenital variant in which the aortic valve has two leaflets instead of the usual three, making it prone to earlier calcification.
+
+### Symptoms
+Aortic stenosis is often silent for years. When severe, it produces a classic symptom triad:
+1. **Angina** — chest pain on exertion; the thickened heart muscle outstrips its blood supply
+2. **Syncope** — fainting on exertion; the narrowed valve limits cardiac output when demand rises
+3. **Breathlessness** — the hallmark of developing heart failure from valve disease
+
+**The appearance of symptoms in aortic stenosis marks a critical point:** natural history changes dramatically once symptoms develop — without valve intervention, average survival is substantially reduced and the risk of sudden cardiac death rises.
+
+### Diagnosis
+- Echocardiogram: measures the valve area, pressure gradient across the valve, and ejection fraction — the key investigations for grading severity as mild, moderate, or severe
+- Doppler assessment: quantifies peak velocity and mean gradient across the valve
+- CT calcium scoring of the aortic valve: used to confirm severity when echocardiographic findings are discordant
+
+### Treatment
+- **Mild–moderate aortic stenosis, or severe but asymptomatic with preserved ejection fraction:** regular echocardiographic surveillance (every 1–5 years depending on severity) and risk factor management
+- **Severe aortic stenosis with symptoms** (or significant decline in ejection fraction): valve intervention is recommended promptly
+  - **TAVI (Transcatheter Aortic Valve Implantation)** — minimally invasive catheter-based valve replacement; now the standard approach for most patients over 75 and for many intermediate-risk patients
+  - **Surgical aortic valve replacement (SAVR)** — open-heart surgery; preferred for younger patients (under approximately 70), those with concomitant surgical indications, or anatomical factors unsuitable for TAVI
+
+---
+
+## Mitral Regurgitation
+
+The most common valve condition globally, affecting a significant proportion of adults across all age groups.
+
+### What it is
+The mitral valve — between the left atrium and left ventricle — does not close completely, allowing blood to leak back into the left atrium during each heartbeat. The atrium and ventricle must handle extra volume, progressively enlarging both chambers. Eventually the left ventricle may weaken and heart failure develops.
+
+**Primary mitral regurgitation** — the valve itself is structurally abnormal:
+- **Mitral valve prolapse (MVP)** — the most common cause in developed countries; one or both leaflets billow back into the atrium; most cases are mild and benign, but severe prolapse can cause significant regurgitation
+- Chordal rupture — a tendon supporting the valve leaflet tears, causing acute or sudden worsening of regurgitation
+
+**Secondary (functional) mitral regurgitation** — the valve leaflets are structurally normal but do not close properly because the left ventricle has dilated (from cardiomyopathy or after a heart attack), pulling the leaflet attachment points apart.
+
+### Symptoms
+Mild mitral regurgitation is usually asymptomatic. When severe:
+- Breathlessness on exertion, progressing to breathlessness at rest
+- Fatigue and reduced exercise tolerance
+- Palpitations — atrial fibrillation is a common complication of mitral regurgitation
+- Signs of heart failure (ankle swelling, orthopnoea)
+
+### Treatment
+- **Mild–moderate or asymptomatic severe MR with preserved left ventricular function:** regular surveillance
+- **Severe MR with symptoms, declining ejection fraction, or progressive left ventricular enlargement:** valve intervention recommended
+  - **Surgical repair** — preferred over replacement for primary MR when technically feasible; repair preserves the native valve and has superior long-term outcomes
+  - **Surgical replacement** — when repair is not possible; mechanical or tissue valve
+  - **Transcatheter edge-to-edge repair (TEER, MitraClip)** — a catheter-based procedure that clips the mitral leaflets together to reduce regurgitation; used in high-risk surgical patients with primary MR, or in selected patients with secondary MR causing persistent symptoms despite optimal medical therapy
+
+---
+
+## Aortic Regurgitation
+
+The aortic valve does not close properly, allowing blood to leak back from the aorta into the left ventricle during diastole (the relaxation phase). This volume load causes progressive left ventricular enlargement.
+
+### Causes
+- Bicuspid aortic valve
+- Aortic root dilation (as in hypertension, Marfan syndrome, or aortic aneurysm)
+- Infective endocarditis (infection destroying valve tissue)
+- Rheumatic heart disease
+
+### Symptoms
+Aortic regurgitation can be silent for many years as the left ventricle compensates by enlarging. When the ventricle begins to fail:
+- Breathlessness and reduced exercise tolerance
+- Palpitations (the hyperdynamic left ventricle generates visible and palpable pulsations)
+- Heart failure symptoms
+
+### Treatment
+- Regular echocardiographic surveillance
+- Surgical aortic valve replacement when symptoms develop or when left ventricular function or dimensions reach specified threshold criteria — even in the absence of symptoms, to prevent irreversible damage
+
+---
+
+## Mitral Stenosis
+
+Narrowing of the mitral valve restricts blood flow from the left atrium to the left ventricle. In developed countries, most cases result from **rheumatic heart disease** — valve scarring caused by rheumatic fever following untreated Group A streptococcal infection in childhood. Mitral stenosis remains common in parts of Asia, sub-Saharan Africa, and Latin America.
+
+### Symptoms
+- Breathlessness on exertion — the left atrium cannot empty efficiently, raising pulmonary pressures
+- Palpitations — atrial fibrillation is a common and important complication
+- Haemoptysis (coughing blood) in advanced disease
+- Stroke risk, particularly with coexistent atrial fibrillation
+
+### Treatment
+- **Percutaneous mitral balloon valvuloplasty (PMBV)** — a catheter-based procedure to expand the narrowed mitral valve; highly effective in rheumatic mitral stenosis with favourable anatomy
+- **Surgical repair or replacement** — when PMBV is not appropriate or anatomy is unfavourable
+- Anticoagulation for stroke prevention, particularly when atrial fibrillation is present
+
+---
+
+## Tricuspid Valve Disease
+
+The tricuspid valve — between the right atrium and right ventricle — is most commonly affected by **secondary tricuspid regurgitation** (a leaking valve caused by enlargement of the right heart due to left-sided heart disease, pulmonary hypertension, or heart failure). Primary tricuspid disease is less common.
+
+Mild tricuspid regurgitation is very common and usually requires no specific treatment beyond managing the underlying cause. Severe symptomatic tricuspid regurgitation causing right heart failure (fluid retention, liver congestion, fatigue) may require tricuspid valve repair or replacement — either via open surgery or through emerging transcatheter tricuspid interventions available at specialist centres.
+
+---
+
+## Heart Murmurs
+
+A heart murmur is the sound made by turbulent blood flow through the heart. When detected through a stethoscope, it prompts further investigation — usually an echocardiogram.
+
+**Not all murmurs indicate disease.** Many are:
+- **Innocent (functional)** — produced by fast flow through a structurally normal valve; common in children, pregnancy, and athletes; no treatment needed
+- **Flow murmurs** — caused by anaemia or fever increasing cardiac output
+
+**Murmurs that warrant echocardiography:**
+- Any diastolic murmur (always abnormal)
+- Loud systolic murmurs (grade 3 or above)
+- Murmurs accompanied by symptoms (breathlessness, syncope, chest pain, reduced exercise tolerance)
+- Murmurs in people with risk factors for valve disease (bicuspid aortic valve, prior rheumatic fever, connective tissue disorders, prior endocarditis)
+
+If you have been told you have a murmur and have not had an echocardiogram, ask your doctor whether one is indicated.
+
+---
+
+## Diagnosis
+
+### Echocardiogram (Heart Ultrasound)
+The central investigation for valve disease. An echocardiogram:
+- Identifies the affected valve(s) and the type of lesion (stenosis or regurgitation)
+- Grades severity (mild, moderate, severe) using standardised measurements
+- Assesses the consequences for heart chamber size and function (including ejection fraction)
+- Guides the timing of intervention
+
+**Transoesophageal echocardiography (TOE/TEE)** — where the probe is passed into the oesophagus — provides closer, more detailed imaging. It is used to plan surgery and transcatheter procedures, assess valve anatomy in detail, and diagnose endocarditis.
+
+### CT Imaging
+CT is essential for planning TAVI and other catheter-based procedures (measuring anatomy, valve dimensions, and vascular access routes). Cardiac MRI can provide additional structural information in complex cases.
+
+### Exercise Testing
+Used to unmask symptoms in apparently asymptomatic patients — for example, to confirm whether a patient with severe aortic stenosis is truly symptom-free. An abnormal blood pressure response or exercise-induced symptoms may bring forward the recommendation to intervene.
+
+---
+
+## Treatment: Overview
+
+Treatment decisions are guided by:
+1. Valve lesion type and severity (measured by echocardiogram)
+2. Presence and severity of symptoms
+3. Heart function — whether ejection fraction is preserved or declining
+4. Chamber size — progressive enlargement can trigger intervention even before symptoms develop
+5. Patient factors — age, comorbidities, surgical risk, and patient preference
+
+### Monitoring (Conservative Management)
+For mild or moderate valve disease, or for asymptomatic severe disease with preserved heart function, regular echocardiographic surveillance is appropriate. The interval depends on severity and type of lesion.
+
+### Valve Repair
+Repair is preferred over replacement when technically feasible:
+- Preserves the native valve structure
+- Associated with better long-term heart function
+- Avoids the need for long-term anticoagulation (required with mechanical valves)
+- Standard of care for primary mitral regurgitation at specialist centres
+
+### Valve Replacement: Mechanical vs Tissue Valves
+
+When repair is not possible, a diseased valve is replaced with one of two options:
+
+**Mechanical valves:**
+- Durable — designed to last a lifetime, avoiding future reoperation
+- Require lifelong anticoagulation with warfarin — a commitment to regular INR blood tests and management of bleeding risk
+- Preferred in younger patients (generally under 50–60 years) where durability over decades is the priority
+
+**Tissue (biological) valves:**
+- Made from animal tissue (typically porcine or bovine pericardium)
+- Do not require long-term warfarin (aspirin only after a settling period, unless another anticoagulation indication exists)
+- Deteriorate over time — may require replacement after 10–20 years; the younger the patient at the time of implant, the higher the likelihood of needing a future reoperation
+- Preferred in older patients, those with contraindications to warfarin, or those at high bleeding risk
+
+### TAVI — Transcatheter Aortic Valve Implantation
+
+TAVI (also called TAVR — Transcatheter Aortic Valve Replacement, the terminology used in the United States and in Australian clinical trials) is a minimally invasive catheter-based procedure that replaces the diseased aortic valve without open-heart surgery.
+
+**How it works:**
+- A new tissue valve, mounted on a collapsible stent frame, is compressed and loaded into a catheter
+- The catheter is typically inserted via the femoral artery in the groin under X-ray and echocardiographic guidance
+- The new valve is deployed inside the diseased native aortic valve, pushing it aside and taking over its function
+- The procedure is performed under sedation or general anaesthesia; most patients are mobile and able to go home within one to three days
+
+**Who is it for?**
+TAVI was initially developed for patients too high-risk for open surgery. Large randomised trials have since established TAVI as appropriate — and in many centres preferred — for intermediate- and lower-risk patients, particularly those aged over 75. Current ESC and AHA/ACC guidelines recommend TAVI as the preferred approach for most symptomatic patients with severe aortic stenosis over 75 years.
+
+**Other transcatheter valve procedures:**
+- **MitraClip (TEER)** — transcatheter edge-to-edge mitral repair for mitral regurgitation in high-risk surgical patients
+- **Transcatheter tricuspid interventions** — an emerging field for severe tricuspid regurgitation
+
+---
+
+## Relationship to Heart Failure
+
+Valve disease is a major cause of heart failure:
+- **Aortic stenosis** → sustained pressure overload → left ventricular hypertrophy → eventual systolic and diastolic dysfunction → heart failure
+- **Mitral regurgitation** → chronic volume overload → left atrial and ventricular dilation → declining ejection fraction → heart failure
+- **Secondary mitral regurgitation** → arises in the context of underlying cardiomyopathy and heart failure; the two conditions worsen each other and management must address both
+
+Treating the valve lesion at the appropriate time — before irreversible damage to the heart muscle — is the primary goal of ongoing surveillance and timely intervention.
+
+See: [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+
+---
+
+## Relationship to Atrial Fibrillation
+
+Valve disease — particularly mitral valve disease — is one of the strongest risk factors for [atrial fibrillation](/guides/atrial-fibrillation). The enlarged left atrium that develops as a consequence of mitral regurgitation or stenosis becomes an electrical environment prone to AF. Aortic stenosis, with its pressure-overloaded left ventricle, also increases AF risk.
+
+Conversely, AF worsens valve disease outcomes — the irregular rhythm reduces cardiac output, increases heart failure risk, and raises stroke risk significantly (compounded in the presence of mitral stenosis or regurgitation).
+
+People with both valve disease and AF typically require anticoagulation — both for AF-related stroke prevention and, after mechanical valve implantation, to prevent valve thrombosis.
+
+---
+
+## Infective Endocarditis: An Important Complication
+
+Infective endocarditis — a bacterial (or, rarely, fungal) infection of the heart valves — is more common in people with structural valve disease. Bacteria adhere to abnormal valve surfaces, forming infected deposits (vegetations) that can rapidly destroy the valve and embolise to other organs including the brain.
+
+**Prevention:** People with specific high-risk conditions — including mechanical or biological prosthetic valves, and some repaired or unrepaired structural heart lesions — should receive antibiotic prophylaxis before certain dental procedures. Discuss with your cardiologist whether this applies to you.
+
+**Symptoms of endocarditis** include prolonged fever, chills, fatigue, night sweats, a new or changing heart murmur, and occasionally visible skin changes (splinter haemorrhages under the nails, red tender nodules on the fingers or toes). Seek urgent medical assessment if these symptoms develop.
+
+---
+
+## FAQ
+
+**Q: If I have a heart murmur, does that mean I have valve disease?**
+Not necessarily. Many murmurs are innocent and require no treatment or ongoing surveillance. A murmur that is diastolic, loud, or accompanied by symptoms warrants investigation with an echocardiogram. Your GP or cardiologist can advise based on the murmur's characteristics and your overall clinical picture.
+
+**Q: How often do I need a follow-up echocardiogram for valve disease?**
+This depends on the type and severity. Mild disease may need surveillance every three to five years; moderate disease every one to two years; severe disease — especially when approaching the threshold for intervention — may need follow-up every six to twelve months. Your cardiologist will advise on the appropriate schedule.
+
+**Q: If I need valve surgery, how long is the recovery?**
+After open-heart valve surgery, most people spend five to ten days in hospital and require six to twelve weeks of recovery before returning to normal activities. TAVI recovery is faster — most people go home within one to three days and are largely back to normal within a few weeks. [Cardiac rehabilitation](/guides/cardiac-rehabilitation) is recommended after all major cardiac procedures.
+
+**Q: Do I need lifelong warfarin after valve replacement?**
+This depends on the valve type. Mechanical valves require lifelong anticoagulation (warfarin, or in selected cases a direct oral anticoagulant — your cardiologist will advise). Tissue valves generally require anticoagulation only for the first three months after implantation, then aspirin alone — unless you have atrial fibrillation or another indication for ongoing anticoagulation.
+
+**Q: Can I exercise with valve disease?**
+Most people with mild or moderate valve disease can exercise safely. Severe symptomatic aortic stenosis and other advanced valve conditions require more caution — supervised exercise testing may be recommended before independent exercise programmes. After valve repair or replacement, cardiac rehabilitation helps guide a safe return to activity. Always discuss your specific exercise plan with your cardiologist.
+
+---
+
+## Further Reading
+
+- [ESC 2021 Guidelines for the Management of Valvular Heart Disease](https://www.escardio.org/Guidelines/Clinical-Practice-Guidelines/Valvular-Heart-Disease) — European Society of Cardiology clinical guidelines on valve disease assessment and treatment
+- [AHA/ACC 2021 Guideline for the Management of Valvular Heart Disease](https://www.jacc.org/doi/10.1016/j.jacc.2020.11.018) — American guideline covering indication thresholds and transcatheter vs surgical approaches
+- [NHS — Heart Valve Disease](https://www.nhs.uk/conditions/heart-valve-disease/) — UK patient information on symptoms, types, and treatment
+- [Heart Foundation Australia](https://www.heartfoundation.org.au/) — Australian patient resources and heart health information
+
+---
+
+## Related Guides
+
+- [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+- [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
+- [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)
+- [Common Heart Medications and Their Side Effects](/guides/common-heart-medications)
+- [Heart & Circulation — Guide Hub](/guides/heart-circulation)
+
+---
+
+*Educational only — not a substitute for professional medical advice. Always speak with your cardiologist about your specific valve condition and the appropriate management plan.*

--- a/src/content/guides/living-with-heart-failure.md
+++ b/src/content/guides/living-with-heart-failure.md
@@ -321,10 +321,12 @@ Heart failure is serious, but many people live with it for years or decades. Mod
 
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
 - [Heart Failure Warning Signs: When Symptoms Need Urgent Care](/guides/heart-failure-warning-signs)
+- [Cardiomyopathy: Symptoms, Causes, Diagnosis, and Treatment](/guides/cardiomyopathy-overview)
+- [Heart Valve Disease: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-valve-disease-overview)
 - [Cardiac Rehabilitation — What It Is and Why It Matters](/guides/cardiac-rehabilitation)
-- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
 - [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)
 - [High Blood Pressure (Hypertension): Symptoms, Causes, and Treatment](/guides/high-blood-pressure)
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
 - [Sleep Health Hub](/guides/sleep-health-hub)
 - [Palliative Care — Guide Hub](/guides/palliative-care)
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)


### PR DESCRIPTION
## Summary

- Adds **cardiomyopathy-overview.md** — patient guide covering dilated, hypertrophic, and restrictive cardiomyopathy; causes (genetics, alcohol, chemotherapy, myocarditis); diagnosis (ECG, echo, cardiac MRI, genetic testing); treatment (the HFrEF medicine stack, mavacamten for obstructive HCM, tafamidis for ATTR, ICDs, CRT, septal reduction therapy); relationship to heart failure and arrhythmias.
- Adds **heart-valve-disease-overview.md** — patient guide covering aortic stenosis, mitral regurgitation, aortic regurgitation, mitral stenosis, and tricuspid disease; stenosis vs regurgitation; heart murmurs; echocardiography; valve repair vs replacement; mechanical vs tissue valves; TAVI/TAVR overview; infective endocarditis; relationship to heart failure and AF.
- Cross-links added to `atrial-fibrillation`, `cardiac-rehabilitation`, `heart-circulation` (new Structural Heart Disease section), and the heart failure cluster guides.

## Sources

- ESC 2023 Guidelines for the Management of Cardiomyopathies
- ESC 2021 Guidelines for the Management of Valvular Heart Disease
- AHA/ACC 2020 Guideline for Hypertrophic Cardiomyopathy
- AHA/ACC 2021 Guideline for Valvular Heart Disease
- NHS patient information (cardiomyopathy, heart valve disease)
- Heart Foundation Australia

## Test plan

- [x] `npm run content:check` — no errors (212 pre-existing FAQ warnings on unrelated guides)
- [x] `npm run build` — complete, 740 pages indexed (pagefind)
- [x] No duplicate slugs (`cardiomyopathy-overview`, `heart-valve-disease-overview`)
- [x] Category `"Heart & Circulation"` — valid enum
- [x] `publishDate: "2026-06-07"`, `updatedDate: "2026-06-07"`, `draft: false`
- [x] Australian English throughout
- [x] Internal links verified against existing guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)