### PR TITLE
feat(aging): add falls prevention and frailty guides

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -1,0 +1,162 @@
+---
+title: "Aging and Longevity Hub"
+description: "A guide hub for healthy aging, longevity, frailty, falls prevention, bone health, dementia risk, and planning for later life."
+category: "Guide Hubs"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - aging
+  - longevity
+  - frailty
+  - falls prevention
+  - healthy aging
+  - hub
+faq:
+  - question: "What does healthy aging mean?"
+    answer: "Healthy aging means maintaining function, independence, quality of life, and resilience for as long as possible — not simply living longer."
+  - question: "Is frailty an inevitable part of aging?"
+    answer: "No. Frailty becomes more common with age, but it is not inevitable. Strength training, nutrition, medical care, social support, and falls prevention can all make a meaningful difference."
+  - question: "Why are falls important in older adults?"
+    answer: "Falls can lead to fractures, loss of confidence, hospitalisation, and reduced independence. Many fall risks can be assessed and reduced."
+  - question: "What is the difference between lifespan and healthspan?"
+    answer: "Lifespan is how long someone lives. Healthspan is the period of life spent in good health and functional independence."
+  - question: "What should people focus on for better aging?"
+    answer: "Key areas include movement, strength, nutrition, sleep, social connection, medication review, chronic disease management, vision and hearing care, and safer home environments."
+---
+
+# Aging and Longevity Hub
+
+Aging well is not only about adding years to life — it is about adding life to years. This hub connects PatientGuide's evidence-based content on healthy aging, longevity, frailty, falls prevention, bone health, brain health, and planning for later life.
+
+---
+
+## Key Points
+
+- Aging is universal; significant decline is not inevitable — lifestyle, medicine, and environment shape how people age
+- Frailty, falls, and bone loss are among the most modifiable threats to independence in later life
+- Chronic conditions including heart disease, diabetes, CKD, and dementia become more common with age — and interact
+- Preventive health, medication review, and strength and balance training can substantially reduce disability risk
+- Planning ahead — including advance care preferences and support networks — matters more as people age
+
+---
+
+## Start Here
+
+- [Healthspan vs Lifespan: What's the Difference?](/guides/healthspan-vs-lifespan) — why how long you live well matters more than how long you live
+- [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging) — the core biology of aging and how it shapes disease and decline
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — practical strategies for reducing fall risk at any age
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — understanding frailty, its causes, and what can help
+
+---
+
+## Strength, Mobility, and Independence
+
+Maintaining physical capacity is one of the most important things older adults can do to preserve independence, reduce fall risk, and extend healthspan.
+
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — causes, home safety, exercise, medication review, and when to seek help
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — signs, contributors, and what can help
+- [Fractures and Falls](/guides/fractures-and-falls) — fracture risk, bone fragility, and management
+- [After a Fracture](/guides/after-a-fracture) — recovery, rehabilitation, and preventing future fractures
+- [Exercise and Physical Activity](/guides/exercise) — evidence on activity for health at all ages
+- [Bone Health Basics](/guides/bone-health-basics) — what bones need to stay strong
+- [Osteoporosis](/guides/osteoporosis) — bone loss, risk factors, diagnosis, and treatment
+
+---
+
+## Brain Health and Cognition
+
+Cognitive health is deeply connected to physical activity, vascular risk, sleep, and social connection.
+
+- [Dementia Overview](/guides/dementia-overview) — what dementia is, types, progression, and care
+- [Alzheimer's Disease: Prevention and Exercise](/guides/alzheimers-prevention-and-exercise) — what the evidence shows about lifestyle and dementia risk
+- [Brain Health Hub](/guides/brain-health-hub) — stroke, TIA, dementia, and brain health prevention
+- [Sleep](/guides/sleep) — the role of sleep in cognitive health and aging
+- [Social Connection and Health](/guides/social-connection) — why isolation can accelerate decline
+
+---
+
+## Chronic Disease and Aging
+
+Many chronic conditions become more common with age and interact with one another. Managing them well is central to healthy aging.
+
+- [Heart and Circulation Hub](/guides/heart-circulation) — conditions, prevention, medications, and cardiac rehabilitation
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — CKD becomes more common with age and interacts with cardiovascular and metabolic risk
+- [Diabetes Hub](/guides/diabetes-hub) — metabolic health in the context of aging
+- [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — the most common modifiable cardiovascular risk factor
+- [Parkinson's Disease Overview](/guides/parkinsons-disease-overview) — movement, balance, and motor complications in later life
+- [Stroke Prevention](/guides/stroke-prevention) — reducing stroke risk and recognising early warning signs
+
+---
+
+## Bone Health and Fractures
+
+Bone loss accelerates with age and is often silent until a fracture occurs.
+
+- [Bone Health Basics](/guides/bone-health-basics) — calcium, vitamin D, exercise, and bone maintenance
+- [Osteoporosis](/guides/osteoporosis) — causes, DEXA scanning, and treatment options
+- [Fractures and Falls](/guides/fractures-and-falls) — the link between bone fragility and fall-related fractures
+- [After a Fracture](/guides/after-a-fracture) — recovery and secondary fracture prevention
+
+---
+
+## Planning and Support
+
+Planning for later life — including medical, legal, and emotional preparation — allows people to retain choice and dignity.
+
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — what palliative care involves and when it applies
+- [Voluntary Assisted Dying in Australia](/guides/voluntary-assisted-dying) — the Australian framework for VAD
+
+---
+
+## Prevention and Screening
+
+Preventive health care is especially valuable in later life — screening, vaccination, and medication review can prevent serious events.
+
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based screening recommendations from 50s onward, including bone density, cardiovascular risk, and cancer checks
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — practical fall risk reduction
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — clinical assessment and what can help
+
+---
+
+## FAQ
+
+**What does healthy aging mean?**
+Healthy aging means maintaining function, independence, quality of life, and resilience for as long as possible — not simply living longer.
+
+**Is frailty an inevitable part of aging?**
+No. Frailty becomes more common with age, but it is not inevitable. Strength training, nutrition, medication review, and social support can all make a difference.
+
+**Why are falls important in older adults?**
+Falls can lead to fractures, loss of confidence, hospitalisation, and reduced independence — but many fall risks can be assessed and reduced.
+
+**What is the difference between lifespan and healthspan?**
+Lifespan is how long someone lives. Healthspan is the period of life spent in good health and functional independence.
+
+**What should people focus on for better aging?**
+Key areas include movement, strength, nutrition, sleep, social connection, medication review, chronic disease management, vision and hearing care, and safer home environments.
+
+---
+
+## Further Reading
+
+- [WHO — Healthy Ageing](https://www.who.int/health-topics/ageing)
+- [National Institute on Aging — Healthy Aging](https://www.nia.nih.gov/health)
+- [CDC — Falls Prevention](https://www.cdc.gov/falls/)
+- [Healthdirect Australia — Falls prevention for older people](https://www.healthdirect.gov.au/falls-prevention-for-older-people)
+
+---
+
+## Related Guides
+
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Healthspan vs Lifespan: What's the Difference?](/guides/healthspan-vs-lifespan)
+- [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging)
+- [Brain Health Hub](/guides/brain-health-hub)
+- [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+
+---
+
+*This hub is for educational purposes only and is not a substitute for professional medical advice. Speak with your clinician about screening, medications, and care plans appropriate for your individual situation.*

--- a/src/content/guides/brain-health-hub.mdx
+++ b/src/content/guides/brain-health-hub.mdx
@@ -239,6 +239,8 @@ A: Yes — stroke symptoms appear abruptly. If symptoms pass quickly, that may b
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment)
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)
 - [Mental Health Toolkit](/guides/mental-health-toolkit)
+- [Aging and Longevity Hub](/guides/aging-longevity-hub)
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
 
 ---
 

--- a/src/content/guides/chronic-kidney-disease-hub.md
+++ b/src/content/guides/chronic-kidney-disease-hub.md
@@ -3,7 +3,7 @@ title: "Chronic Kidney Disease — Guide Hub"
 description: "A guide hub for chronic kidney disease, including causes, stages, tests, treatment, monitoring, complications, dialysis, transplant, and related conditions."
 category: "Guide Hubs"
 publishDate: "2026-06-08"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 draft: false
 tags: ["chronic kidney disease", "kidney disease", "kidney function", "CKD", "diabetes", "blood pressure", "dialysis", "kidney transplant", "hub"]
 faq:
@@ -328,6 +328,8 @@ Specialist referral depends on kidney function, urine results, blood pressure, r
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — risk tools and prevention in people with CKD
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — kidney function testing in preventive health
 - [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — healthy aging, frailty, and falls prevention in the context of aging with chronic conditions
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty and CKD often coexist; a shared management approach improves outcomes
 
 ---
 

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -1,0 +1,307 @@
+---
+title: "Falls Prevention: How to Reduce Fall Risk"
+description: "A patient-friendly guide to falls prevention, including common causes, home safety, strength and balance training, medication review, vision, footwear, bone health, and when to seek help."
+category: "Aging & Longevity"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - falls prevention
+  - aging
+  - frailty
+  - bone health
+  - balance
+faq:
+  - question: "Are falls a normal part of aging?"
+    answer: "Falls become more common with age, but they are not simply normal or inevitable. Many fall risks can be identified and meaningfully reduced."
+  - question: "What are common causes of falls?"
+    answer: "Falls are often linked to balance problems, muscle weakness, dizziness, medicines that affect blood pressure or alertness, poor vision, foot problems, home hazards, or acute illness."
+  - question: "What exercise helps prevent falls?"
+    answer: "Strength and balance training — particularly when supervised — can meaningfully reduce fall risk. A physiotherapist can advise on a suitable programme based on individual health and fitness."
+  - question: "Should someone see a doctor after a fall?"
+    answer: "Medical review is important after any fall with injury, head impact, loss of consciousness, dizziness, chest pain, new weakness, confusion, or repeated falls."
+  - question: "How can the home be made safer?"
+    answer: "Useful steps include improving lighting, removing loose rugs, installing handrails, checking footwear, and keeping frequently used items easy to reach. An occupational therapist can assess the home."
+---
+
+## Introduction
+
+Falls are a leading cause of injury in older adults — but they are not simply an inevitable part of getting older. Many falls have identifiable causes that can be addressed. Understanding fall risk, making practical changes at home, reviewing medicines, and building strength and balance can all reduce the likelihood of a fall and its consequences.
+
+This guide is for people who want to understand their fall risk, support someone at higher risk, or find practical strategies to stay safer.
+
+---
+
+## Key Points
+
+- Falls are common with age but are not inevitable — many causes are modifiable
+- Multiple risk factors acting together dramatically increase fall risk
+- Strength and balance training is among the most effective preventive strategies
+- Medication review is important — some medicines significantly increase fall risk
+- After any fall with injury, loss of consciousness, or repeated falls, seek medical review
+- Home safety changes can meaningfully reduce hazards
+
+---
+
+## Why Falls Matter
+
+A fall can have consequences well beyond the immediate injury. In older adults with reduced bone density, a fall can cause a hip, wrist, or vertebral fracture — injuries that can lead to prolonged hospitalisation, loss of independence, and in some cases, life-threatening complications.
+
+Even without physical injury, falls can cause lasting loss of confidence. Fear of falling can lead people to reduce their activity — which in turn weakens muscles and balance, increasing the risk of the next fall.
+
+Falls are a leading reason for emergency department presentations in adults over 65. They are also among the most preventable.
+
+---
+
+## Falls Are Not Inevitable
+
+Falls become more common with age, but this does not mean they are unavoidable. Many people who are at elevated fall risk can substantially lower that risk through:
+
+- Targeted exercise programmes
+- Medication review and adjustment
+- Home modifications
+- Vision and hearing care
+- Management of contributing conditions
+
+The aim is not to eliminate all movement or physical risk — restriction of activity can itself increase frailty and fall risk. The aim is to identify and address what is modifiable.
+
+---
+
+## Common Causes and Risk Factors
+
+Falls are usually the result of multiple risk factors combining, rather than a single cause.
+
+### Muscle Weakness and Deconditioning
+
+Loss of muscle strength — particularly in the legs — makes it harder to recover balance after a stumble. Reduced leg strength is one of the most important and modifiable risk factors for falls.
+
+### Balance Problems
+
+Inner ear problems, neurological conditions, and deconditioning can all affect balance. Balance deteriorates with age but can be substantially improved with targeted training.
+
+### Dizziness and Fainting
+
+Dizziness, light-headedness, and fainting significantly raise fall risk. Common causes include sudden drops in blood pressure when standing (orthostatic hypotension), heart rhythm problems, and medication side effects.
+
+See: [Dizziness — When to Worry](/guides/dizziness-when-to-worry) | [Syncope and Fainting](/guides/syncope-fainting-overview)
+
+### Vision Problems
+
+Poor vision makes it harder to identify hazards, judge depth, and react to uneven surfaces. Even mildly reduced vision increases fall risk. Regular vision assessment and appropriate correction are important.
+
+### Foot Problems and Footwear
+
+Painful or numb feet, toe deformities, peripheral neuropathy, and poorly fitted footwear all contribute to falls. Shoes with firm soles, good grip, and a proper fit are safer than loose slippers, socks on smooth floors, or unsecured footwear.
+
+### Medications
+
+Several types of medicine raise fall risk, including:
+- Sedatives, sleep medicines, and benzodiazepines
+- Blood pressure medicines — particularly if causing dizziness when standing
+- Diuretics (fluid tablets)
+- Antidepressants and antipsychotics
+- Opioid pain medicines
+- Some diabetes medicines (through hypoglycaemia)
+- Antihistamines
+
+The more medicines a person takes, the higher the overall fall risk. A GP or pharmacist can review medicines for fall-related effects. Never stop or reduce prescription medicines without speaking with a clinician first.
+
+### Alcohol
+
+Alcohol affects balance, reaction time, and judgement. Even moderate use can increase fall risk, particularly in older adults or people taking other medicines that interact.
+
+### Low Blood Pressure When Standing
+
+Orthostatic hypotension — a sudden drop in blood pressure when moving from sitting or lying to standing — causes brief light-headedness and is a common cause of falls, particularly in people on blood pressure medicines, those who are dehydrated, or those with heart disease or diabetes.
+
+### Acute Illness
+
+Infection, dehydration, or any sudden change in health can trigger a fall. A fall in an older adult with no other obvious cause may be the first sign of an underlying acute illness.
+
+### Home Hazards
+
+Common household fall risks include:
+- Poor lighting — particularly on stairs and in bathrooms
+- Loose or unsecured rugs and mats
+- Unstable furniture
+- Trailing cables or cords
+- Wet or slippery floors
+- Stairs without rails
+- Low toilet seats and baths without grab rails
+- Pets underfoot
+- Clutter in walkways
+
+### Cognitive Impairment
+
+Dementia and cognitive impairment increase fall risk through reduced awareness of hazards, impulsive behaviour, and difficulty following safety strategies.
+
+See: [Dementia Overview](/guides/dementia-overview)
+
+---
+
+## Who Is at Higher Risk
+
+Fall risk is highest in people who have:
+
+- Had a previous fall — one of the strongest predictors of the next fall
+- Osteoporosis or low bone density — increasing fracture severity when falls occur
+- Frailty — reduced muscle reserve and resilience
+- Parkinson's disease — postural instability, freezing, and gait changes
+- Dementia — impaired judgement and hazard recognition
+- Stroke history — weakness, spasticity, or coordination problems
+- Heart disease, CKD, or diabetes — through medication effects and neurological changes
+- Multiple medicines (polypharmacy)
+
+See: [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) | [Osteoporosis](/guides/osteoporosis) | [Parkinson's Disease Overview](/guides/parkinsons-disease-overview)
+
+---
+
+## What to Do After a Fall
+
+If someone falls:
+
+1. **Do not rush to get up** — take a moment to check for pain, dizziness, or injury before moving
+2. **If injured or in severe pain** — call for help; do not attempt to get up without assistance
+3. **If alone and unable to get up** — move to a supported position and use an alarm, phone, or wait until help arrives
+4. **Seek medical review** — particularly after injury, head impact, loss of consciousness, or repeated falls
+
+Falls without obvious injury should still be reviewed by a clinician if they are unexpected, repeated, or have no clear explanation.
+
+---
+
+## Exercise and Balance Training
+
+Exercise is among the most effective strategies for reducing falls. Programmes that combine strength and balance training — delivered by a physiotherapist, exercise physiologist, or in a supervised group — have the strongest evidence.
+
+### Strength Training
+
+Resistance exercise targeting leg muscles helps prevent the muscle loss that increases fall risk. This can include chair-based exercise, resistance bands, or weights — adapted to current fitness and any medical conditions.
+
+### Balance Training
+
+Balance exercises challenge the body's ability to control position — for example, single-leg standing, heel-to-toe walking, and Tai Chi. Tai Chi in particular has a reasonable evidence base for reducing fall frequency in older adults.
+
+### Supervised and Group Exercise
+
+Supervised exercise programmes tailored to fall risk — often available through hospitals, physiotherapy services, or community health programmes — tend to produce better outcomes than unsupervised activity alone, particularly for people with significant frailty or previous falls.
+
+The right exercise plan depends on fitness level, medical conditions, and individual fall history. A physiotherapist or exercise physiologist can design a safe, targeted programme. The goal is increased activity, not unnecessary restriction.
+
+---
+
+## Home Safety
+
+Simple changes to the home environment can meaningfully reduce fall risk:
+
+- **Lighting** — improve lighting in corridors, stairs, and bathrooms; use night lights; ensure switches are accessible
+- **Rugs and mats** — remove loose rugs, or secure edges firmly; avoid mats in high-traffic areas
+- **Bathrooms** — install grab rails in the shower and near the toilet; use a non-slip bath mat; consider a shower chair
+- **Stairs** — ensure rails on both sides; mark step edges if visibility is poor; avoid carrying bulky items on stairs
+- **Footwear** — wear well-fitting shoes with non-slip soles; avoid walking in socks or loose slippers on smooth floors
+- **Clutter** — keep walkways clear; store frequently used items at waist height to avoid excessive reaching or bending
+- **Furniture** — ensure chairs are stable and at an appropriate height for rising safely
+- **Cables and cords** — secure or reroute power cords away from walking paths
+
+An occupational therapist can conduct a home assessment and recommend specific modifications.
+
+---
+
+## Medication Review
+
+Medication review is an important and often overlooked component of falls prevention. A GP or clinical pharmacist can:
+
+- Identify medicines that affect balance, alertness, or blood pressure
+- Review whether dosing, timing, or alternative medicines could reduce fall risk
+- Assess for drug interactions that compound risk
+- Advise on orthostatic hypotension and whether dose changes are appropriate
+
+Never stop or reduce prescribed medicines without speaking with a clinician first.
+
+---
+
+## Vision, Hearing, Feet, and Footwear
+
+Regular vision assessment and corrected vision reduce fall risk. Cataracts and uncorrected refractive errors are addressable and worth attending to.
+
+Hearing loss can affect spatial awareness and balance through shared vestibular pathways. Addressing hearing problems may have additional benefits beyond communication.
+
+Foot care — including management of neuropathy, calluses, deformities, and nail problems — is relevant for people with diabetes, peripheral vascular disease, or persistent foot pain. A podiatrist can assess foot health and footwear suitability.
+
+---
+
+## Bone Health and Fracture Prevention
+
+Falls cause fractures most often in people with reduced bone density. Preventing and treating osteoporosis does not prevent falls, but it reduces the severity of injury if a fall does occur.
+
+See: [Bone Health Basics](/guides/bone-health-basics) | [Osteoporosis](/guides/osteoporosis) | [Fractures and Falls](/guides/fractures-and-falls)
+
+---
+
+## Assistive Devices
+
+Walking aids — including walking sticks and frames — can provide balance support and reduce fall risk when used correctly. An incorrectly sized or improperly used aid can itself be a hazard. A physiotherapist or occupational therapist can advise on the most suitable aid and ensure it is properly fitted.
+
+Personal alarm devices allow people who live alone to call for help if they fall and cannot get up — reducing the time spent on the floor after a fall.
+
+---
+
+## When to Seek Urgent Help
+
+Seek emergency care after a fall if there is:
+
+- Head injury or loss of consciousness
+- Chest pain or shortness of breath
+- Sudden weakness, numbness, or facial drooping (possible stroke)
+- Severe pain, particularly in the hip, wrist, or spine
+- Inability to stand or bear weight
+- Confusion or changed mental state
+- Suspected fracture
+
+Repeated falls without obvious explanation, or falls with dizziness, always warrant medical review — even without injury.
+
+---
+
+## FAQ
+
+**Are falls a normal part of aging?**
+Falls become more common with age, but they are not simply normal or inevitable. Many fall risks can be identified and meaningfully reduced.
+
+**What are common causes of falls?**
+Falls are often linked to balance problems, muscle weakness, dizziness, medicines that affect blood pressure or alertness, poor vision, foot problems, home hazards, or acute illness.
+
+**What exercise helps prevent falls?**
+Strength and balance training — particularly when supervised — can meaningfully reduce fall risk. A physiotherapist can advise on a suitable programme based on individual health and fitness.
+
+**Should someone see a doctor after a fall?**
+Medical review is important after any fall with injury, head impact, loss of consciousness, dizziness, chest pain, new weakness, confusion, or repeated falls.
+
+**How can the home be made safer?**
+Useful steps include improving lighting, removing loose rugs, installing handrails, checking footwear, and keeping frequently used items easy to reach. An occupational therapist can assess the home.
+
+---
+
+## Further Reading
+
+- [CDC — Falls Prevention](https://www.cdc.gov/falls/)
+- [Healthdirect Australia — Falls prevention for older people](https://www.healthdirect.gov.au/falls-prevention-for-older-people)
+- [NHS — Preventing Falls](https://www.nhs.uk/conditions/falls/)
+- [National Institute on Aging — Prevent Falls and Fractures](https://www.nia.nih.gov/health/falls-and-falls-prevention/prevent-falls-and-fractures)
+
+---
+
+## Related Guides
+
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — overview of healthy aging content
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — the connection between frailty and falls
+- [Fractures and Falls](/guides/fractures-and-falls) — fracture management and bone fragility
+- [After a Fracture](/guides/after-a-fracture) — recovery and secondary fracture prevention
+- [Bone Health Basics](/guides/bone-health-basics) — what bones need to stay strong
+- [Osteoporosis](/guides/osteoporosis) — diagnosis and treatment of low bone density
+- [Dizziness — When to Worry](/guides/dizziness-when-to-worry) — causes of dizziness relevant to fall risk
+- [Syncope and Fainting](/guides/syncope-fainting-overview) — causes and management of fainting
+- [Dementia Overview](/guides/dementia-overview) — cognitive impairment and fall risk
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks including bone density and vision
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice. Speak with your clinician about your individual fall risk, medications, and any exercise programme.*

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -1,0 +1,282 @@
+---
+title: "Frailty: What It Means and How to Reduce Risk"
+description: "A patient-friendly guide to frailty, including signs, causes, assessment, prevention, strength, nutrition, medication review, falls risk, and support planning."
+category: "Aging & Longevity"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - frailty
+  - aging
+  - falls prevention
+  - healthy aging
+  - muscle loss
+faq:
+  - question: "What does frailty mean?"
+    answer: "Frailty means reduced resilience — a person may recover more slowly after illness, injury, or stress, and may be more vulnerable to falls, hospitalisation, or loss of independence."
+  - question: "Is frailty the same as old age?"
+    answer: "No. Frailty is more common with age, but the two are not the same. Some older adults remain robust into advanced age, and serious illness or prolonged inactivity can contribute to frailty at any age."
+  - question: "Can frailty improve?"
+    answer: "Frailty can sometimes improve or stabilise — particularly when identified early. Strength training, nutrition support, medication review, chronic disease management, and social support can all make a difference."
+  - question: "What are signs of frailty?"
+    answer: "Signs can include unintentional weight loss, weakness, slow walking pace, persistent exhaustion, low physical activity, falls, poor balance, and difficulty recovering after illness."
+  - question: "Who can help with frailty?"
+    answer: "Support may come from a GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharmacist, occupational therapist, social worker, and family or carers — often working as a team."
+---
+
+## Introduction
+
+Frailty is a recognised medical syndrome in which the body has reduced reserves and resilience. People living with frailty are more vulnerable to falls, infections, hospital admissions, and difficulties recovering from illness or surgery. It is more common in older adults, but it is not the same as old age — and it is not always irreversible.
+
+Understanding frailty early, identifying contributing factors, and taking targeted action can help maintain independence and quality of life.
+
+---
+
+## Key Points
+
+- Frailty means reduced resilience — not simply old age
+- It is more common with advancing age, but is not inevitable
+- Early recognition improves the chances of meaningful improvement or stabilisation
+- Multiple factors contribute: muscle loss, poor nutrition, chronic disease, inactivity, social isolation, and polypharmacy
+- Strength training and nutrition are among the most important modifiable factors
+- Frailty overlaps with falls risk, cognitive decline, and chronic disease management
+- A team approach — involving clinicians, physiotherapist, dietitian, pharmacist, and social supports — is most effective
+
+---
+
+## What Frailty Is
+
+Frailty describes a state of reduced physiological reserve — the body's capacity to cope with physical and medical stress. In a person who is not frail, a minor infection or short illness is managed and recovered from without lasting consequences. In someone who is frail, the same event can trigger a cascade: hospitalisation, delirium, muscle loss, reduced mobility, or significant decline in function.
+
+Frailty is not a single disease. It reflects the cumulative effect of multiple chronic conditions, muscle loss, nutritional gaps, inactivity, and social vulnerability working together.
+
+---
+
+## Frailty Is Not the Same as Age
+
+Chronological age is one risk factor for frailty — but many older people are robust, and frailty can develop in younger people with serious or long-term illness.
+
+The distinction matters because:
+- Frail patients need different care planning than robust patients of the same age
+- Treatment intensity, surgical risk, and medication dosing may all need adjustment
+- Earlier intervention offers the best chance of reversibility
+- Assuming decline is inevitable can miss opportunities for meaningful improvement
+
+---
+
+## Signs and Patterns
+
+Frailty is recognised through clusters of signs and functional changes, not a single test. Common patterns include:
+
+- **Unintentional weight loss** — losing weight without trying, particularly muscle mass
+- **Muscle weakness** — difficulty gripping, rising from a chair, or climbing stairs
+- **Slow walking pace** — a simple, well-validated marker of physiological reserve
+- **Persistent exhaustion** — fatigue out of proportion to activity
+- **Low physical activity** — doing very little activity due to low energy or confidence
+- **Falls** — particularly repeated or unexplained falls
+- **Poor balance** — instability when standing, turning, or navigating uneven ground
+- **Difficulty recovering** — taking much longer than expected to recover after illness, injury, or surgery
+- **Increasing dependence** — needing more help with daily tasks than previously
+
+Not all signs need to be present. The picture is cumulative — the more of these features present, the more likely frailty is.
+
+---
+
+## Causes and Contributors
+
+### Muscle Loss
+
+Loss of muscle mass and strength — which accelerates with inactivity, illness, and nutritional deficiency — is one of the most important biological contributors to frailty. It is largely preventable and partially reversible with exercise and adequate protein intake.
+
+### Poor Nutrition and Low Appetite
+
+Reduced appetite, difficulty eating, social isolation, depression, and financial hardship can all lead to inadequate nutrition. Protein deficiency in particular accelerates muscle loss. Unexplained weight loss in older adults is rarely benign and warrants medical attention.
+
+### Chronic Disease
+
+Conditions including heart failure, COPD, CKD, diabetes, and cancer all deplete physical reserves. The more chronic conditions a person has, the greater the cumulative strain on their capacity to cope with additional illness.
+
+See: [Heart and Circulation Hub](/guides/heart-circulation) | [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub)
+
+### Cognitive Impairment
+
+Dementia and mild cognitive impairment are associated with frailty, both as contributors and as consequences. They reduce motivation, activity, and the ability to organise daily tasks — which can accelerate physical decline.
+
+See: [Dementia Overview](/guides/dementia-overview)
+
+### Social Isolation
+
+Social isolation is independently associated with faster physical decline, depression, reduced activity, and inadequate nutrition. Maintaining meaningful social connection is a genuine health intervention.
+
+### Polypharmacy
+
+Taking multiple medicines — particularly sedatives, strong pain medicines, antidepressants, and blood pressure medicines — can cause fatigue, dizziness, appetite suppression, and sedation that together mimic or worsen frailty. Medication review is an important part of frailty management.
+
+### Hospitalisation
+
+Hospital admissions — even brief ones — can cause significant deconditioning in frail older adults, through bedrest, poor nutrition, disruption to routine, and exposure to infection. Early mobilisation and nutritional support during hospital stays are now recognised priorities in geriatric care.
+
+### Pain
+
+Persistent pain limits activity, disrupts sleep, and reduces motivation — all of which accelerate physical decline. Identifying and managing pain is part of a comprehensive frailty assessment.
+
+### Depression and Anxiety
+
+Depression causes reduced motivation, poor appetite, social withdrawal, and low activity — all of which contribute to the frailty cycle.
+
+See: [Depression](/guides/depression) | [Anxiety](/guides/anxiety)
+
+---
+
+## How Frailty Is Assessed
+
+There is no single blood test for frailty. Clinicians assess it through a combination of:
+
+- **Clinical history and functional assessment** — asking about activity levels, falls, weight change, fatigue, and daily tasks
+- **Grip strength** — a simple, reproducible marker of overall muscle strength and a predictor of outcomes
+- **Walking speed or the Timed Up and Go (TUG) test** — practical, validated measures of functional capacity
+- **Validated frailty scales** — tools such as the Clinical Frailty Scale (CFS) or Fried frailty phenotype are used to categorise frailty severity in clinical and research settings
+- **Comprehensive Geriatric Assessment (CGA)** — a structured multidisciplinary review of medical, functional, cognitive, social, and nutritional status; the most thorough approach and the standard of care in geriatric medicine
+- **Medication review** — identifying medicines that contribute to weakness, fatigue, or cognitive impairment
+
+Frailty assessment matters because it changes care decisions — including surgical risk estimation, medication choices, and advance care planning.
+
+---
+
+## What Can Help
+
+### Strength and Balance Training
+
+Resistance exercise — even at low intensity, including chair-based exercise — can improve muscle strength, balance, and function in frail older adults. This is the intervention with the strongest evidence base. A physiotherapist can design a safe programme matched to current capacity.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+### Nutrition and Protein
+
+Adequate protein intake is essential for muscle maintenance and recovery. Older adults often require more protein per kilogram of body weight than younger people. A dietitian can advise on appropriate intake, food fortification, and nutritional supplements where needed. Vitamin D is also relevant to muscle function and bone health.
+
+### Treating Reversible Causes
+
+Some contributors to frailty — including anaemia, thyroid problems, depression, pain, and nutritional deficiency — are potentially reversible. A thorough medical assessment can identify treatable causes that may significantly improve function.
+
+### Medication Review
+
+A clinician or pharmacist can review whether current medicines are contributing to weakness, fatigue, or dizziness — and whether any can be safely adjusted, reduced, or stopped. Deprescribing — the deliberate reduction of unnecessary or harmful medicines — is an established component of geriatric care.
+
+### Falls Prevention
+
+Falls and frailty are closely linked: frailty increases fall risk, and falls accelerate frailty through injury, hospitalisation, and fear. Falls prevention strategies are an integral part of frailty management.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+### Vision and Hearing Care
+
+Correcting vision and addressing hearing loss reduce fall risk, improve social engagement, and reduce cognitive load — all relevant to managing frailty.
+
+### Social Support
+
+Maintaining social connection, community engagement, and emotional support reduces the consequences of isolation. Carers and families play an important role. Social workers and community services can help identify available support programmes.
+
+### Chronic Disease Management
+
+Well-controlled heart disease, diabetes, CKD, and other conditions place less strain on physical reserves. Integrating frailty management with chronic disease care — rather than treating them in isolation — produces better outcomes.
+
+---
+
+## Frailty and Falls
+
+The relationship between frailty and falls is bidirectional. Frail people fall more often, because muscle weakness, slow gait, balance problems, and polypharmacy all increase risk. Falls cause injury, hospitalisation, and fear — which further reduce activity and accelerate frailty.
+
+Addressing frailty and falls together is more effective than treating either in isolation.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) | [Fractures and Falls](/guides/fractures-and-falls)
+
+---
+
+## Frailty and Hospital Care
+
+Frailty significantly affects how people respond to hospital care, surgery, and acute illness. Frail patients are more likely to experience:
+
+- Delirium during hospital admission
+- Prolonged recovery periods
+- Hospital-acquired infection
+- Functional decline from bedrest
+- Difficulty returning to their usual home environment
+
+Knowing that a person is frail before planned surgery allows clinicians to adjust planning, prepare for rehabilitation, and set realistic expectations. Comprehensive geriatric assessment before surgery has been shown to improve outcomes in frail older adults.
+
+---
+
+## Frailty, Palliative Care, and Planning
+
+For people with severe frailty, the goals of care may shift toward maintaining quality of life, independence, and dignity — rather than aggressive treatment of every underlying condition.
+
+Advance care planning — documenting preferences for medical treatment, resuscitation, and end-of-life care — is an important conversation for people with significant frailty and those who support them. It ensures that care reflects the person's values and wishes, particularly if their capacity to communicate changes in the future.
+
+Palliative and supportive care can be integrated alongside active management of chronic conditions at any stage — it does not mean withdrawal of care.
+
+See: [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+
+---
+
+## When to Seek Help
+
+Speak with a clinician if you or someone you care for:
+
+- Has had repeated falls or a fall with injury
+- Is losing weight unexpectedly or eating very little
+- Seems to be deteriorating faster than expected
+- Has become confused or less mentally sharp than usual
+- Is struggling with daily tasks that were previously manageable
+- Is recovering slowly after illness or surgery
+- Is taking many medicines and seems more tired or unsteady than before
+- Is a carer who is struggling to provide safe support
+
+Early review — by a GP, geriatrician, or a multidisciplinary team — gives the best chance of identifying reversible causes and implementing changes before frailty becomes entrenched.
+
+---
+
+## FAQ
+
+**What does frailty mean?**
+Frailty means reduced resilience — the body's capacity to cope with illness, injury, or stress is diminished. Recovery may be slower, and vulnerability to falls, hospitalisation, or loss of independence is higher.
+
+**Is frailty the same as old age?**
+No. Frailty is more common with age, but the two are not the same. Some older adults remain robust into advanced age, and frailty can develop in younger people with serious illness.
+
+**Can frailty improve?**
+Frailty can sometimes improve or stabilise — particularly when identified early and addressed with exercise, nutrition, medication review, and treatment of contributing conditions.
+
+**What are signs of frailty?**
+Signs include unintentional weight loss, weakness, slow walking pace, persistent exhaustion, low activity, falls, poor balance, and difficulty recovering after illness.
+
+**Who can help with frailty?**
+A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharmacist, occupational therapist, social worker, and family or carers can all contribute — often working as a team.
+
+---
+
+## Further Reading
+
+- [WHO — Integrated Care for Older People (ICOPE)](https://www.who.int/teams/maternal-newborn-child-adolescent-health-and-ageing/ageing/integrated-care-for-older-people-icope)
+- [National Institute on Aging — Healthy Aging](https://www.nia.nih.gov/health)
+- [Healthdirect Australia — Frailty in older adults](https://www.healthdirect.gov.au/frailty)
+- [NHS — Frailty](https://www.nhs.uk/conditions/frailty/)
+- [British Geriatrics Society — Fit for Frailty](https://www.bgs.org.uk/resources/fit-for-frailty-comprehensive-practical-guidance-for-primary-care-and-community-and)
+
+---
+
+## Related Guides
+
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — overview of healthy aging content
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — the overlap between frailty and falls risk
+- [Bone Health Basics](/guides/bone-health-basics) — bone health in the context of frailty
+- [Dementia Overview](/guides/dementia-overview) — cognitive impairment and frailty
+- [Depression](/guides/depression) — depression as a contributor to frailty
+- [Anxiety](/guides/anxiety) — emotional health and physical decline
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — goals of care in severe frailty
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — CKD and its interaction with frailty
+- [Heart and Circulation Hub](/guides/heart-circulation) — cardiovascular disease and frailty
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice. Speak with your clinician about frailty assessment, treatment options, and care planning for your individual situation.*

--- a/src/content/guides/mens-health-hub.md
+++ b/src/content/guides/mens-health-hub.md
@@ -4,7 +4,7 @@ slug: "mens-health-hub"
 description: "Your central guide to men's health — covering testosterone, erectile dysfunction, prostate health, testicular cancer, men's mental health, cardiovascular disease, sleep apnoea, metabolic health, and the key screenings every man should know about."
 category: "Guide Hubs"
 publishDate: "2026-06-02"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 draft: false
 tags:
   - men's health
@@ -147,6 +147,7 @@ Insulin resistance underlies type 2 diabetes, obesity, and metabolic syndrome �
 - [Sleep Health Hub](/guides/sleep-health-hub) — Sleep apnoea, shift work, and chronic sleep deprivation disproportionately affect men and compound cardiovascular and metabolic risk
 - [Obesity and Metabolic Health Hub](/guides/obesity-metabolic-health-hub) — Visceral obesity is central to many men's health problems; evidence-based weight management changes outcomes
 - [Brain Health Hub](/guides/brain-health-hub) — Cognitive health, dementia prevention, and mental performance
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — Falls prevention, frailty, bone health, and healthy aging — relevant to men from midlife onward
 - [Alcohol and Health](/guides/alcohol-and-health) — Men drink more than women on average; alcohol contributes to liver disease, cancer, injury, and mental health disorders
 - [Smoking Cessation](/guides/smoking-cessation) — Smoking is a major cause of erectile dysfunction, cardiovascular disease, and lung cancer in men; the benefits of quitting are rapid
 

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -4,7 +4,7 @@ slug: "palliative-care"
 description: "A patient-friendly guide to palliative care, including symptom control, emotional support, advance care planning, family support, and how it differs from end-of-life care."
 category: "Cancer"
 publishDate: "2025-09-17"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 draft: false
 tags: ["palliative care", "supportive care", "cancer", "symptom control", "advance care planning"]
 faq:
@@ -316,6 +316,8 @@ Palliative care is a broad approach to symptom management and support across any
 - [COPD: Chronic Obstructive Pulmonary Disease](/guides/copd)
 - [Chronic Kidney Disease: Stages, Symptoms, and Progression Explained](/guides/chronic-kidney-disease-stages-explained)
 - [Dementia Overview](/guides/dementia-overview)
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Aging and Longevity Hub](/guides/aging-longevity-hub)
 - [Depression](/guides/depression)
 - [Anxiety](/guides/anxiety)
 - [Shortness of Breath — When to Seek Urgent Help](/guides/shortness-of-breath)

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -4,7 +4,7 @@ slug: "preventive-screening-hub"
 description: "Your central guide to preventive health screening — cancer checks, cardiovascular testing, metabolic health, and age-based schedules for staying ahead of disease."
 category: "Guide Hubs"
 publishDate: "2026-06-05"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 hubKey: "Preventive Screening"
 draft: false
 tags:
@@ -311,6 +311,7 @@ Men face underdiagnosis across many conditions — lower rates of healthcare eng
 
 ## Related Hubs
 
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — falls prevention, frailty, bone health, and healthy aging
 - [Preventive Health — Guide Hub](/guides/preventive-health) — vaccination, nutrition, exercise, and broader lifestyle-based prevention
 - [Testing and Screening — Guide Hub](/guides/testing-and-screening) — how to interpret test results, sensitivity and specificity, cardiovascular biomarkers
 - [Women's Health Hub](/guides/womens-health-hub) — cervical, breast, bone, and hormonal health

--- a/src/content/guides/womens-health-hub.md
+++ b/src/content/guides/womens-health-hub.md
@@ -4,7 +4,7 @@ slug: "womens-health-hub"
 description: "Your central guide to women's health — covering hormones and menopause, perimenopause, PCOS, endometriosis, cervical and breast screening, bone health, fertility, and the symptoms women most commonly search for."
 category: "Guide Hubs"
 publishDate: "2026-06-01"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 draft: false
 tags:
   - women's health
@@ -136,7 +136,9 @@ Women's health does not exist in isolation. Several major health conditions disp
 - [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes) — Women with PCOS have 3–7× the diabetes risk; postmenopausal hormonal changes further increase metabolic risk
 - [Cardiovascular Risk Assessment — Understanding Your Numbers](/guides/cardiovascular-risk-assessment) — Women's cardiovascular risk, lower than men's before menopause, converges with men's risk after it; the transition is a key intervention window
 - [Osteoporosis: Symptoms, Risk, and Treatment](/guides/osteoporosis) — Women lose 10–20% of bone density around menopause; osteoporosis is predominantly a women's health issue
-- [Ageing and Longevity Basics](/guides/aging-and-longevity-basics) — Menopause is the single largest determinant of biological ageing trajectory in women
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — Menopause accelerates bone loss and cardiovascular risk; aging well is a core women's health concern
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — Osteoporosis and frailty after menopause increase fall and fracture risk
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — Frailty is more common in older women; early recognition and intervention help
 
 ---
 

--- a/src/lib/featuredHubs.ts
+++ b/src/lib/featuredHubs.ts
@@ -12,8 +12,8 @@ export const HUBS: FeaturedHub[] = [
   },
   {
     title: "Aging & Longevity",
-    href: "/guides/aging-longevity",
-    description: "Aging biology, lifespan heritability, and longevity debates."
+    href: "/guides/aging-longevity-hub",
+    description: "Healthy aging, falls prevention, frailty, bone health, and longevity."
   },
   {
     title: "Infectious Diseases",


### PR DESCRIPTION
## Summary

* Adds /guides/aging-longevity-hub -- new hub for the Aging and Longevity cluster, connecting aging biology, falls, frailty, bone health, brain health, chronic disease, and planning content
* Adds /guides/falls-prevention -- patient guide covering causes, home safety, exercise, medication review, vision, footwear, bone health, assistive devices, and when to seek urgent help
* Adds /guides/frailty-overview -- patient guide covering signs, causes, assessment tools, what can help, frailty and hospital care, advance care planning, and when to seek help
* Updates featuredHubs.ts -- Aging and Longevity hub entry now points to /guides/aging-longevity-hub (previously pointed to missing slug)
* Fixes broken link in womens-health-hub -- stale /guides/aging-and-longevity-basics replaced with correct hub link
* Adds cross-links in: brain-health-hub, chronic-kidney-disease-hub, palliative-care, preventive-screening-hub, womens-health-hub, mens-health-hub

## Checks

* npm run content:check -- 0 errors, 13 warnings (same baseline)
* npm run build -- 755 pages built, 0 errors
* Routes confirmed in dist: /guides/aging-longevity-hub/, /guides/falls-prevention/, /guides/frailty-overview/