### PR TITLE
feat(cancer): add lung cancer and melanoma overview guides

### DIFF
--- a/src/content/guides/cancer.md
+++ b/src/content/guides/cancer.md
@@ -1,10 +1,10 @@
 ---
 title: "Cancer — Guide Hub"
 slug: "cancer"
-description: "Cancer is a group of diseases where abnormal cells grow uncontrollably and may spread. Explore guides on bowel, breast, prostate, skin, cervical, and liver cancer."
+description: "Cancer is a group of diseases where abnormal cells grow uncontrollably and may spread. Explore guides on lung, bowel, breast, prostate, skin, cervical, liver, and other cancers."
 category: "Cancer"
 publishDate: "2025-08-20"
-updatedDate: "2026-06-06"
+updatedDate: "2026-06-08"
 hubKey: "Cancer"
 draft: false
 tags: ["cancer", "oncology", "patientguide", "hub"]
@@ -62,7 +62,11 @@ Essential guides for anyone navigating a cancer diagnosis or wanting to understa
 - [Skin Cancer — Guide Hub](/guides/skin-cancer) — Skin cancer types, prevention, diagnosis, and treatment.
 - [Liver Cancer — Guide Hub](/guides/liver-cancer) — Liver cancer: risk factors, detection, and treatment options.
 - [Cervical Cancer: Causes, Screening, Prevention, and Treatment](/guides/cervical-cancer-guide) — A comprehensive guide to cervical cancer prevention and care.
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview) — Lung cancer: types, symptoms, risk factors, diagnosis, staging, treatment options, and follow-up.
 - [Pancreatic Cancer: Symptoms, Diagnosis, and Treatment](/guides/pancreatic-cancer-overview) — Pancreatic cancer: symptoms, why diagnosis is often late, surgery, chemotherapy, and targeted therapy.
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview) — Melanoma: warning signs, ABCDE rule, diagnosis, staging, immunotherapy, and targeted therapy.
+- [Ovarian Cancer: Symptoms, Diagnosis, and Treatment](/guides/ovarian-cancer-overview) — Ovarian cancer: non-specific symptoms, BRCA genetics, staging, surgery, and PARP inhibitors.
+- [Testicular Cancer: Symptoms, Diagnosis, and Treatment](/guides/testicular-cancer-overview) — Testicular cancer: what to look for, diagnosis, and treatment.
 - [Palliative Care — Guide Hub](/guides/palliative-care) — Supportive and comfort-focused care for people living with serious illness.
 
 ---
@@ -92,13 +96,17 @@ See also: [Emergencies — Guide Hub](/guides/emergencies) | [Sepsis](/guides/se
 
 ## Key Guides
 
-### Cancer Type Hubs
+### Cancer Type Hubs and Overviews
 - [Bowel Cancer — Guide Hub](/guides/bowel-cancer) — Colorectal cancer: screening (FIT, colonoscopy), surgery, chemo, genetics, and survivorship.
 - [Breast Cancer — Guide Hub](/guides/breast-cancer) — Mammography, surgical options, hormone therapy, targeted therapy, and recovery.
 - [Prostate Cancer — Guide Hub](/guides/prostate-cancer) — PSA, active surveillance, surgery vs radiotherapy, and hormonal treatment.
 - [Skin Cancer — Guide Hub](/guides/skin-cancer) — Melanoma and non-melanoma: detection, prevention, and treatment.
 - [Liver Cancer — Guide Hub](/guides/liver-cancer) — Hepatocellular carcinoma: risk factors (hepatitis B/C, cirrhosis), detection, and treatment.
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview) — Types (NSCLC, SCLC), symptoms, risk factors, molecular testing, staging, and treatment.
 - [Pancreatic Cancer: Symptoms, Diagnosis, and Treatment](/guides/pancreatic-cancer-overview) — Symptoms, staging, surgery, chemotherapy, KRAS biology, and biomarker-driven treatment.
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview) — Warning signs, ABCDE rule, Breslow thickness, immunotherapy, and targeted therapy.
+- [Ovarian Cancer: Symptoms, Diagnosis, and Treatment](/guides/ovarian-cancer-overview) — Non-specific symptoms, BRCA genetics, staging, cytoreductive surgery, and PARP inhibitors.
+- [Testicular Cancer: Symptoms, Diagnosis, and Treatment](/guides/testicular-cancer-overview) — What to look for, diagnosis, and treatment.
 
 ### Precision Oncology
 - [Precision Medicine in Cancer: Biomarkers, Targeted Therapy, and Genetic Testing](/guides/precision-medicine-in-cancer) — How tumour profiling, biomarkers, and targeted drugs work — including KRAS, EGFR, HER2, BRCA, and MSI.
@@ -107,11 +115,14 @@ See also: [Emergencies — Guide Hub](/guides/emergencies) | [Sepsis](/guides/se
 ### Cervical and Skin Cancer Guides
 - [Cervical Cancer: Causes, Screening, Prevention, and Treatment](/guides/cervical-cancer-guide) — HPV's role, Pap smears vs HPV testing, and treatment by stage.
 - [Cervical Cancer Screening Explained: HPV Testing, Self-Collection, and What's Changed](/guides/cervical-cancer-screening-hpv-self-testing) — How modern cervical screening programs work.
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview) — A dedicated overview of melanoma: warning signs, ABCDE rule, diagnosis, staging, and treatment.
 - [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention) — How to recognise melanoma and non-melanoma skin cancers.
 - [Skin Cancer: Diagnosis and Treatment](/guides/skin-cancer-diagnosis-treatment) — What happens after an abnormal skin finding.
+- [Skin Cancer — Prevention](/guides/skin-cancer-prevention) — Sun protection, sunscreen, and reducing UV exposure.
 - [Nicotinamide and Skin Cancer Prevention](/guides/nicotinamide-skin-cancer-prevention) — Evidence on vitamin B3 supplementation for high-risk patients.
 
 ### Screening and Prevention
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview) — Patient overview: types, symptoms, risk factors, and treatment.
 - [Lung Cancer Screening: Low-Dose CT, Benefits, Risks, and Eligibility](/guides/lung-cancer-screening-low-dose-ct) — Who qualifies for annual LDCT, what pack-years means, the evidence base, and shared decision-making.
 - [Skin Cancer — Prevention](/guides/skin-cancer-prevention) — Sun protection, sunscreen, and reducing UV exposure.
 - [HPV Vaccine](/guides/hpv-vaccine) — How HPV vaccination protects against cervical, anal, and other cancers.
@@ -184,6 +195,10 @@ Seek emergency care for severe bleeding, sudden breathlessness or chest pain, hi
 - [Breast Cancer — Guide Hub](/guides/breast-cancer)
 - [Prostate Cancer — Guide Hub](/guides/prostate-cancer)
 - [Skin Cancer — Guide Hub](/guides/skin-cancer)
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview)
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview)
+- [Ovarian Cancer: Symptoms, Diagnosis, and Treatment](/guides/ovarian-cancer-overview)
+- [Testicular Cancer: Symptoms, Diagnosis, and Treatment](/guides/testicular-cancer-overview)
 - [Pancreatic Cancer: Symptoms, Diagnosis, and Treatment](/guides/pancreatic-cancer-overview)
 - [Precision Medicine in Cancer: Biomarkers, Targeted Therapy, and Genetic Testing](/guides/precision-medicine-in-cancer)
 - [KRAS Mutations Explained: Why Some Cancer Targets Are Hard to Treat](/guides/kras-mutations-explained)

