### PR TITLE
feat(kidney): add CKD hub and management guide

### DIFF
--- a/src/content/guides/chronic-kidney-disease-hub.md
+++ b/src/content/guides/chronic-kidney-disease-hub.md
@@ -1,0 +1,334 @@
+---
+title: "Chronic Kidney Disease — Guide Hub"
+description: "A guide hub for chronic kidney disease, including causes, stages, tests, treatment, monitoring, complications, dialysis, transplant, and related conditions."
+category: "Guide Hubs"
+publishDate: "2026-06-08"
+updatedDate: "2026-06-08"
+draft: false
+tags: ["chronic kidney disease", "kidney disease", "kidney function", "CKD", "diabetes", "blood pressure", "dialysis", "kidney transplant", "hub"]
+faq:
+  - question: "What is chronic kidney disease?"
+    answer: "Chronic kidney disease means the kidneys have reduced function or signs of damage for a sustained period — generally defined as three months or more. It can range from mild and stable to advanced, depending on test results, underlying causes, and complications."
+  - question: "What tests are used to check kidney disease?"
+    answer: "Common tests include blood tests for kidney function (eGFR, creatinine), urine tests for albumin or protein (ACR), blood pressure checks, and sometimes imaging. Both the blood and urine tests together give a more complete picture than either alone."
+  - question: "Can chronic kidney disease be slowed down?"
+    answer: "In many people, progression can be slowed with blood pressure control, diabetes management, medication review, lifestyle changes, and treatment of the underlying cause. Early detection and consistent follow-up give the best chance of keeping kidney function stable."
+  - question: "Does chronic kidney disease always lead to dialysis?"
+    answer: "No. Many people with chronic kidney disease — especially those diagnosed at an early stage — never need dialysis. Good management significantly reduces the risk of reaching kidney failure."
+  - question: "When should someone see a kidney specialist?"
+    answer: "Referral to a kidney specialist (nephrologist) depends on kidney function, urine results, blood pressure, the underlying cause, how quickly function is changing, and complications. A clinician can advise on when specialist review is appropriate."
+---
+
+## Introduction
+
+Chronic kidney disease (CKD) is one of the most common long-term conditions worldwide — yet most people who have it are unaware until it reaches a more advanced stage. The kidneys work silently, and early damage rarely causes symptoms.
+
+This hub is the central navigation point for PatientGuide's kidney health content: what CKD is, how it is staged, how it is managed, how it interacts with diabetes, blood pressure, and heart disease, and what to expect at more advanced stages.
+
+CKD is not one condition with one cause. It arises from long-term kidney damage — most often from diabetes or high blood pressure — and covers a wide spectrum from very mild to severe. Most people with CKD, particularly those diagnosed early, never reach kidney failure. The goal of management is to keep it that way.
+
+---
+
+## Key Points
+
+- CKD is persistent kidney damage or reduced function lasting three months or more
+- It is very common and usually **has no symptoms** in early and moderate stages
+- The most common causes are **type 2 diabetes** and **high blood pressure**
+- Early detection depends on blood and urine tests — not symptoms
+- **Most people with CKD never reach kidney failure**
+- All stages of CKD carry increased risk of **cardiovascular disease**
+- Management focuses on slowing progression and reducing heart and blood vessel risk
+
+---
+
+## Start Here
+
+Begin with these three guides to build a clear foundation:
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — what CKD means, why it is often silent, how it is measured, and when to seek advice
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) — the full staging system using eGFR and urine albumin, and how to interpret the numbers
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — a practical guide to slowing progression, monitoring, medicines, diet, complications, and planning ahead
+
+---
+
+## Understanding CKD
+
+### What Is CKD and How Does It Develop?
+
+CKD is defined as kidney damage or reduced kidney function — persisting for three months or more. The damage is usually gradual and cumulative. Over time, healthy kidney tissue is replaced by scar tissue that cannot filter blood.
+
+The kidneys filter waste products, regulate fluid balance, control blood pressure, produce hormones that stimulate red blood cell production, and activate vitamin D for bone health. When function is impaired — even partially — the effects can ripple across multiple body systems.
+
+**Most common causes:**
+- Type 2 diabetes (leading cause worldwide — sustained high blood glucose damages the kidney's filtration units)
+- High blood pressure (sustained elevated pressure damages delicate kidney structures)
+- Obesity (contributes via blood pressure and metabolic pathways)
+- Glomerulonephritis (inflammation of the kidney's filtering units)
+- Polycystic kidney disease (inherited condition causing fluid-filled cysts)
+- Autoimmune conditions, including lupus
+- Recurrent kidney infections
+- Obstruction from kidney stones, enlarged prostate, or structural abnormalities
+- Long-term use of certain medicines, including NSAIDs
+
+In some people, no single cause is identified. Age and genetics both contribute.
+
+See: [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease)
+
+---
+
+### Kidney Function Tests
+
+Two key tests are used to assess CKD:
+
+**eGFR (estimated glomerular filtration rate)**
+eGFR estimates how efficiently the kidneys are filtering blood per minute. It is calculated from a blood test for serum creatinine, along with age and sex. A lower eGFR indicates reduced filtering capacity.
+
+**Urine albumin (ACR — albumin-to-creatinine ratio)**
+Albumin is a protein that should stay in the blood. When kidneys are damaged, albumin leaks into the urine. The ACR measures how much is leaking — an early and sensitive indicator of kidney damage.
+
+Both tests together tell a more complete story than either alone. A person with a normal eGFR but elevated albumin may still have early CKD. A person with mildly reduced eGFR but normal albumin may not have CKD at all — particularly if older.
+
+---
+
+### CKD Stages
+
+CKD is classified using eGFR and urine albumin together, from Stage 1 (mildest) to Stage 5 (kidney failure). Stage 3 is divided into 3a and 3b because the risk profile differs meaningfully between them.
+
+Most people with CKD are at Stages 1–3. Many remain stable at these stages for many years with good management.
+
+See: [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained)
+
+---
+
+### Blood Pressure and Kidney Health
+
+Blood pressure and kidney health are deeply interconnected. High blood pressure damages the kidneys' filtration structures. Kidney disease, in turn, can raise blood pressure — creating a cycle where each makes the other worse.
+
+Blood pressure monitoring and treatment are central to CKD care at every stage. For many people, keeping blood pressure well controlled is the single most important thing they can do to protect their kidney function.
+
+See: [High Blood Pressure (Hypertension)](/guides/high-blood-pressure)
+
+---
+
+## CKD and Related Conditions
+
+### Diabetes
+
+Type 2 diabetes is the leading cause of CKD worldwide. Persistently elevated blood glucose damages the small blood vessels supplying the kidney's filtering units — a process known as diabetic nephropathy.
+
+People with diabetes and CKD need careful monitoring of both kidney function and blood glucose. Managing diabetes well reduces the rate of kidney damage. At the same time, some diabetes medicines require dose adjustment or monitoring in CKD.
+
+Importantly, CKD is not exclusive to people with diabetes. It develops in many people whose primary condition is high blood pressure, a kidney-specific disease, or another cause entirely.
+
+See: [Diabetes Hub](/guides/diabetes-hub) | [Type 2 Diabetes](/guides/type-2-diabetes)
+
+---
+
+### High Blood Pressure
+
+High blood pressure is both a cause and a consequence of CKD. For this reason, detecting and treating hypertension is a central part of kidney protection at every stage — not just in those with obvious cardiovascular risk.
+
+Certain blood pressure medicines (ACE inhibitors and ARBs) have additional kidney-protective properties beyond lowering blood pressure, and are commonly used in CKD with appropriate monitoring.
+
+See: [High Blood Pressure (Hypertension)](/guides/high-blood-pressure)
+
+---
+
+### Heart Disease and Cardiovascular Risk
+
+CKD significantly raises the risk of heart attack, stroke, and heart failure. For many people with CKD — particularly those with mild to moderate disease — cardiovascular complications are a greater near-term risk than progression to kidney failure.
+
+The relationship between kidney and heart disease is sometimes called cardiorenal syndrome: each organ can damage the other through shared mechanisms involving blood pressure, fluid balance, inflammation, and metabolic changes.
+
+Cardiovascular risk reduction — through blood pressure, cholesterol, diabetes management, and lifestyle — is therefore a core component of CKD care, not a separate issue.
+
+See: [Heart & Circulation Hub](/guides/heart-circulation) | [Preventing Heart Disease](/guides/preventing-heart-disease) | [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
+
+---
+
+### Ageing and CKD
+
+Kidney function naturally declines modestly with age. A mildly reduced eGFR in an older adult without other signs of kidney damage may not represent CKD. Context matters — clinicians interpret eGFR in light of age, trends over time, and the presence or absence of albuminuria.
+
+Ageing also raises the prevalence of diabetes and hypertension, which in turn increases CKD risk. For older adults with multiple conditions, CKD management is integrated with broader cardiovascular and metabolic care.
+
+---
+
+### Medication Safety in CKD
+
+Many medicines are processed by or excreted through the kidneys. In people with reduced kidney function, certain medicines may:
+- Accumulate to higher-than-intended levels
+- Cause direct kidney harm
+- Need dose adjustment
+
+NSAIDs (such as ibuprofen and naproxen) reduce blood flow to the kidneys and can accelerate CKD progression — people with kidney disease are generally advised to avoid their regular use.
+
+Iodinated contrast dyes used in CT scans and some other procedures can also affect kidney function in susceptible individuals. People with known CKD should always inform imaging teams of their kidney function before contrast procedures.
+
+A pharmacist or clinician can review medicines for kidney-related safety considerations.
+
+See: [Managing Chronic Kidney Disease — Medication Safety](/guides/managing-chronic-kidney-disease)
+
+---
+
+## Treatment and Management
+
+### Blood Pressure Control
+
+Keeping blood pressure well controlled is the most important intervention for slowing CKD progression. Target blood pressure in CKD is generally lower than for the general population, particularly in people with significant albuminuria.
+
+ACE inhibitors and ARBs (angiotensin receptor blockers) are often used in CKD because they lower blood pressure and directly reduce protein leakage from the kidneys. They require regular blood and urine monitoring.
+
+---
+
+### Diabetes Management
+
+For people with CKD and diabetes, good blood glucose control reduces the rate of kidney damage. The choice of diabetes medicines in CKD requires care — some require dose adjustment at lower eGFR levels.
+
+Some medicines used for diabetes or heart failure have also shown kidney-protective effects in clinical trials, independently of their glucose-lowering actions. A clinician can advise on suitability based on individual kidney function, diagnosis, and other factors.
+
+---
+
+### Kidney-Protective Medicines
+
+Several medicine classes have evidence for slowing CKD progression or reducing cardiovascular risk in people with CKD. These include medicines that reduce blood pressure and albuminuria, and medicines used for certain metabolic conditions. Suitability depends on the individual's eGFR, urine results, other conditions, and clinical history — not all medicines suit all people with CKD.
+
+---
+
+### Lifestyle
+
+Lifestyle changes support kidney protection alongside medical treatment:
+- **Salt reduction** — helps blood pressure control
+- **Smoking cessation** — smoking accelerates kidney damage and cardiovascular risk
+- **Physical activity** — supports blood pressure, weight, and metabolic health
+- **Weight management** — reducing obesity reduces metabolic load on the kidneys
+- **Limiting alcohol** — excess alcohol raises blood pressure
+
+Diet advice in CKD (particularly around protein, potassium, and phosphate) depends on kidney stage and blood test results and should be personalised — a kidney dietitian is the right person to advise.
+
+---
+
+### Dietitian Support
+
+People with CKD — especially at more advanced stages — benefit from dietitian input. Dietary needs vary considerably depending on blood results, stage, whether diabetes is present, and individual nutritional requirements. Self-modifying diet based on general CKD advice alone (particularly around protein, potassium, or phosphate) is not recommended without professional guidance.
+
+---
+
+## Complications and Monitoring
+
+As CKD progresses, the kidneys can no longer maintain normal levels of certain blood components. Complications are more common at later stages but can develop earlier in some people.
+
+### Anaemia
+
+The kidneys produce erythropoietin, a hormone that stimulates red blood cell production. Reduced kidney function leads to less erythropoietin and, over time, anaemia — causing fatigue, breathlessness, and reduced exercise capacity. Anaemia in CKD is assessed and managed differently from iron-deficiency anaemia and may require specific treatment.
+
+### Bone and Mineral Changes
+
+The kidneys help regulate calcium, phosphate, and vitamin D. Disrupted mineral metabolism in CKD can weaken bones, promote calcification in blood vessels, and affect parathyroid hormone levels. These changes are monitored through blood tests and managed with diet and, where needed, medicines.
+
+### Fluid Overload
+
+In advanced CKD, the kidneys struggle to excrete excess fluid. Fluid accumulation can cause ankle and leg swelling, raised blood pressure, and breathlessness. Fluid and salt intake management becomes increasingly important.
+
+### Potassium Changes
+
+The kidneys regulate potassium levels. In CKD, potassium can build up (hyperkalaemia), which may cause muscle weakness and heart rhythm abnormalities. Potassium levels are monitored regularly; dietary adjustments and, where needed, medicines are used to manage elevated levels.
+
+### Cardiovascular Risk
+
+All stages of CKD carry increased cardiovascular risk. This is addressed through blood pressure management, cholesterol treatment where appropriate, diabetes care, and lifestyle measures, as part of integrated CKD management.
+
+See: [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
+
+---
+
+## Advanced CKD
+
+When kidney function is very low — typically at Stage 4 or 5 — the focus of care expands to include planning for what comes next. This does not mean dialysis is inevitable or imminent; planning starts early so that if and when it becomes necessary, the transition is as well-prepared as possible.
+
+### Dialysis
+
+Dialysis replaces some kidney function by filtering waste products and fluid from the blood. It does not restore kidney function or reverse CKD.
+
+The two main forms are:
+- **Haemodialysis** — typically performed at a dialysis centre several times per week
+- **Peritoneal dialysis** — performed at home, usually daily, using the lining of the abdomen as a filter
+
+The choice between types depends on many individual factors, including lifestyle, medical status, and preference.
+
+### Kidney Transplantation
+
+A kidney transplant involves placing a donated kidney from a living or deceased donor into the body. For eligible people, transplantation generally offers better long-term outcomes than dialysis and is the preferred treatment for kidney failure where suitable. It requires lifelong immunosuppression to prevent rejection, and not everyone is suitable.
+
+### Conservative Kidney Management
+
+Not everyone chooses — or is suitable for — dialysis or transplantation. Conservative kidney management (sometimes called comprehensive conservative care or supportive care) focuses on symptom management, quality of life, and dignity without dialysis. For some people, especially older adults with multiple other conditions, this may be the most appropriate approach.
+
+### Advance Care Planning and Palliative Care
+
+As CKD approaches the most advanced stage, conversations about advance care planning — including preferences for treatment intensity, resuscitation, and end-of-life wishes — are an important part of care. Palliative and supportive care can be integrated alongside kidney treatment at any stage.
+
+See: [Palliative Care — Guide Hub](/guides/palliative-care)
+
+---
+
+## When to Seek Urgent Help
+
+Seek emergency care for:
+
+- Sudden, marked reduction in urine output
+- Severe swelling of the legs, face, or around the eyes
+- Difficulty breathing, especially at rest (may indicate fluid on the lungs)
+- Confusion, severe fatigue, or deteriorating consciousness
+- Chest pain
+- Severe or sudden worsening of any CKD symptoms
+
+If you have known CKD and become acutely unwell — particularly with vomiting, diarrhoea, or fever — seek medical advice promptly. Dehydration and acute illness can cause rapid deterioration in kidney function.
+
+---
+
+## FAQ
+
+**What is chronic kidney disease?**
+Chronic kidney disease means the kidneys have reduced function or signs of damage for a sustained period — generally three months or more. It ranges from very mild to advanced and is classified using blood and urine tests.
+
+**What tests are used to check kidney disease?**
+The main tests are a blood test for eGFR (how well the kidneys are filtering), a urine test for albumin or protein (ACR), and blood pressure measurement. Together they give a fuller picture than either alone.
+
+**Can chronic kidney disease be slowed down?**
+In many people, progression can be slowed with blood pressure control, diabetes management, medication review, and lifestyle change. Early diagnosis and consistent follow-up give the best outcomes.
+
+**Does chronic kidney disease always lead to dialysis?**
+No. Many people with CKD — especially when diagnosed early — never reach kidney failure. The goal of management is to keep kidney function as stable as possible.
+
+**When should someone see a kidney specialist?**
+Specialist referral depends on kidney function, urine results, blood pressure, rate of change, underlying cause, and complications. A GP or primary care clinician can advise when review with a nephrologist is appropriate.
+
+---
+
+## Further Reading
+
+- [Kidney Health Australia — About CKD](https://kidney.org.au/your-kidneys/what-is-ckd)
+- [National Kidney Foundation — Chronic Kidney Disease](https://www.kidney.org/kidney-topics/chronic-kidney-disease-ckd)
+- [NIDDK — Kidney Disease](https://www.niddk.nih.gov/health-information/kidney-disease)
+- [NHS — Chronic Kidney Disease](https://www.nhs.uk/conditions/kidney-disease/)
+- [NICE — Chronic Kidney Disease (patient information)](https://www.nice.org.uk/guidance/ng203)
+
+---
+
+## Related Guides
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — causes, detection, and what the tests mean
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) — the staging system, eGFR, and albuminuria
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — monitoring, medicines, diet, complications, and planning ahead
+- [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — the second most common cause of CKD and a central management target
+- [Diabetes Hub](/guides/diabetes-hub) — the leading cause of CKD
+- [Type 2 Diabetes](/guides/type-2-diabetes) — managing diabetes to protect kidney function
+- [Heart & Circulation Hub](/guides/heart-circulation) — the cardiorenal connection; CKD and cardiovascular risk
+- [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — risk tools and prevention in people with CKD
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — kidney function testing in preventive health
+- [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice, diagnosis, or treatment. Always speak with a qualified healthcare provider about your individual situation.*

--- a/src/content/guides/chronic-kidney-disease-stages-explained.md
+++ b/src/content/guides/chronic-kidney-disease-stages-explained.md
@@ -1,9 +1,9 @@
 ---
 title: "Chronic Kidney Disease Stages Explained"
 description: "A clear explanation of CKD stages 1 to 5, how eGFR and albuminuria are used together, what progression means, and how to reduce your risk."
-category: "Diabetes"
+category: "General Health"
 publishDate: "2026-05-31"
-updatedDate: "2026-05-31"
+updatedDate: "2026-06-08"
 tags: ["chronic kidney disease", "CKD stages", "eGFR", "albuminuria", "kidney disease progression", "kidney failure", "dialysis"]
 draft: false
 faq:
@@ -243,6 +243,8 @@ A: No. The majority of people with CKD — especially those diagnosed in early s
 
 ## Related Guides
 
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — central navigation for all CKD content
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — practical guide to slowing progression, medicines, diet, and planning
 - [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — foundations: causes, symptoms, and tests
 - [Type 2 Diabetes](/guides/type-2-diabetes) — the leading cause of CKD; managing diabetes is inseparable from managing diabetic kidney disease
 - [High Blood Pressure](/guides/high-blood-pressure) — blood pressure control is the most important modifiable factor in slowing progression

--- a/src/content/guides/diabetes-hub.md
+++ b/src/content/guides/diabetes-hub.md
@@ -190,6 +190,16 @@ Learn more: [CGM vs Finger Prick](/guides/cgm-vs-finger-prick) | [Continuous Glu
 - [Long-Term Complications of Type 1 Diabetes](/guides/type-1-diabetes-long-term-complications) — retinopathy, nephropathy, neuropathy, and cardiovascular risk: why they occur, screening, and how consistent management reduces risk.
 - [Diabetic Neuropathy and Nerve Damage](/guides/diabetic-neuropathy-and-nerve-damage) — peripheral neuropathy (feet and legs), autonomic neuropathy, pain management, foot care, and prevention through glucose control.
 
+### Kidney Disease (Diabetic Nephropathy)
+
+Diabetes is the leading cause of chronic kidney disease worldwide. Persistently high blood glucose damages the kidneys' filtration units over time — a process known as diabetic nephropathy. It is often silent until advanced. Regular kidney function and urine tests are an important part of diabetes care, even when no symptoms are present.
+
+Note that chronic kidney disease is not exclusive to people with diabetes — it can also result from high blood pressure, inherited conditions, and other causes.
+
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — central navigation for all CKD content: stages, management, complications, and advanced care
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — what CKD means, how it is measured, and when to seek advice
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — blood pressure, medicines, diet, monitoring, and planning ahead
+
 ---
 
 ## Frequently Asked Questions
@@ -234,6 +244,7 @@ Yes. With modern insulin therapy, continuous glucose monitoring, and good self-m
 
 ## Related Guides
 - [Heart & Circulation Hub](/guides/heart-circulation) — diabetes significantly raises cardiovascular risk; heart health and glucose management are closely linked.
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — diabetes is the leading cause of CKD; kidney monitoring is part of integrated diabetes care.
 - [Testing and Screening](/guides/testing-and-screening) — HbA1c, fasting glucose, and lipid panels in context alongside diabetes monitoring.
 - [Statin Side Effects: Evidence](/guides/statin-side-effects-evidence) — statins are frequently co-prescribed with diabetes medications; understand the benefit/risk profile.
 - [Healthy Weight Loss Guide](/guides/healthy-weight-loss-guide) — weight reduction is a core strategy for Type 2 diabetes risk reduction and remission.

--- a/src/content/guides/heart-circulation.md
+++ b/src/content/guides/heart-circulation.md
@@ -133,6 +133,13 @@ See also: [Early Warning Signs of a Heart Attack](/guides/early-warning-signs-of
 - [Blood Pressure at Home: How to Measure Correctly](/guides/blood-pressure-at-home) — Technique, timing, and what the numbers mean.
 - [2025 High Blood Pressure Guideline — Key Updates](/guides/2025-high-blood-pressure-guideline) — What changed in the latest hypertension management guidance.
 
+### Kidney Disease and the Heart
+
+Chronic kidney disease and cardiovascular disease are closely linked — each worsens the other through shared mechanisms involving blood pressure, fluid balance, inflammation, and metabolic change. CKD is an independent cardiovascular risk factor; conversely, poorly controlled blood pressure and heart disease drive kidney damage.
+
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — central CKD navigation including the cardiorenal relationship, complications, and management
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — blood pressure targets, medicines, and cardiovascular risk reduction in CKD
+
 ### Prevention
 - [Preventing Heart Disease: Lifestyle and Medical Screening](/guides/preventing-heart-disease) — Diet, exercise, smoking cessation, cholesterol control, and screening checks.
 - [Abdominal Aortic Aneurysm Screening: Who Should Be Tested and When](/guides/abdominal-aortic-aneurysm-screening) — What an AAA is, why rupture is so dangerous, who should have an ultrasound, and how results guide surveillance and treatment.
@@ -214,6 +221,7 @@ Immediately for severe chest pain, chest pain with arm or jaw pain, sudden breat
 
 - [Stroke — Symptoms, Emergency Response, and Treatment Time Windows](/guides/stroke-symptoms-fast-response)
 - [Emergencies — Guide Hub](/guides/emergencies)
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — kidney disease raises cardiovascular risk; the cardiorenal relationship, blood pressure, and management
 - [Cancer — Guide Hub](/guides/cancer) — Some cancers affect the heart; cardiac toxicity from cancer treatment is an important shared topic.
 - [Preventive Health — Guide Hub](/guides/preventive-health)
 

--- a/src/content/guides/high-blood-pressure.md
+++ b/src/content/guides/high-blood-pressure.md
@@ -179,5 +179,6 @@ A: Causes may include medication resistance, underlying conditions, or persisten
 
 - [2025 High Blood Pressure Guideline](/guides/2025-high-blood-pressure-guideline)
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview)
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — high blood pressure is the second most common cause of CKD; blood pressure control is central to kidney protection
 - [Heart & Circulation Overview](/guides/heart-circulation-overview)
 - [Stroke](/guides/stroke-symptoms-fast-response)

--- a/src/content/guides/managing-chronic-kidney-disease.md
+++ b/src/content/guides/managing-chronic-kidney-disease.md
@@ -1,0 +1,332 @@
+---
+title: "Managing Chronic Kidney Disease"
+description: "A patient-friendly guide to managing chronic kidney disease, including monitoring, blood pressure, diabetes, medicines, diet, complications, and when specialist care may be needed."
+category: "General Health"
+publishDate: "2026-06-08"
+updatedDate: "2026-06-08"
+draft: false
+tags: ["chronic kidney disease", "kidney disease", "kidney management", "blood pressure", "diabetes", "kidney function", "CKD", "eGFR"]
+faq:
+  - question: "What is the main goal of CKD management?"
+    answer: "The main goals are to slow kidney damage, reduce heart and blood vessel risk, manage symptoms, monitor for complications, and plan ahead if kidney function declines significantly."
+  - question: "Why is blood pressure important in CKD?"
+    answer: "High blood pressure can damage the kidneys, and kidney disease can raise blood pressure — each making the other worse. Monitoring and treating blood pressure is one of the most important parts of CKD management."
+  - question: "Do people with CKD need a special diet?"
+    answer: "Some people benefit from dietary changes, but advice depends on kidney stage, blood results, whether diabetes is present, and individual nutritional needs. A kidney dietitian can provide personalised guidance — it is not advisable to self-modify diet for CKD based on general advice alone."
+  - question: "Should people with CKD avoid anti-inflammatory medicines?"
+    answer: "NSAIDs (such as ibuprofen and naproxen) can reduce blood flow to the kidneys and worsen kidney function. People with kidney disease are generally advised to avoid their regular use. Always check with a clinician or pharmacist before using anti-inflammatory medicines."
+  - question: "When is dialysis discussed?"
+    answer: "Dialysis planning is typically introduced when kidney function is at an advanced stage, or when blood results and symptoms suggest kidney replacement therapy may eventually be needed. Planning often starts before dialysis becomes urgent, to allow time for preparation."
+---
+
+## Introduction
+
+Managing chronic kidney disease (CKD) is not a single action but an ongoing process. The goals are to slow the loss of kidney function, reduce cardiovascular risk, manage complications, and — for those with advanced disease — prepare for what may come next.
+
+Most of what matters in CKD management is consistent and unglamorous: knowing your numbers, controlling blood pressure, taking prescribed medicines, and attending regular follow-up. These steps make a meaningful difference to outcomes.
+
+This guide covers what to monitor, what to do, and what to be aware of at each stage.
+
+---
+
+## Key Points
+
+- Blood pressure control is the most important modifiable factor for slowing CKD progression
+- Diabetes management is central for people with diabetic kidney disease
+- Some medicines protect kidneys; others can harm them — a regular medication review matters
+- Diet advice in CKD should be personalised, not self-directed
+- All stages of CKD carry increased cardiovascular risk — this is managed alongside kidney protection
+- Planning for advanced CKD begins well before dialysis is needed
+- Seek urgent help for sudden worsening of symptoms or rapid changes in kidney function
+
+---
+
+## What CKD Management Is Trying to Achieve
+
+CKD cannot usually be reversed. The aim of treatment is to:
+
+- **Slow progression** — reduce the rate at which kidney function declines
+- **Reduce cardiovascular risk** — CKD raises the risk of heart attack and stroke; managing this is as important as managing the kidneys themselves
+- **Prevent and manage complications** — anaemia, bone disease, fluid overload, and potassium changes all occur more often as kidney function declines
+- **Maintain quality of life** — managing symptoms, supporting nutrition, and addressing fatigue and other impacts
+- **Plan ahead** — for people with progressive disease, timely planning for dialysis, transplant, or conservative management allows more informed and dignified choices
+
+---
+
+## Know Your Kidney Numbers
+
+Understanding a few key results helps make sense of medical appointments and treatment decisions.
+
+### eGFR
+
+eGFR (estimated glomerular filtration rate) estimates how much blood the kidneys filter per minute. It is calculated from a blood test for creatinine, adjusted for age and sex. A lower number indicates reduced kidney function.
+
+eGFR is used to stage CKD (from Stage 1 to Stage 5) and to guide monitoring frequency and treatment decisions. Trends over time matter as much as a single reading — an eGFR that is declining year-on-year is more concerning than a stable reading at the same level.
+
+### Urine ACR (Albumin-to-Creatinine Ratio)
+
+Albumin is a protein that should stay in the blood. When kidneys are damaged, albumin leaks into the urine. The ACR measures this leakage. Elevated ACR is an important indicator of kidney damage and an independent predictor of both CKD progression and cardiovascular risk.
+
+### Blood Pressure
+
+Blood pressure should be monitored regularly in CKD. High blood pressure is both a cause and a consequence of kidney disease. Target blood pressure in CKD is generally lower than population targets — a clinician will advise on the right goal for an individual.
+
+### Potassium
+
+The kidneys regulate potassium levels. In CKD, potassium can build up (hyperkalaemia), causing muscle weakness and potentially dangerous heart rhythm changes. Potassium is checked regularly; diet and, where needed, medicines help manage it.
+
+### Haemoglobin
+
+The kidneys produce erythropoietin, which stimulates red blood cell production. Reduced kidney function often leads to anaemia (low haemoglobin). Regular checks allow this to be identified and treated.
+
+### Bone and Mineral Tests
+
+The kidneys regulate calcium, phosphate, and vitamin D. As CKD progresses, these become dysregulated — affecting bone strength, parathyroid hormone levels, and blood vessel calcification. Blood tests for calcium, phosphate, parathyroid hormone, and vitamin D form part of monitoring at moderate and advanced stages.
+
+---
+
+## Blood Pressure and CKD
+
+Controlling blood pressure is the most important intervention for slowing CKD progression and reducing cardiovascular risk.
+
+High blood pressure damages the kidney's filtration units (glomeruli). As the kidneys become damaged, they are less able to regulate blood pressure — creating a cycle that drives deterioration of both systems.
+
+**What you can do:**
+- Know your blood pressure target (your clinician will advise — it is often lower than general population targets in CKD, particularly with significant albuminuria)
+- Check blood pressure regularly — at home if advised, and at clinical reviews
+- Take prescribed blood pressure medicines consistently
+- Reduce salt intake
+- Maintain a healthy weight
+- Limit alcohol
+- Exercise regularly
+
+ACE inhibitors (such as ramipril and perindopril) and ARBs (angiotensin receptor blockers, such as irbesartan and candesartan) are commonly used in CKD. Beyond their blood pressure-lowering effects, they reduce protein leakage from the kidneys and have direct kidney-protective properties. They require regular monitoring of kidney function and potassium.
+
+See: [High Blood Pressure (Hypertension)](/guides/high-blood-pressure)
+
+---
+
+## Diabetes and CKD
+
+For people with both diabetes and CKD, managing blood glucose is a core part of kidney protection. High blood glucose damages the small blood vessels supplying the kidneys — sustained control significantly slows this damage.
+
+**Key points:**
+- HbA1c targets in CKD may need to be individualised — very tight control may carry greater hypoglycaemia risk, particularly in older adults or those with advanced CKD
+- Some diabetes medicines require dose adjustment or are not suitable at lower eGFR levels — a diabetes team or GP can review
+- Blood glucose monitoring and regular diabetes reviews remain important even when CKD is also being managed
+
+See: [Type 2 Diabetes](/guides/type-2-diabetes) | [Diabetes Hub](/guides/diabetes-hub)
+
+---
+
+## Kidney-Protective Medicines
+
+Several medicine classes have evidence for slowing kidney disease progression or reducing cardiovascular risk in CKD. These are not suitable for everyone — suitability depends on eGFR, ACR, other conditions, and individual clinical factors. A clinician will determine whether any of these are appropriate.
+
+**ACE inhibitors and ARBs**
+Used for blood pressure control, they also reduce albuminuria and have kidney-protective effects. They require monitoring of kidney function and potassium. Not suitable in all circumstances.
+
+**SGLT2 inhibitors**
+Originally developed as diabetes medicines, SGLT2 inhibitors (such as empagliflozin and dapagliflozin) have shown kidney-protective and cardiovascular-protective effects in clinical trials, including in people without diabetes. They are now used for some people with CKD and significant albuminuria, or CKD alongside heart failure or type 2 diabetes. However, suitability depends on kidney function level, diagnosis, other medicines, and individual factors — not everyone with CKD will be prescribed them.
+
+**Statins and cardiovascular risk reduction**
+Because CKD significantly raises cardiovascular risk, statin therapy for cholesterol management is often appropriate. A clinician will assess overall cardiovascular risk to decide.
+
+**Other medicines**
+Additional medicines may be used to manage specific complications — for anaemia (such as iron or erythropoiesis-stimulating agents), bone mineral disease, or high potassium. These are prescribed based on blood results and clinical assessment.
+
+---
+
+## Medication Safety
+
+Kidney disease changes how many medicines behave in the body.
+
+### NSAIDs (Anti-inflammatory Medicines)
+
+Ibuprofen, naproxen, and other NSAIDs reduce blood flow to the kidneys. Regular use can worsen kidney function and accelerate CKD progression. People with CKD are generally advised to avoid them, or use them only briefly and under clinical guidance. Always ask a pharmacist or clinician before using anti-inflammatory medicines regularly.
+
+### Contrast Dyes (for Scans)
+
+Iodinated contrast agents used in CT scans and some other imaging procedures can affect kidney function in people with CKD, particularly at lower eGFR levels. Always inform the radiology or imaging team of your kidney function before any procedure involving contrast. Your clinician can advise whether contrast is safe and whether any precautions are needed.
+
+### Supplements and Herbal Products
+
+Many complementary medicines, supplements, and herbal preparations are processed by the kidneys or can interact with kidney function or medicines. Always disclose all supplements and herbal products to your clinician or pharmacist.
+
+### Sick Day Rules
+
+Acute illness — particularly with vomiting, diarrhoea, fever, or reduced fluid intake — can cause rapid deterioration in kidney function. Some medicines (particularly blood pressure medicines, diuretics, and certain diabetes medicines) may need to be temporarily paused during acute illness to protect the kidneys. Your clinical team can advise on a personalised sick day plan. Do not stop regular medicines without guidance, but seek advice promptly when you are acutely unwell.
+
+---
+
+## Diet and Lifestyle
+
+### Salt Reduction
+
+Reducing salt intake helps control blood pressure — one of the most important dietary changes in CKD. This includes reducing added salt and monitoring high-sodium foods such as processed meats, canned goods, and salty snacks.
+
+### Protein Intake
+
+Some evidence suggests that very high protein intake may strain the kidneys. However, protein restriction in CKD can increase the risk of malnutrition. Protein advice in CKD should be personalised by a dietitian based on kidney stage, nutritional status, and other conditions.
+
+### Potassium and Phosphate
+
+In more advanced CKD, blood potassium and phosphate may rise to levels that need dietary management. However, unnecessarily restricting these nutrients without evidence of raised levels is not recommended. Blood test results, not general advice, should drive dietary changes — a kidney dietitian can guide this.
+
+### Smoking Cessation
+
+Smoking damages blood vessels, raises blood pressure, accelerates kidney disease progression, and substantially increases cardiovascular risk. Stopping smoking is one of the most beneficial changes a person with CKD can make.
+
+### Physical Activity
+
+Regular physical activity helps control blood pressure, blood glucose, and weight — all of which are important in CKD management. Activity should be matched to fitness level and other conditions. Speak to your clinical team about what level and type of exercise is appropriate.
+
+### Weight and Metabolic Health
+
+Excess weight contributes to high blood pressure and insulin resistance, both of which drive CKD progression. For people who are overweight or obese, weight management is part of kidney protection.
+
+---
+
+## Monitoring and Follow-up
+
+### How Often?
+
+Monitoring frequency in CKD depends on stage, albuminuria level, rate of change, and other conditions. In general:
+- More frequent monitoring is needed at higher stages and with greater albuminuria
+- People with stable, mild CKD may need annual checks
+- Those with progressive, advanced, or complicated CKD are monitored more frequently — sometimes every 3–6 months or more often
+
+### Who Is Involved?
+
+**GP or primary care clinician** — coordinates CKD monitoring, prescribes and reviews medicines, manages blood pressure and diabetes, organises referral when needed.
+
+**Nephrologist (kidney specialist)** — involved at moderate-to-advanced stages, rapid progression, uncertain diagnosis, or complex management needs.
+
+**Pharmacist** — medicine review, dose adjustment in CKD, identification of kidney-harming medicines, sick day advice.
+
+**Kidney dietitian** — dietary assessment and personalised advice on protein, potassium, phosphate, fluid, and salt.
+
+**Diabetes care team** — if diabetes is present, coordination of blood glucose management and medicine review in CKD.
+
+---
+
+## Managing Complications
+
+### Anaemia
+
+When the kidneys produce insufficient erythropoietin, red blood cell production falls. Anaemia in CKD causes fatigue, breathlessness, and reduced exercise tolerance. It is assessed through blood tests and managed depending on cause and severity — iron deficiency is addressed first; erythropoiesis-stimulating agents may be used for some people with more severe anaemia.
+
+### Bone and Mineral Disease
+
+Dysregulated calcium, phosphate, vitamin D, and parathyroid hormone in CKD weakens bones and increases cardiovascular risk from calcium deposits in blood vessels. Management may include dietary phosphate modification, phosphate binders, vitamin D supplementation, and medicines affecting parathyroid hormone.
+
+### Fluid Retention
+
+Advanced CKD reduces the kidneys' ability to excrete fluid. Swelling of legs and ankles, rising blood pressure, and breathlessness may develop. Fluid and salt intake may need restriction; diuretics may be used.
+
+### Itching (Pruritus)
+
+Uraemic pruritus — itching associated with kidney failure — affects some people with advanced CKD. It can significantly affect quality of life. Management options are available; let your clinical team know if this is a problem.
+
+### Fatigue
+
+Fatigue is common in CKD and multifactorial — contributed to by anaemia, sleep disturbance, metabolic changes, and medication effects. Addressing reversible causes (particularly anaemia) is the first step. A clinical team can help assess what is contributing.
+
+### Cardiovascular Risk
+
+CKD is an independent cardiovascular risk factor. Active management of blood pressure, cholesterol, and diabetes, alongside not smoking and regular physical activity, forms the basis of cardiovascular risk reduction in CKD. Some guidelines recommend treating CKD as a high cardiovascular risk category.
+
+See: [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
+
+---
+
+## Preparing for Advanced CKD
+
+For people with progressive disease, preparation for advanced stages is more helpful when started early.
+
+### Dialysis Education
+
+Understanding dialysis options — haemodialysis and peritoneal dialysis — helps people make informed choices about which approach might suit their lifestyle and circumstances. Education is typically offered through kidney specialist services.
+
+### Transplant Assessment
+
+For eligible people, transplant assessment begins when kidney function is falling toward Stage 4–5. Assessment considers general health, cardiovascular status, infection screening, and surgical suitability. Being listed for a transplant early, where eligible, maximises the chance of receiving one.
+
+### Conservative Kidney Management
+
+For some people — particularly older adults with multiple conditions and reduced life expectancy — conservative kidney management (supportive care without dialysis) may be the most appropriate choice. This approach focuses on symptom management, quality of life, and maintaining dignity.
+
+### Advance Care Planning
+
+Conversations about future treatment preferences, resuscitation wishes, and priorities of care are an important part of managing advanced CKD. These conversations are best held before a crisis, when the person with CKD can participate fully and make considered decisions.
+
+### Palliative and Supportive Care
+
+Palliative care is not only for the final days of life. It focuses on managing symptoms, supporting quality of life, and addressing psychological and social needs — and can be integrated with kidney treatment at any advanced stage.
+
+See: [Palliative Care — Guide Hub](/guides/palliative-care)
+
+---
+
+## When to Seek Urgent Help
+
+Seek emergency care for:
+
+- Severe breathlessness, particularly at rest
+- Chest pain
+- Confusion or altered consciousness
+- Sudden fainting or collapse
+- Severe and rapidly worsening swelling
+- Very low urine output or no urine output
+- Signs of severe infection (high fever, shaking, rapid deterioration)
+- Rapidly worsening symptoms that are unusual for you
+
+If you have CKD and become acutely unwell — with vomiting, diarrhoea, or high fever — seek medical advice early. Acute kidney injury (AKI) can develop rapidly in people with CKD during illness, particularly if fluid intake is reduced.
+
+---
+
+## FAQ
+
+**What is the main goal of CKD management?**
+To slow the loss of kidney function, reduce cardiovascular risk, prevent and manage complications, and plan ahead for any progression. Consistent monitoring and treatment make a meaningful difference to outcomes.
+
+**Why is blood pressure important in CKD?**
+High blood pressure accelerates kidney damage. Kidney disease raises blood pressure. Controlling blood pressure well is the single most impactful intervention for slowing CKD in most people.
+
+**Do people with CKD need a special diet?**
+Some people need dietary adjustments, but the right changes depend on blood results, kidney stage, and other conditions. A kidney dietitian can provide personalised advice. Unsupervised restriction of potassium or protein without evidence of need is not recommended.
+
+**Should people with CKD avoid anti-inflammatory medicines?**
+NSAIDs (such as ibuprofen and naproxen) reduce kidney blood flow and should generally be avoided in CKD. Always check with a clinician or pharmacist before using anti-inflammatory medicines if you have known kidney disease.
+
+**When is dialysis discussed?**
+Planning begins when kidney function has declined significantly and progression appears likely — typically at Stage 4 CKD or earlier if decline is rapid. The aim is to have a plan in place before dialysis becomes urgent.
+
+---
+
+## Further Reading
+
+- [Kidney Health Australia — Living with CKD](https://kidney.org.au/your-kidneys/manage)
+- [National Kidney Foundation — Slowing CKD Progression](https://www.kidney.org/kidney-topics/chronic-kidney-disease-ckd)
+- [NIDDK — Managing CKD](https://www.niddk.nih.gov/health-information/kidney-disease/chronic-kidney-disease-ckd/managing)
+- [NHS — Chronic Kidney Disease: Living With CKD](https://www.nhs.uk/conditions/kidney-disease/living-with/)
+- [NICE — Chronic Kidney Disease (CKD)](https://www.nice.org.uk/guidance/ng203)
+
+---
+
+## Related Guides
+
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — central navigation for all CKD content
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — causes, detection, and what tests show
+- [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) — the staging system and what the numbers mean
+- [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — management and targets in CKD
+- [Type 2 Diabetes](/guides/type-2-diabetes) — diabetes management in the context of kidney disease
+- [Diabetes Hub](/guides/diabetes-hub) — diabetes types, complications, and management
+- [Heart & Circulation Hub](/guides/heart-circulation) — cardiovascular risk in CKD
+- [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — risk scoring and prevention
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — kidney function testing as preventive health
+- [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice, diagnosis, or treatment. Always speak with a qualified healthcare provider about your individual situation.*

--- a/src/content/guides/preventing-heart-disease.md
+++ b/src/content/guides/preventing-heart-disease.md
@@ -111,6 +111,7 @@ Heart disease remains one of the leading causes of illness and death worldwide. 
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Cardiac Rehabilitation After a Heart Event](/guides/cardiac-rehabilitation)  
 - [Preventive Health — Guide Hub](/guides/preventive-health)  
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — CKD is an independent cardiovascular risk factor; blood pressure control and shared risk reduction apply across both
 - [Coronary Artery Calcium (CAC) Score](/guides/coronary-artery-calcium-score)  
 - [Lipoprotein(a): The Overlooked Genetic Heart Risk Factor](/guides/lipoprotein-a-explained)  
 

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -4,7 +4,7 @@ slug: "preventive-screening-hub"
 description: "Your central guide to preventive health screening — cancer checks, cardiovascular testing, metabolic health, and age-based schedules for staying ahead of disease."
 category: "Guide Hubs"
 publishDate: "2026-06-05"
-updatedDate: "2026-06-09"
+updatedDate: "2026-06-08"
 hubKey: "Preventive Screening"
 draft: false
 tags:
@@ -216,6 +216,19 @@ Type 2 diabetes develops slowly — prediabetes often precedes it by years and i
 - [Understanding HbA1c — What It Means and How to Use It](/guides/understanding-hba1c) — interpreting the most common diabetes monitoring test
 
 **Who should screen:** Adults over 40 with one or more risk factors (overweight, family history, gestational diabetes history, hypertension, or certain ethnicities with higher baseline risk). Screening uses fasting blood glucose or HbA1c.
+
+---
+
+### Kidney Function and CKD
+
+Chronic kidney disease is common and usually has no symptoms until it is advanced. Early detection relies on blood and urine tests, not symptoms.
+
+People with type 2 diabetes, high blood pressure, cardiovascular disease, or a family history of kidney disease are at higher risk. Kidney function testing is a standard part of preventive health reviews for these groups, and in general health checks from midlife.
+
+- [What Is Chronic Kidney Disease?](/guides/what-is-chronic-kidney-disease) — what CKD means, how it is measured, and when to seek advice
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — full CKD content: stages, management, complications, and specialist care
+
+**Key tests:** A blood test for eGFR (kidney filtration rate) and a urine test for albumin (ACR — protein leakage) together give a more complete picture than either alone. A single abnormal result requires repeat testing to confirm. Most people with early CKD are asymptomatic — testing is the only way to know.
 
 ---
 

--- a/src/content/guides/type-2-diabetes.mdx
+++ b/src/content/guides/type-2-diabetes.mdx
@@ -223,4 +223,5 @@ A: This varies by individual circumstances, but most guidelines recommend HbA1c 
 - [GLP-1 Side Effects: Evidence vs Myth](/guides/glp-1-side-effects-evidence-vs-myth)
 - [Understanding HbA1c — What It Means and How to Use It](/guides/understanding-hba1c)
 - [Prediabetes: Early Warning Signs and Prevention](/guides/prediabetes)
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — diabetes is the leading cause of CKD; regular kidney monitoring is part of diabetes care
 - [Metabolic Syndrome](/guides/metabolic-syndrome)

--- a/src/content/guides/what-is-chronic-kidney-disease.md
+++ b/src/content/guides/what-is-chronic-kidney-disease.md
@@ -1,9 +1,9 @@
 ---
 title: "What Is Chronic Kidney Disease?"
 description: "A clear guide to chronic kidney disease — what it is, why it often goes unnoticed, how it is measured, and when to seek medical advice."
-category: "Diabetes"
+category: "General Health"
 publishDate: "2026-05-31"
-updatedDate: "2026-05-31"
+updatedDate: "2026-06-08"
 tags: ["chronic kidney disease", "CKD", "kidney function", "eGFR", "albuminuria", "kidney damage", "renal disease"]
 draft: false
 faq:
@@ -192,6 +192,8 @@ A: Yes, though it is far less common in children. When it does occur, inherited 
 
 ## Related Guides
 
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — central navigation for all CKD content
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — monitoring, medicines, diet, complications, and planning ahead
 - [Chronic Kidney Disease Stages Explained](/guides/chronic-kidney-disease-stages-explained) — the staging system, eGFR numbers, and how risk is classified
 - [Heart Failure: Symptoms, Causes, Diagnosis, and Treatment](/guides/heart-failure-overview) — heart and kidney disease frequently worsen each other (cardiorenal syndrome)
 - [Type 2 Diabetes](/guides/type-2-diabetes) — the leading cause of CKD globally


### PR DESCRIPTION
## Summary

- Adds chronic-kidney-disease-hub.md (Guide Hubs category): central navigation for all CKD content — stages, causes, related conditions, treatment, complications, advanced care, dialysis/transplant planning
- Adds managing-chronic-kidney-disease.md (General Health category): practical management guide covering monitoring numbers, blood pressure, diabetes, kidney-protective medicines, SGLT2 inhibitors with suitability caveats, medication safety, diet, complications, and preparing for advanced CKD
- Reclassifies what-is-chronic-kidney-disease.md and chronic-kidney-disease-stages-explained.md from Diabetes to General Health; adds hub back-links to both
- Updates diabetes-hub.md: adds Kidney Disease (Diabetic Nephropathy) sub-section with CKD hub links in Complications and Related Guides
- Updates heart-circulation.md: adds Kidney Disease and the Heart section; CKD hub in Related Guides
- Updates preventive-screening-hub.md: adds Kidney Function and CKD sub-section in Heart and Metabolic Health
- Targeted link additions to high-blood-pressure.md, type-2-diabetes.mdx, and preventing-heart-disease.md

## Category handling

"Kidney Disease" is not in the CATEGORY enum in src/content/config.ts.
- Hub page: category "Guide Hubs" (matches all other hub pages)
- Management guide: category "General Health" (best existing fit for a cross-system condition)
- Reclassified guides: category "General Health" (moved out of Diabetes)

## Checks

- npm run content:check: 0 errors, 22 warnings (all pre-existing; no new warning files introduced)
- npm run build: 750 pages, 0 errors
- Routes confirmed: /guides/chronic-kidney-disease-hub/ and /guides/managing-chronic-kidney-disease/