--- a/src/content/guides/lung-cancer-overview.md
+++ b/src/content/guides/lung-cancer-overview.md
@@ -1,0 +1,384 @@
+---
+title: "Lung Cancer: Symptoms, Diagnosis, and Treatment"
+description: "A patient-friendly guide to lung cancer, including symptoms, risk factors, diagnosis, staging, treatment options, screening, and follow-up."
+category: "Cancer"
+publishDate: "2026-06-08"
+updatedDate: "2026-06-08"
+draft: false
+tags:
+  - lung cancer
+  - cancer
+  - screening
+  - smoking
+  - respiratory health
+faq:
+  - q: "What are common symptoms of lung cancer?"
+    a: "Common symptoms can include a persistent cough, coughing up blood, chest pain, shortness of breath, repeated chest infections, unexplained weight loss, fatigue, or hoarseness. Many of these symptoms overlap with other conditions — persistent or unexplained symptoms warrant medical review."
+  - q: "Can people who have never smoked get lung cancer?"
+    a: "Yes. Smoking is the biggest risk factor, but lung cancer can also occur in people who have never smoked. Other risk factors include radon exposure, asbestos, air pollution, and family history."
+  - q: "How is lung cancer diagnosed?"
+    a: "Diagnosis usually involves imaging tests such as a chest X-ray or CT scan, followed by a biopsy where a sample of tissue is examined for cancer cells. Molecular testing of the tumour helps guide treatment choice."
+  - q: "What is the difference between screening and diagnosis?"
+    a: "Screening looks for early signs of cancer in people at higher risk before symptoms appear. Diagnosis confirms whether cancer is present after symptoms develop or an abnormal test result occurs. Screening uses low-dose CT for eligible high-risk individuals."
+  - q: "Is lung cancer treatable?"
+    a: "Treatment depends on the cancer type, stage, and general health. Options may include surgery, radiotherapy, chemotherapy, immunotherapy, targeted therapy, or palliative care. Early-stage disease has substantially better outcomes than advanced disease."
+  - q: "What is non-small cell lung cancer?"
+    a: "Non-small cell lung cancer (NSCLC) is the most common type of lung cancer, accounting for roughly 85% of cases. It includes adenocarcinoma, squamous cell carcinoma, and large cell carcinoma. Treatment approach depends on stage and molecular testing results."
+  - q: "What does molecular testing mean for lung cancer treatment?"
+    a: "Molecular (biomarker) testing analyses the tumour for genetic changes that can be targeted with specific drugs. Mutations in EGFR, ALK, ROS1, KRAS, and other genes each have targeted therapy options. Testing is now a standard part of planning treatment for NSCLC."
+---
+
+## What Is Lung Cancer?
+
+Lung cancer is a malignancy that begins in the cells of the lung — usually the airways or air sacs. It is the **leading cause of cancer death** globally and in Australia, accounting for more deaths than any other cancer type. Most cases are diagnosed at an advanced stage, when the cancer has already spread, because early-stage lung cancer rarely causes symptoms.
+
+The two main categories — non-small cell and small cell — behave differently and are treated differently. Understanding the type and stage of a lung cancer is the essential first step before any treatment decisions are made.
+
+This guide covers what lung cancer is, how it develops, what to watch for, how it is diagnosed and staged, what treatment involves, and what to expect when living with the diagnosis.
+
+---
+
+## Key Points
+
+- Lung cancer is the leading cause of cancer death worldwide.
+- Most cases are diagnosed at an advanced stage because early-stage disease rarely causes symptoms.
+- Smoking is the most significant risk factor — but lung cancer also occurs in people who have never smoked.
+- Non-small cell lung cancer (NSCLC) accounts for approximately 85% of cases; small cell lung cancer (SCLC) accounts for most of the remainder.
+- Molecular (biomarker) testing of the tumour now guides treatment choice — targeted therapies and immunotherapy are available for specific tumour subtypes.
+- Low-dose CT (LDCT) screening is recommended for people with a significant smoking history who meet age and pack-year eligibility — but is not appropriate for the general population.
+- Treatment options include surgery, radiotherapy, chemotherapy, immunotherapy, targeted therapy, and palliative/supportive care.
+- Early-stage disease has substantially better outcomes than advanced disease.
+- Persistent cough, coughing up blood, unexplained weight loss, or worsening breathlessness warrant prompt medical review.
+
+---
+
+## Types of Lung Cancer
+
+### Non-Small Cell Lung Cancer (NSCLC)
+
+Non-small cell lung cancer accounts for approximately **85% of all lung cancers**. It includes three main histological subtypes:
+
+| Subtype | Features |
+|---|---|
+| **Adenocarcinoma** | Most common NSCLC subtype; arises in glandular cells; most common in non-smokers and women; frequently found peripherally in the lung; most likely to harbour targetable mutations (EGFR, ALK, KRAS) |
+| **Squamous cell carcinoma** | Arises in the flat cells lining the airways; strongly associated with smoking; tends to occur centrally near larger airways |
+| **Large cell carcinoma** | A less common subtype defined by exclusion; tends to grow and spread quickly |
+
+NSCLC grows relatively more slowly than small cell lung cancer and is more likely to be localised at diagnosis. Surgery and radiotherapy can be curative in early-stage disease.
+
+### Small Cell Lung Cancer (SCLC)
+
+Small cell lung cancer accounts for approximately **15% of lung cancers** and is almost exclusively associated with smoking. It grows rapidly and spreads early — most people are diagnosed at an extensive stage. SCLC is initially very responsive to chemotherapy but relapses quickly in most cases. Treatment is primarily chemotherapy and immunotherapy; surgery is rarely an option.
+
+### Molecular Testing
+
+**Molecular (biomarker) testing** of the tumour is now a standard part of treatment planning for NSCLC. The tumour tissue is analysed for specific genetic changes — mutations, fusions, or gene amplifications — that can be targeted with matched drugs:
+
+- **EGFR mutation** — targeted by osimertinib and other EGFR inhibitors
+- **ALK fusion** — targeted by alectinib and other ALK inhibitors
+- **KRAS G12C mutation** — targeted by sotorasib, adagrasib
+- **ROS1 fusion, MET amplification, BRAF, RET, NTRK** — each with targeted options
+- **PD-L1 expression** — guides use of immunotherapy (pembrolizumab and others)
+
+Treatment planning for advanced NSCLC requires knowing the molecular profile of the tumour. This is one reason why biopsy and pathology are so important.
+
+See also: [Precision Medicine in Cancer: Biomarkers, Targeted Therapy, and Genetic Testing](/guides/precision-medicine-in-cancer)
+
+---
+
+## Symptoms
+
+Lung cancer symptoms are often absent in early-stage disease. When symptoms do occur, they commonly include:
+
+**Respiratory symptoms:**
+- A persistent cough — new, or a significant change in a pre-existing cough
+- Coughing up blood (haemoptysis) — even small amounts warrant urgent evaluation
+- [Shortness of breath](/guides/shortness-of-breath) — gradual worsening, or breathlessness on exertion
+- Chest pain — persistent, dull ache or sharp discomfort in the chest
+- Recurrent chest infections — pneumonia or bronchitis that keeps coming back
+
+**Systemic (whole-body) symptoms:**
+- Unexplained weight loss
+- Persistent fatigue
+- Loss of appetite
+- Hoarseness or a change in voice
+
+**Symptoms from spread:**
+- Bone pain (particularly back or hip) if cancer has spread to bone
+- Headaches, visual changes, or new neurological symptoms if spread to the brain
+- Swelling of the face or arms (superior vena cava syndrome — a medical emergency)
+- Persistent shoulder pain (Pancoast tumour at the lung apex)
+
+Many of these symptoms overlap with other conditions — particularly [COPD](/guides/copd), asthma, chest infections, and heart conditions. Persistent or unexplained symptoms, particularly in a current or former smoker, warrant medical review.
+
+---
+
+## Risk Factors
+
+### Smoking
+
+Cigarette smoking is the **single most important risk factor** for lung cancer, responsible for approximately **85% of cases** in high-income countries. Risk is related to cumulative exposure — how many cigarettes smoked per day and for how many years. People who quit smoking substantially reduce their future lung cancer risk, though risk remains elevated compared to never-smokers for many years after quitting.
+
+See: [Smoking Cessation — Methods, Support, and What Actually Works](/guides/smoking-cessation)
+
+### Second-Hand Smoke
+
+Regular exposure to other people's cigarette smoke increases lung cancer risk. Non-smokers who live with a smoker have a higher risk than those with no household exposure.
+
+### Radon Gas
+
+Radon is a naturally occurring radioactive gas that can accumulate in buildings, particularly in basements or poorly ventilated lower floors. It is the **leading cause of lung cancer in non-smokers** in some countries. Testing is available and remediation (improving building ventilation) reduces exposure.
+
+### Occupational Exposures
+
+Long-term workplace exposure to certain substances increases lung cancer risk:
+
+- **Asbestos** — particularly in combination with smoking; causes mesothelioma and lung adenocarcinoma
+- **Silica dust** (mining, construction)
+- **Diesel exhaust**
+- **Chromium, nickel, arsenic** (in certain industrial processes)
+- **Polycyclic aromatic hydrocarbons** (PAHs — combustion-related exposures)
+
+Occupational history is an important part of risk assessment for lung cancer.
+
+### Air Pollution
+
+Outdoor air pollution — particularly fine particulate matter (PM2.5) from traffic and industrial sources — is classified as a Group 1 carcinogen by the International Agency for Research on Cancer (IARC). Long-term exposure increases lung cancer risk in both smokers and non-smokers.
+
+### Family History and Genetic Factors
+
+Having a first-degree relative with lung cancer modestly increases individual risk, independent of smoking. Rare hereditary lung cancer syndromes exist but account for a very small proportion of cases.
+
+### Prior Lung Disease
+
+People with [COPD](/guides/copd), pulmonary fibrosis, or a history of tuberculosis have a higher baseline lung cancer risk. Lung cancer and COPD frequently co-exist because they share common causes.
+
+### Prior Radiation
+
+People who have previously received radiotherapy to the chest — for example, as part of treatment for another cancer — have an elevated risk of radiation-related lung cancer. This risk is relevant decades after the original treatment.
+
+---
+
+## Screening
+
+Screening aims to detect lung cancer at an early, more treatable stage in people who are at elevated risk — before symptoms develop.
+
+**Low-dose CT (LDCT)** is the only lung cancer screening method with demonstrated mortality reduction. Major guidelines (including USPSTF 2021) recommend annual LDCT for adults with a significant smoking history who meet age and pack-year eligibility criteria.
+
+The purpose of screening is different from diagnosis:
+
+- **Screening** — done in people at higher risk with no symptoms, to detect cancer early
+- **Diagnosis** — done after symptoms appear or an abnormal result occurs
+
+See: [Lung Cancer Screening: Low-Dose CT, Benefits, Risks, and Eligibility](/guides/lung-cancer-screening-low-dose-ct)
+
+**Who should consider screening:** Adults aged 50–80 with a smoking history of 20 or more pack-years who currently smoke or have quit within the past 15 years. Screening is not appropriate for people outside these criteria without specific guidance from a clinician.
+
+---
+
+## Diagnosis
+
+### Initial Assessment
+
+A GP or specialist will take a clinical history, examine you, and arrange initial tests. This usually starts with:
+
+- **Chest X-ray** — may detect an abnormality but misses many early lung cancers; a normal chest X-ray does not rule out lung cancer if symptoms are persistent
+- **CT scan of the chest** — the main imaging tool for evaluating a suspected lung mass; more sensitive than X-ray and better defines tumour size, location, and lymph node involvement
+
+### Further Imaging
+
+- **PET-CT scan** — a PET scan combined with CT; detects metabolic activity and helps stage the cancer by identifying spread to lymph nodes or distant sites
+- **MRI of the brain** — used in staging to assess for brain metastases in selected patients
+- **Bone scan** — sometimes used to detect bone metastases if not covered by PET
+
+### Tissue Diagnosis (Biopsy)
+
+A definitive diagnosis requires examining cancer cells under a microscope. This is done through biopsy, which may be obtained by:
+
+- **Bronchoscopy** — a thin flexible camera inserted through the mouth or nose into the airways to visualise and sample tissue from central tumours; endobronchial ultrasound (EBUS) extends reach to lymph nodes
+- **CT-guided needle biopsy** — a needle inserted through the chest wall, guided by CT imaging, to sample peripheral tumours
+- **Surgical biopsy (VATS)** — video-assisted thoracoscopic surgery; used when other biopsy methods cannot reach the lesion
+- **Pleural fluid sampling** — if there is fluid around the lung (pleural effusion), testing the fluid may confirm malignancy
+
+### Pathology and Molecular Testing
+
+Once tissue is obtained, the pathologist determines the **histological type** (NSCLC vs SCLC; adenocarcinoma vs squamous) and performs **molecular testing** — looking for targetable mutations, fusions, and gene expression markers (PD-L1). This information is essential for selecting the most appropriate treatment in NSCLC.
+
+---
+
+## Staging
+
+Staging describes how far the cancer has spread and is the foundation for treatment decisions.
+
+### NSCLC Staging (TNM system, plain language)
+
+| Stage | Description | Typical Treatment Approach |
+|---|---|---|
+| **Stage I** | Tumour confined to the lung | Surgery or stereotactic radiotherapy (curative intent) |
+| **Stage II** | Tumour with nearby lymph node involvement or larger size | Surgery + chemotherapy; radiotherapy in some cases |
+| **Stage III** | Spread to lymph nodes in the chest (locally advanced) | Chemotherapy + radiotherapy; surgery in selected cases |
+| **Stage IV** | Spread to the other lung, pleura, or distant organs (metastatic) | Systemic therapy (targeted therapy, immunotherapy, chemotherapy); palliative care |
+
+### SCLC Staging
+
+SCLC is typically staged as:
+- **Limited stage** — cancer confined to one side of the chest (may be treated with chemotherapy and radiotherapy)
+- **Extensive stage** — cancer spread beyond the chest or to both lungs (treated with chemotherapy and immunotherapy)
+
+Approximately two-thirds of SCLC cases are extensive stage at diagnosis.
+
+---
+
+## Treatment
+
+Treatment depends on the cancer type, stage, molecular test results, overall health, and the person's preferences and goals of care. A multidisciplinary team (MDT) — including thoracic surgeons, oncologists, radiologists, pathologists, and palliative care — reviews each case before treatment is recommended.
+
+### Surgery
+
+Surgery is the treatment of choice for early-stage NSCLC when the tumour can be completely removed. Options include:
+
+- **Lobectomy** — removal of the affected lobe of the lung; the standard surgical approach
+- **Segmentectomy or wedge resection** — removal of a smaller portion of lung; used when full lobectomy is not possible
+- **Pneumonectomy** — removal of the entire lung; reserved for selected cases
+
+Surgery requires adequate lung function and general fitness. Pulmonary function tests help determine whether the remaining lung can support normal breathing.
+
+### Radiotherapy
+
+- **Stereotactic ablative radiotherapy (SABR/SBRT)** — delivers precise high-dose radiation to early-stage tumours; an effective alternative to surgery for people who cannot have an operation
+- **Concurrent chemoradiotherapy** — combines chemotherapy with radiotherapy for locally advanced (Stage III) NSCLC; the standard treatment when surgery is not appropriate
+- **Palliative radiotherapy** — lower-dose treatment to relieve symptoms from advanced cancer (bone pain, breathlessness from airway obstruction)
+
+### Chemotherapy
+
+Chemotherapy uses drugs that target rapidly dividing cells. In lung cancer it is used:
+
+- **Adjuvant chemotherapy** — after surgery in Stage II–IIIA NSCLC to reduce recurrence risk
+- **In combination with radiotherapy** — for locally advanced disease
+- **As systemic treatment** — for advanced NSCLC or SCLC, often combined with immunotherapy
+- **As first-line treatment** — for SCLC (etoposide + carboplatin or cisplatin)
+
+### Immunotherapy
+
+Immunotherapy drugs (checkpoint inhibitors — pembrolizumab, nivolumab, atezolizumab, durvalumab) block the mechanisms cancer cells use to avoid immune detection. They are now a standard part of treatment for many advanced NSCLC cases, either alone or combined with chemotherapy. Eligibility depends on PD-L1 expression and the absence of targetable mutations.
+
+### Targeted Therapy
+
+For NSCLC with a targetable molecular alteration, specific drugs may be substantially more effective than standard chemotherapy:
+
+- **EGFR-mutated NSCLC:** osimertinib (Tagrisso), erlotinib, gefitinib
+- **ALK-rearranged NSCLC:** alectinib, brigatinib, lorlatinib
+- **KRAS G12C-mutated NSCLC:** sotorasib, adagrasib
+- **Other targets (ROS1, MET, BRAF, RET, NTRK):** multiple approved agents depending on the specific alteration
+
+Targeted therapy is oral medication taken daily. It is not appropriate without molecular testing confirming the relevant mutation.
+
+### Palliative and Supportive Care
+
+[Palliative care](/guides/palliative-care) is specialised support focused on symptom relief and quality of life. It is appropriate at any stage of lung cancer — not only at end of life. Palliative care helps manage breathlessness, pain, fatigue, nausea, and emotional distress. It can be delivered alongside cancer-directed treatment. Referral to a palliative care team early in the course of advanced lung cancer is associated with better quality of life and, in some studies, improved survival.
+
+---
+
+## Living with Lung Cancer
+
+### Breathlessness
+
+Breathlessness is one of the most common and distressing symptoms of lung cancer. It may be caused by the tumour itself, pleural effusion, anaemia, or treatment side effects. Management includes:
+
+- Breathing exercises and positions (sitting forward, pursed-lip breathing)
+- Oxygen therapy when indicated
+- Opioid medications (low-dose opioids reduce breathlessness safely in advanced disease)
+- Pleural drainage for effusion
+- Referral to palliative care for specialist symptom management
+
+### Fatigue
+
+Cancer-related fatigue affects most people with lung cancer. It is different from ordinary tiredness — it is not relieved by rest and can be severe. Strategies include pacing activity, maintaining as much gentle exercise as tolerated, treating anaemia if present, and addressing sleep disruption.
+
+### Nutrition
+
+Lung cancer and its treatment can affect appetite and weight. Maintaining nutritional intake supports treatment tolerance and recovery. A dietitian can provide personalised support, including managing swallowing difficulties or treatment-related nausea.
+
+### Cough Management
+
+A persistent cough is distressing and may be difficult to fully control. Options include cough suppressants, humidified air, treating reversible causes (infection, reflux), and specialist cough physiotherapy. For cough caused by pleural effusion, drainage may provide relief.
+
+### Emotional and Psychological Support
+
+A lung cancer diagnosis causes significant psychological distress for most people and their families. Anxiety, depression, grief, and uncertainty about the future are common. Support from:
+
+- Clinical psychologists or counsellors attached to cancer services
+- Cancer support groups and peer networks
+- Lung cancer helplines and patient advocacy organisations
+- Palliative care teams skilled in emotional support
+
+should be offered alongside physical care. Partners, carers, and family members may also need their own support.
+
+---
+
+## When to Seek Urgent Help
+
+**Go to an emergency department or call emergency services for:**
+
+- Coughing up a significant amount of blood
+- Sudden or severely worsening [shortness of breath](/guides/shortness-of-breath) at rest
+- [Chest pain](/guides/chest-pain) that is severe, new, or worsening
+- Swelling of the face, neck, or arms — particularly with a feeling of fullness in the head (may indicate superior vena cava syndrome)
+- Sudden confusion, severe headache, or new neurological symptoms (weakness, loss of speech)
+- Fainting or collapse
+- High fever with chills, particularly if you are on chemotherapy (possible neutropenic sepsis — a medical emergency)
+- Rapid worsening of any symptoms over hours to a day
+
+Contact your cancer team promptly for any concerning changes in your condition between scheduled appointments.
+
+---
+
+## FAQ
+
+**Q: What are common symptoms of lung cancer?**
+Common symptoms include a persistent cough, coughing up blood, chest pain, shortness of breath, recurrent chest infections, unexplained weight loss, fatigue, and hoarseness. Many early lung cancers cause no symptoms at all.
+
+**Q: Can people who have never smoked get lung cancer?**
+Yes. While smoking is the biggest risk factor, lung cancer also occurs in never-smokers. Radon exposure, asbestos, air pollution, and genetic factors also contribute.
+
+**Q: How is lung cancer diagnosed?**
+Diagnosis usually begins with imaging (chest X-ray, CT scan) and is confirmed by biopsy — laboratory examination of tumour tissue. Molecular testing of the biopsy guides treatment.
+
+**Q: What is the difference between screening and diagnosis?**
+Screening uses low-dose CT to look for early lung cancer in people at elevated risk who have no symptoms. Diagnostic testing is done when symptoms develop or a screening result is abnormal. The two serve different purposes.
+
+**Q: Is lung cancer treatable?**
+Yes, treatment is available and depends on type, stage, and general health. Options include surgery, radiotherapy, chemotherapy, immunotherapy, targeted therapy, and palliative care. Early-stage disease has much better outcomes than advanced disease.
+
+**Q: What is non-small cell lung cancer?**
+Non-small cell lung cancer (NSCLC) is the most common type, accounting for about 85% of cases. It includes adenocarcinoma, squamous cell carcinoma, and large cell carcinoma. Treatment depends on stage and molecular testing.
+
+**Q: What does molecular testing mean for lung cancer treatment?**
+Molecular testing analyses the tumour for specific genetic changes — mutations or fusions — that can be matched to targeted drugs. Results determine whether targeted therapy, immunotherapy, or chemotherapy is most appropriate.
+
+---
+
+## Further Reading
+
+- [Cancer Council Australia — Lung Cancer](https://www.cancer.org.au/cancer-information/types-of-cancer/lung-cancer) — Australian patient information on lung cancer
+- [Cancer Research UK — Lung Cancer](https://www.cancerresearchuk.org/about-cancer/lung-cancer) — Comprehensive UK patient guide
+- [National Cancer Institute — Lung Cancer](https://www.cancer.gov/types/lung) — US NCI patient information and treatment summaries
+- [American Cancer Society — Lung Cancer](https://www.cancer.org/cancer/types/lung-cancer.html) — Patient-facing overview with staging and treatment information
+- [Lung Foundation Australia](https://lungfoundation.com.au/) — Australian lung health support and advocacy
+
+---
+
+## Related Guides
+
+- [Lung Cancer Screening: Low-Dose CT, Benefits, Risks, and Eligibility](/guides/lung-cancer-screening-low-dose-ct)
+- [Cancer — Guide Hub](/guides/cancer)
+- [Precision Medicine in Cancer: Biomarkers, Targeted Therapy, and Genetic Testing](/guides/precision-medicine-in-cancer)
+- [COPD: Chronic Obstructive Pulmonary Disease](/guides/copd)
+- [Shortness of Breath — When to Seek Urgent Help](/guides/shortness-of-breath)
+- [Smoking Cessation — Methods, Support, and What Actually Works](/guides/smoking-cessation)
+- [Palliative Care — Guide Hub](/guides/palliative-care)
+- [Respiratory Hub](/guides/respiratory-hub)
+
+---
+
+_This guide is for educational purposes only and is not a substitute for professional medical advice. If you have symptoms that concern you, speak with your doctor._

--- a/src/content/guides/lung-cancer-screening-low-dose-ct.md
+++ b/src/content/guides/lung-cancer-screening-low-dose-ct.md
@@ -287,6 +287,7 @@ A GP referral is required for LDCT in most Australian contexts.
 
 ## Related Guides
 
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview) — Full patient guide to lung cancer types, symptoms, diagnosis, and treatment
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Cancer — Guide Hub](/guides/cancer)
 - [Smoking Cessation — Methods, Support, and What Actually Works](/guides/smoking-cessation)

--- a/src/content/guides/melanoma-overview.md
+++ b/src/content/guides/melanoma-overview.md
@@ -1,0 +1,368 @@
+---
+title: "Melanoma: Symptoms, Diagnosis, and Treatment"
+description: "A patient-friendly guide to melanoma, including warning signs, skin checks, diagnosis, staging, treatment options, and follow-up."
+category: "Cancer"
+publishDate: "2026-06-08"
+updatedDate: "2026-06-08"
+draft: false
+tags:
+  - melanoma
+  - skin cancer
+  - moles
+  - cancer
+  - sun protection
+faq:
+  - q: "What does melanoma usually look like?"
+    a: "Melanoma may appear as a new or changing spot, mole, or patch of skin. Warning signs include asymmetry, irregular borders, uneven colour, change in size, or bleeding. Some melanomas do not look like typical moles — they may appear as a flat, discoloured patch or a pink nodule."
+  - q: "Can melanoma occur on skin that is not exposed to the sun?"
+    a: "Yes. Melanoma is more common on sun-exposed skin, but it can also occur on less exposed areas including the scalp, sole of the foot, under nails, between toes, and — rarely — in the eye or on mucosal surfaces (inside the mouth or genitals)."
+  - q: "How is melanoma diagnosed?"
+    a: "Melanoma is usually diagnosed by removing a suspicious spot entirely (excision biopsy) or taking a partial biopsy, so the tissue can be examined under a microscope. A dermoscope may help a clinician assess a lesion before deciding whether biopsy is needed."
+  - q: "Is melanoma treatable?"
+    a: "Many melanomas are treatable, especially when found early. Localised melanoma removed completely with clear surgical margins is often cured. Treatment for advanced melanoma has improved greatly with immunotherapy and targeted therapy. Outcomes depend on tumour thickness, spread, and overall health."
+  - q: "When should I get a mole checked?"
+    a: "A mole or skin spot should be checked promptly if it is new, growing, bleeding, painful, itchy, crusting, or looks different from your other spots. Any lesion that does not heal within a few weeks also warrants review."
+  - q: "Who is at higher risk of melanoma?"
+    a: "Higher-risk groups include people with fair skin, a history of sunburn (particularly blistering sunburn in childhood or adolescence), many moles or atypical (dysplastic) moles, a personal or family history of melanoma, use of tanning beds, and those who are immunosuppressed."
+  - q: "What is the ABCDE rule?"
+    a: "The ABCDE rule is a guide to warning signs in a mole or skin lesion: Asymmetry (one half differs from the other), Border (irregular, ragged, or blurred edges), Colour (uneven or multiple shades — brown, black, red, white, or blue), Diameter (larger than 6mm, roughly the size of a pencil eraser), Evolving (changing in size, shape, colour, or behaviour over time). Any one of these features warrants prompt medical review."
+---
+
+## What Is Melanoma?
+
+Melanoma is a cancer that develops from melanocytes — the pigment-producing cells in the skin. Although it is less common than basal cell carcinoma and squamous cell carcinoma, melanoma is the most serious form of skin cancer because of its ability to spread (metastasise) to lymph nodes and distant organs if not caught early.
+
+Australia and New Zealand have among the **highest melanoma rates in the world**, driven by high UV radiation levels and a predominantly fair-skinned population. In Australia, approximately **18,000 people** are diagnosed with melanoma each year, and it is one of the most common cancers in people under 40.
+
+The good news: melanoma detected at an early stage — before it has grown deep or spread — is usually curable with surgery. Early detection matters enormously.
+
+---
+
+## Key Points
+
+- Melanoma arises from pigment-producing skin cells (melanocytes) and is the most serious form of skin cancer.
+- Australia has one of the highest melanoma rates in the world — UV radiation is the primary driver.
+- Early-stage melanoma removed completely is often cured; prognosis worsens with increasing thickness and spread.
+- The ABCDE rule helps identify suspicious lesions: Asymmetry, Border, Colour, Diameter, Evolving.
+- Not all melanomas look like typical dark moles — nodular melanoma may be pink or skin-coloured.
+- Melanoma can occur on any area of skin, including sun-protected areas and under nails.
+- Treatment for early-stage disease is surgery; advanced melanoma is treated with immunotherapy and targeted therapy.
+- Regular skin checks and sun protection are the cornerstones of prevention and early detection.
+- People with risk factors (fair skin, many moles, family history) benefit from regular professional skin checks.
+
+---
+
+## Why Melanoma Matters
+
+### It Can Be Serious
+
+Melanoma is disproportionately lethal compared with other skin cancers. When it is detected and removed early — while still thin and localised — the outlook is excellent. When it spreads to the lymph nodes or distant organs, treatment is substantially more challenging, though treatment advances in the last decade (immunotherapy and targeted therapy) have significantly improved outcomes even in advanced disease.
+
+### Early Detection Makes a Difference
+
+Tumour thickness at the time of removal is the single strongest predictor of outcome. Thin melanomas (under 1mm, T1) have a ten-year survival rate above 90%. Thick or metastatic melanomas have much lower survival rates. This is the reason regular skin checks and prompt review of suspicious spots are so important.
+
+### Not All Melanomas Look the Same
+
+The classic picture of a dark, irregular mole is only one presentation. Melanomas can be:
+
+- **Superficial spreading melanoma** — the most common type; a flat or slightly raised discoloured patch that grows outward before thickening
+- **Nodular melanoma** — grows vertically and quickly; may be pink, red, or skin-coloured rather than dark; accounts for a disproportionate number of melanoma deaths because it is often not recognised early
+- **Lentigo maligna melanoma** — a flat lesion developing on chronically sun-damaged skin, particularly the face; tends to occur in older adults
+- **Acral lentiginous melanoma** — on the palms, soles, or under nails; not related to UV exposure; more common in darker-skinned populations
+
+---
+
+## Warning Signs
+
+### The ABCDE Rule
+
+The ABCDE rule guides recognition of suspicious skin lesions:
+
+| Letter | Meaning | What to look for |
+|---|---|---|
+| **A** | Asymmetry | One half looks different from the other |
+| **B** | Border | Irregular, ragged, notched, or blurred edges |
+| **C** | Colour | Multiple shades — varying brown, black, red, white, or blue within the same spot |
+| **D** | Diameter | Larger than 6mm (about the size of a pencil eraser) — though melanomas can be smaller |
+| **E** | Evolving | Any change in size, shape, colour, or behaviour over weeks to months |
+
+Any one of these features warrants prompt review by a clinician.
+
+### The Ugly Duckling Sign
+
+The ugly duckling sign is a useful complementary approach: compare a suspicious spot to the other spots on your body. Most people have a consistent "family" of moles. A lesion that looks markedly different from all your others — standing out like an ugly duckling — is more likely to warrant review, regardless of whether it meets all ABCDE criteria.
+
+### Other Warning Signs
+
+- A new spot or mole in adulthood (particularly after the age of 40)
+- A mole that bleeds without trauma, or that repeatedly catches on clothing
+- A spot that itches, crusts, or does not fully heal
+- A non-healing ulcer or sore on the skin
+- Nail changes: a dark (brown or black) streak running lengthwise under a nail, particularly if it is widening, irregular, or associated with nail distortion — especially in an adult with no prior nail injury. A dark streak under the nail in a darker-skinned person is more likely to be benign, but unexplained or changing streaks in any person warrant medical assessment.
+
+---
+
+## Risk Factors
+
+### Ultraviolet (UV) Radiation
+
+Cumulative UV exposure — from sun and from tanning beds — is the primary driver of melanoma. UV radiation damages the DNA in skin cells. Both UVA and UVB contribute.
+
+**Sunburn** is a particularly important risk factor. Blistering sunburns in childhood or adolescence significantly increase lifetime melanoma risk, even if sun exposure is reduced in later life.
+
+### Tanning Beds
+
+Tanning beds emit UV radiation that causes the same DNA damage as sunlight. Using tanning beds before age 35 increases melanoma risk by approximately 59% (IARC). There is no safe tan from a tanning bed.
+
+### Fair Skin and Sun-Sensitive Phenotype
+
+People with fair skin, light or red hair, blue or green eyes, and a tendency to burn rather than tan have higher melanoma risk. This reflects reduced baseline melanin protection in the skin.
+
+### Many Moles or Atypical Moles
+
+Having a large number of ordinary moles (more than 50) or atypical (dysplastic) moles — which are often larger than ordinary moles, with irregular edges and variable colour — increases melanoma risk. People with many atypical moles, particularly those with a family history of melanoma, may benefit from regular specialist surveillance.
+
+### Family History and Genetics
+
+Approximately **10% of melanomas** occur in people with a family history of the disease. Having a first-degree relative with melanoma approximately doubles individual risk. Rare inherited syndromes (including pathogenic variants in CDKN2A, CDK4, and other genes) account for a small proportion of familial cases. Genetic counselling is available for families with multiple melanoma diagnoses.
+
+### Personal History of Melanoma or Skin Cancer
+
+A person who has had melanoma has a significantly elevated risk of developing a second melanoma. Lifelong skin surveillance is recommended.
+
+### Immunosuppression
+
+People whose immune system is suppressed — including organ transplant recipients, those on long-term immunosuppressive medications, or people with HIV — have a substantially elevated skin cancer risk, including melanoma. Skin checks are particularly important in this group.
+
+---
+
+## Diagnosis
+
+### Skin Examination and Dermoscopy
+
+The diagnostic process begins with a thorough skin examination by a GP or dermatologist. A **dermoscope** — a handheld illuminated magnifier — allows the clinician to visualise structures beneath the skin surface and better assess whether a lesion is suspicious. Dermoscopy improves diagnostic accuracy compared with naked eye examination.
+
+In some settings, total body photography is offered for high-risk patients — photographs of the entire skin surface used as a baseline for tracking changes over time.
+
+### Biopsy
+
+Definitive diagnosis requires a **biopsy** — removal of tissue for laboratory examination. For a lesion suspicious for melanoma:
+
+- **Excision biopsy** (removal of the entire lesion with a small margin) is the preferred approach — it provides the complete lesion for pathological assessment, including thickness measurement.
+- **Punch or shave biopsy** may be used when the lesion is large or in a cosmetically sensitive location, though these have limitations because they may not capture the full depth of the lesion.
+
+The biopsy is examined by a pathologist. The pathology report provides the information needed for staging and treatment planning.
+
+### The Pathology Report
+
+Key information in the pathology report includes:
+
+- **Breslow thickness** — the depth of the melanoma measured from the top of the granular skin layer to the deepest tumour cell. This is the most important single prognostic factor. Melanomas under 1mm (thin) have an excellent prognosis; those over 4mm (thick) have a substantially worse prognosis.
+- **Ulceration** — whether the surface of the melanoma is broken down; worsens prognosis
+- **Mitotic rate** — how rapidly tumour cells are dividing
+- **Histological subtype** (superficial spreading, nodular, lentigo maligna, acral lentiginous)
+- **Margins** — whether the melanoma was removed with clear (cancer-free) edges
+
+---
+
+## Staging
+
+Melanoma is staged using the AJCC (American Joint Committee on Cancer) TNM system. In plain terms:
+
+| Stage | Description | Typical Prognosis |
+|---|---|---|
+| **Stage 0** | Melanoma in situ — cancer cells present only in the outermost skin layer (epidermis) | Virtually 100% cure rate with complete excision |
+| **Stage I** | Thin, localised melanoma (≤2mm, no ulceration or low mitotic rate) | 10-year survival 90%+ |
+| **Stage II** | Thicker or ulcerated localised melanoma, no nodal spread | 10-year survival approximately 60–80% depending on subgroup |
+| **Stage III** | Spread to regional lymph nodes or in-transit metastases (satellite tumours between primary and nodes) | Variable; 10-year survival approximately 40–70% depending on nodal burden |
+| **Stage IV** | Distant metastases — spread to other organs (lungs, liver, brain, bone, other skin) | Historically poor prognosis; substantially improved with immunotherapy and targeted therapy |
+
+Staging determines whether a **sentinel lymph node biopsy** is recommended and guides decisions about adjuvant therapy after surgery.
+
+---
+
+## Treatment
+
+### Surgical Excision
+
+Surgery is the primary treatment for localised melanoma. After a diagnostic biopsy confirms melanoma, a **wide local excision** is performed — removal of the melanoma site with a margin of surrounding normal tissue. The recommended margin depends on Breslow thickness:
+
+- Melanoma in situ: 5–10mm margin
+- Thin melanoma (<1mm): 10mm margin
+- Intermediate thickness (1–2mm): 10–20mm margin
+- Thick melanoma (>2mm): 20mm margin
+
+Achieving clear surgical margins is the goal of definitive surgery.
+
+### Sentinel Lymph Node Biopsy
+
+For melanomas of ≥1mm thickness (or thinner melanomas with high-risk features), a **sentinel lymph node biopsy (SLNB)** may be recommended. This procedure:
+
+- Identifies the first lymph node(s) to drain the melanoma site (the sentinel nodes)
+- Removes these nodes for pathological examination
+- Determines whether microscopic spread to the lymph nodes has occurred (staging information)
+- Informs decisions about adjuvant (preventive) systemic therapy
+
+SLNB is a staging procedure, not a curative one — it provides crucial information but does not itself treat melanoma.
+
+### Adjuvant (Preventive) Systemic Therapy
+
+For Stage III (and selected Stage II) melanoma, adjuvant therapy after surgery aims to reduce recurrence risk:
+
+- **Adjuvant immunotherapy** — pembrolizumab or nivolumab for resected Stage III disease; significantly reduces recurrence risk
+- **Adjuvant targeted therapy** — dabrafenib + trametinib (BRAF/MEK inhibitors) for resected Stage III melanoma with a BRAF V600E or V600K mutation
+
+### Immunotherapy for Advanced Melanoma
+
+Immunotherapy has transformed the treatment of advanced (Stage IV) melanoma. Checkpoint inhibitors block the brakes that cancer cells use to evade immune detection:
+
+- **Pembrolizumab** (anti-PD-1)
+- **Nivolumab** (anti-PD-1)
+- **Ipilimumab** (anti-CTLA-4)
+- **Nivolumab + ipilimumab** (combination) — higher response rate but also more side effects
+
+Long-term responses (durable remission in a proportion of patients) have been observed — a major advance compared to chemotherapy.
+
+### Targeted Therapy for BRAF-Mutated Melanoma
+
+Approximately **50% of melanomas** carry a BRAF V600 mutation. For these tumours, targeted therapy with a BRAF inhibitor combined with a MEK inhibitor produces rapid responses:
+
+- **Dabrafenib + trametinib**
+- **Vemurafenib + cobimetinib**
+- **Encorafenib + binimetinib**
+
+Targeted therapy is particularly useful when rapid tumour shrinkage is needed. BRAF mutation testing is routine in advanced melanoma.
+
+### Radiotherapy
+
+Radiotherapy is used in selected situations:
+
+- To treat residual disease at the lymph node basin after surgery
+- For palliation of symptomatic metastases (bone pain, brain metastases)
+- Stereotactic radiosurgery (e.g., Gamma Knife) for brain metastases
+
+### Palliative and Supportive Care
+
+[Palliative care](/guides/palliative-care) addresses symptoms, quality of life, and emotional wellbeing for people with advanced melanoma — alongside or instead of tumour-directed treatment. Early palliative care involvement improves quality of life and is not only appropriate at end of life.
+
+---
+
+## Follow-Up and Recurrence Monitoring
+
+After treatment for melanoma, ongoing follow-up is important to detect recurrence early and to identify new primary melanomas.
+
+### Professional Skin Checks
+
+Regular whole-body skin examinations are recommended for all people who have had melanoma. Frequency varies by stage and risk:
+
+- Every 3–6 months for the first 1–2 years
+- Every 6–12 months thereafter, often lifelong for higher-risk individuals
+
+Dermatologists or specialist skin cancer clinics provide structured surveillance, sometimes using total body photography and digital dermoscopy to track changes over time.
+
+### Self-Checking
+
+Learning to examine your own skin between professional checks is important. Check your entire skin surface monthly — including the scalp, between the fingers and toes, soles of the feet, and under nails. Use a mirror or ask a partner to check your back.
+
+Any new or changed lesion between checks should be reviewed promptly rather than waiting for the next scheduled appointment.
+
+### Lymph Node Monitoring
+
+After sentinel lymph node biopsy or lymph node surgery, follow-up includes clinical examination of the lymph node regions draining the melanoma site. CT or PET scanning may be used at intervals in higher-stage disease.
+
+### Family Awareness
+
+First-degree relatives of someone diagnosed with melanoma should be encouraged to have a baseline skin check and to establish regular sun protection habits. Genetic counselling is appropriate in families with multiple melanoma diagnoses across generations.
+
+---
+
+## Prevention
+
+### Sunscreen
+
+Broad-spectrum sunscreen (SPF 30 or higher) applied generously and reapplied every two hours — and after swimming or sweating — reduces UV exposure to skin. Daily sunscreen use, even on cloudy days, reduces cumulative damage. See: [Sunscreen: Benefits, SPF Explained, and How It Protects Skin](/guides/sunscreen)
+
+### Protective Clothing and Shade
+
+- Long-sleeved shirts and pants provide greater protection than sunscreen alone
+- Wide-brimmed hats protect the face, neck, and ears
+- UV-protective sunglasses protect the eyes and periorbital skin
+- Seeking shade between 10am and 4pm (peak UV hours in Australia) reduces exposure substantially
+
+### Avoiding Tanning Beds
+
+Tanning beds increase melanoma risk — there is no safe use of UV tanning equipment. This is particularly important for people under 35.
+
+### Skin Checks for Higher-Risk People
+
+People with fair skin, a history of sunburn, many moles, atypical moles, a personal or family history of melanoma, or a history of immunosuppression benefit from regular professional skin checks. The frequency should be discussed with a GP or dermatologist based on individual risk.
+
+See: [Skin Cancer — Prevention](/guides/skin-cancer-prevention) | [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention)
+
+---
+
+## When to Seek Medical Help
+
+See your doctor promptly for any skin spot or mole that:
+
+- Is new or has appeared in adulthood (particularly after age 40)
+- Has grown, changed shape, or changed colour over weeks to months
+- Is bleeding without trauma, or bleeds repeatedly
+- Is persistently itching, crusting, or not healing
+- Looks different from all your other spots (ugly duckling sign)
+- Has a dark streak under a nail that is new, widening, or changing in appearance
+- Is on the palms, soles, or other less sun-exposed areas and is changing
+
+Do not wait for a scheduled appointment if a lesion is changing rapidly — seek review within days to weeks, not months.
+
+---
+
+## FAQ
+
+**Q: What does melanoma usually look like?**
+It may appear as a new or changing spot, mole, or patch of skin. Warning signs include asymmetry, irregular borders, uneven colour, change in size, or bleeding. Not all melanomas are dark — nodular melanoma can be pink or skin-coloured.
+
+**Q: Can melanoma occur on skin that is not exposed to the sun?**
+Yes. Melanoma is more common on sun-exposed skin, but it can also occur on less exposed areas, under nails, on the soles of the feet, and — rarely — in the eye or mucosal surfaces.
+
+**Q: How is melanoma diagnosed?**
+By removing the suspicious spot (excision biopsy) or taking a biopsy, then examining the tissue under a microscope. Dermoscopy helps assess suspicious lesions before biopsy.
+
+**Q: Is melanoma treatable?**
+Many melanomas are curable when caught early. Advanced melanoma has been substantially transformed by immunotherapy and targeted therapy, with durable responses in some patients. Early detection remains the most effective strategy.
+
+**Q: When should I get a mole checked?**
+Any mole or spot that is new, growing, bleeding, itching, changing, or looks different from your others should be checked promptly. Do not wait — changes over weeks should be reviewed within days to weeks.
+
+**Q: Who is at higher risk of melanoma?**
+People with fair skin, history of sunburn, many moles, atypical moles, personal or family history of melanoma, tanning bed use, or immunosuppression are at higher risk and should have regular professional skin checks.
+
+**Q: What is the ABCDE rule?**
+A guide to suspicious features: Asymmetry, Border irregularity, Colour variation, Diameter over 6mm, Evolving (changing) appearance. Any one feature warrants medical review.
+
+---
+
+## Further Reading
+
+- [Cancer Council Australia — Melanoma](https://www.cancer.org.au/cancer-information/types-of-cancer/melanoma) — Australian patient information and statistics
+- [American Academy of Dermatology — Melanoma](https://www.aad.org/public/diseases/skin-cancer/melanoma) — detection, treatment, and prevention
+- [National Cancer Institute — Melanoma Treatment](https://www.cancer.gov/types/skin/patient/melanoma-treatment-pdq) — US NCI patient information
+- [Cancer Research UK — Melanoma Skin Cancer](https://www.cancerresearchuk.org/about-cancer/melanoma) — Comprehensive UK patient guide
+- [Melanoma Institute Australia](https://www.melanoma.org.au/) — Australian patient support, research updates, and clinical trial information
+
+---
+
+## Related Guides
+
+- [Cancer — Guide Hub](/guides/cancer)
+- [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention)
+- [Skin Cancer: Diagnosis and Treatment](/guides/skin-cancer-diagnosis-treatment)
+- [Skin Cancer — Prevention](/guides/skin-cancer-prevention)
+- [Sunscreen: Benefits, SPF Explained, and How It Protects Skin](/guides/sunscreen)
+- [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Palliative Care — Guide Hub](/guides/palliative-care)
+
+---
+
+_This guide is for educational purposes only and is not a substitute for professional medical advice. Melanoma treatment decisions should be made with your medical team._

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -147,14 +147,15 @@ Prostate-specific antigen (PSA) testing is more complex than most cancer screens
 
 ---
 
-### Skin Cancer
+### Skin Cancer and Melanoma
 
-Skin cancer is among the most common cancers in Australia and other high UV-exposure countries. Most cases are preventable and treatable when caught early.
+Skin cancer is among the most common cancers in Australia and other high UV-exposure countries. **Melanoma** is the most serious form — it can spread if not caught early, but detected while still thin and localised it is usually curable. Most skin cancers are preventable and most are highly treatable when found early.
 
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview) — a dedicated guide to melanoma: warning signs, the ABCDE rule, the ugly duckling sign, diagnosis, staging, and treatment
 - [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention) — the ABCDE rule for melanoma, what to look for, and self-examination
 - [Skin Cancer — Prevention](/guides/skin-cancer-prevention) — sun protection strategies
 
-**Who should screen:** Australia has no national organised skin cancer screening program, but annual skin checks by a GP or dermatologist are recommended for people with a history of skin cancer, many moles, or significant past sun exposure.
+**Who should screen:** Australia has no national organised skin cancer screening program, but annual skin checks by a GP or dermatologist are recommended for people with a history of skin cancer, many moles, atypical moles, or significant past sun exposure. People with a personal or family history of melanoma benefit from regular specialist skin surveillance.
 
 ---
 

--- a/src/content/guides/respiratory-hub.md
+++ b/src/content/guides/respiratory-hub.md
@@ -13,7 +13,7 @@ tags:
   - shortness of breath
   - wheezing
 publishDate: '2025-09-18'
-updatedDate: '2026-03-02'
+updatedDate: '2026-06-08'
 draft: false
 faq:
   - q: "What conditions affect the respiratory system?"
@@ -59,6 +59,8 @@ Respiratory conditions on PatientGuide are organised across four clinical groups
 - [Wheezing & Night-time Breathlessness](/guides/wheezing-night-time-breathlessness) — distinguishes asthma, sleep apnoea, and cardiac causes of night-time breathlessness
 
 **4. Overlap with other systems** — respiratory disease frequently intersects with cardiovascular disease. Heart failure causes breathlessness that mimics lung disease; COPD and coronary artery disease share risk factors and commonly co-exist. For breathlessness with chest pain, see [When to Seek Emergency Help for Chest Pain](/guides/when-to-seek-emergency-help-for-chest-pain).
+
+**5. Serious lung conditions** — some persistent respiratory symptoms, such as an ongoing cough, coughing blood, unexplained weight loss, or worsening breathlessness, may need assessment for serious causes, including lung cancer. See [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview).
 
 Respiratory infections — including pneumonia, influenza, and COVID-19 — are covered in the [Infectious Diseases hub](/guides/infectious-diseases), where antibiotic and antiviral treatment decisions are also addressed.
 
@@ -170,6 +172,8 @@ Obstructive [sleep apnoea](/guides/sleep-apnoea) occurs when the upper airway re
 - [Sleep Apnoea](/guides/sleep-apnoea)
 - [Shortness of Breath](/guides/shortness-of-breath)
 - [Wheezing & Night-time Breathlessness](/guides/wheezing-night-time-breathlessness)
+- [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview)
+- [Lung Cancer Screening: Low-Dose CT, Benefits, Risks, and Eligibility](/guides/lung-cancer-screening-low-dose-ct)
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)
 - [Infectious Diseases — Guide Hub](/guides/infectious-diseases)
 - [Emergencies — Guide Hub](/guides/emergencies)

--- a/src/content/guides/skin-cancer-diagnosis-treatment.md
+++ b/src/content/guides/skin-cancer-diagnosis-treatment.md
@@ -175,5 +175,6 @@ A: Surgery for early stages, immunotherapy and targeted therapy for advanced dis
 
 ## Related Guides
 - [Skin Cancer — Guide Hub](/guides/skin-cancer)  
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview)  
 - [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention)  
 - [Life After Skin Cancer: Survivorship and Support](/guides/skin-cancer-survivorship)  

--- a/src/content/guides/skin-cancer-prevention.md
+++ b/src/content/guides/skin-cancer-prevention.md
@@ -65,6 +65,7 @@ A: Yes, most can. For babies under 6 months, focus on shade and clothing first.
 
 ## Related Guides
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Melanoma: Symptoms, Diagnosis, and Treatment](/guides/melanoma-overview)
 - [Skin Cancer — Warning Signs and Prevention](/guides/skin-cancer-signs-prevention)
 - [Sunscreen: Benefits, SPF Explained, and How It Protects Skin](/guides/sunscreen)  
 - [Cancer — Guide Hub](/guides/cancer)  


### PR DESCRIPTION
## Summary
- Adds **lung-cancer-overview.md** — full patient guide covering NSCLC/SCLC types, symptoms, risk factors (smoking, radon, asbestos, air pollution), LDCT screening, diagnosis (CT/PET, biopsy, molecular/biomarker testing), TNM staging, treatment (surgery, radiotherapy, chemo, immunotherapy, targeted therapy), living with lung cancer, and urgent red-flag criteria
- Adds **melanoma-overview.md** — dedicated melanoma guide covering ABCDE rule, ugly duckling sign, nodular melanoma awareness, dermoscopy, excision biopsy, Breslow thickness, SLNB, BRAF-targeted therapy, immunotherapy, follow-up surveillance, prevention, and when to seek help
- Updates **cancer.md** hub: both new guides added to Start Here, Cancer Type Hubs, and Cervical/Skin Guides sections; ovarian and testicular cancer overviews linked for the first time; updatedDate bumped
- Updates **preventive-screening-hub.md**: Skin Cancer section expanded with melanoma overview link and melanoma-specific surveillance copy
- Updates **respiratory-hub.md**: new 'serious lung conditions' paragraph linking to lung-cancer-overview; Related Guides updated
- Updates **lung-cancer-screening-low-dose-ct.md**: lung-cancer-overview added to Related Guides
- Updates **skin-cancer-diagnosis-treatment.md** and **skin-cancer-prevention.md**: melanoma-overview added to Related Guides

## Checks
- \
pm run content:check\: 0 errors | 22 warnings (matches documented baseline)
- \
pm run build\: 750 pages, 0 errors
- Routes confirmed: \/guides/lung-cancer-overview/\ and \/guides/melanoma-overview/\ present in dist