### PR TITLE
feat(aging): add sarcopenia guide

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -47,6 +47,7 @@ Aging well is not only about adding years to life — it is about adding life to
 - [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging) — the core biology of aging and how it shapes disease and decline
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — practical strategies for reducing fall risk at any age
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — understanding frailty, its causes, and what can help
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — what sarcopenia is, how it is assessed, and what can help
 
 ---
 
@@ -56,6 +57,7 @@ Maintaining physical capacity is one of the most important things older adults c
 
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — causes, home safety, exercise, medication review, and when to seek help
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — signs, contributors, and what can help
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle loss, assessment, strength training, and falls risk
 - [Fractures and Falls](/guides/fractures-and-falls) — fracture risk, bone fragility, and management
 - [After a Fracture](/guides/after-a-fracture) — recovery, rehabilitation, and preventing future fractures
 - [Exercise and Physical Activity](/guides/exercise) — evidence on activity for health at all ages
@@ -151,6 +153,7 @@ Key areas include movement, strength, nutrition, sleep, social connection, medic
 
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
 - [Healthspan vs Lifespan: What's the Difference?](/guides/healthspan-vs-lifespan)
 - [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging)
 - [Brain Health Hub](/guides/brain-health-hub)

--- a/src/content/guides/bone-health-basics.mdx
+++ b/src/content/guides/bone-health-basics.mdx
@@ -87,3 +87,4 @@ Age; menopause/low testosterone; family history; low calcium/vitamin D/protein; 
 - [Osteoporosis](/guides/osteoporosis)  
 - [Fractures and Falls](/guides/fractures-and-falls)  
 - [After a Fracture](/guides/after-a-fracture)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle and bone health are closely connected

--- a/src/content/guides/brain-health-hub.mdx
+++ b/src/content/guides/brain-health-hub.mdx
@@ -241,6 +241,7 @@ A: Yes — stroke symptoms appear abruptly. If symptoms pass quickly, that may b
 - [Mental Health Toolkit](/guides/mental-health-toolkit)
 - [Aging and Longevity Hub](/guides/aging-longevity-hub)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — physical and cognitive decline are bidirectionally linked
 
 ---
 

--- a/src/content/guides/chronic-kidney-disease-hub.md
+++ b/src/content/guides/chronic-kidney-disease-hub.md
@@ -330,6 +330,7 @@ Specialist referral depends on kidney function, urine results, blood pressure, r
 - [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
 - [Aging and Longevity Hub](/guides/aging-longevity-hub) — healthy aging, frailty, and falls prevention in the context of aging with chronic conditions
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty and CKD often coexist; a shared management approach improves outcomes
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting is particularly common in CKD and affects outcomes
 
 ---
 

--- a/src/content/guides/diabetes-hub.md
+++ b/src/content/guides/diabetes-hub.md
@@ -249,6 +249,7 @@ Yes. With modern insulin therapy, continuous glucose monitoring, and good self-m
 - [Statin Side Effects: Evidence](/guides/statin-side-effects-evidence) — statins are frequently co-prescribed with diabetes medications; understand the benefit/risk profile.
 - [Healthy Weight Loss Guide](/guides/healthy-weight-loss-guide) — weight reduction is a core strategy for Type 2 diabetes risk reduction and remission.
 - [Aging and Longevity Basics](/guides/aging-and-longevity-basics) — how metabolic health shapes healthspan and long-term disease risk.
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — sarcopenia and diabetes interact through insulin resistance and reduced physical capacity
 
 ## Related Hubs
 - [Metabolic Health & Weight-Loss Medicines Hub](/guides/metabolic-health-hub)

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -73,7 +73,9 @@ Falls are usually the result of multiple risk factors combining, rather than a s
 
 ### Muscle Weakness and Deconditioning
 
-Loss of muscle strength — particularly in the legs — makes it harder to recover balance after a stumble. Reduced leg strength is one of the most important and modifiable risk factors for falls.
+Loss of muscle strength — particularly in the legs — makes it harder to recover balance after a stumble. Reduced leg strength is one of the most important and modifiable risk factors for falls. When this muscle loss is significant enough to affect strength and physical function, it is called sarcopenia — a condition more common in older adults, people with chronic disease, and those who have had prolonged periods of inactivity or hospitalisation.
+
+See: [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
 
 ### Balance Problems
 
@@ -293,6 +295,7 @@ Useful steps include improving lighting, removing loose rugs, installing handrai
 
 - [Aging and Longevity Hub](/guides/aging-longevity-hub) — overview of healthy aging content
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — the connection between frailty and falls
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle loss as a primary falls risk factor
 - [Fractures and Falls](/guides/fractures-and-falls) — fracture management and bone fragility
 - [After a Fracture](/guides/after-a-fracture) — recovery and secondary fracture prevention
 - [Bone Health Basics](/guides/bone-health-basics) — what bones need to stay strong

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -84,9 +84,11 @@ Not all signs need to be present. The picture is cumulative — the more of thes
 
 ## Causes and Contributors
 
-### Muscle Loss
+### Muscle Loss and Sarcopenia
 
-Loss of muscle mass and strength — which accelerates with inactivity, illness, and nutritional deficiency — is one of the most important biological contributors to frailty. It is largely preventable and partially reversible with exercise and adequate protein intake.
+Loss of muscle mass and strength — which accelerates with inactivity, illness, and nutritional deficiency — is one of the most important biological contributors to frailty. It is largely preventable and partially reversible with exercise and adequate protein intake. When muscle loss reaches the level of significantly impaired strength and physical performance, it is called sarcopenia. Sarcopenia and frailty overlap substantially, but they are not identical: sarcopenia is specifically about muscle, while frailty reflects a broader loss of physiological reserve. Both require attention and can often be addressed with similar strategies.
+
+See: [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
 
 ### Poor Nutrition and Low Appetite
 
@@ -269,6 +271,7 @@ A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharma
 
 - [Aging and Longevity Hub](/guides/aging-longevity-hub) — overview of healthy aging content
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — the overlap between frailty and falls risk
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle loss as a major contributor to frailty
 - [Bone Health Basics](/guides/bone-health-basics) — bone health in the context of frailty
 - [Dementia Overview](/guides/dementia-overview) — cognitive impairment and frailty
 - [Depression](/guides/depression) — depression as a contributor to frailty

--- a/src/content/guides/heart-circulation.md
+++ b/src/content/guides/heart-circulation.md
@@ -222,6 +222,7 @@ Immediately for severe chest pain, chest pain with arm or jaw pain, sudden breat
 - [Stroke — Symptoms, Emergency Response, and Treatment Time Windows](/guides/stroke-symptoms-fast-response)
 - [Emergencies — Guide Hub](/guides/emergencies)
 - [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — kidney disease raises cardiovascular risk; the cardiorenal relationship, blood pressure, and management
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle deconditioning in heart failure and cardiac rehabilitation
 - [Cancer — Guide Hub](/guides/cancer) — Some cancers affect the heart; cardiac toxicity from cancer treatment is an important shared topic.
 - [Preventive Health — Guide Hub](/guides/preventive-health)
 

--- a/src/content/guides/managing-chronic-kidney-disease.md
+++ b/src/content/guides/managing-chronic-kidney-disease.md
@@ -3,7 +3,7 @@ title: "Managing Chronic Kidney Disease"
 description: "A patient-friendly guide to managing chronic kidney disease, including monitoring, blood pressure, diabetes, medicines, diet, complications, and when specialist care may be needed."
 category: "General Health"
 publishDate: "2026-06-08"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 draft: false
 tags: ["chronic kidney disease", "kidney disease", "kidney management", "blood pressure", "diabetes", "kidney function", "CKD", "eGFR"]
 faq:
@@ -326,6 +326,7 @@ Planning begins when kidney function has declined significantly and progression 
 - [Cardiovascular Risk Assessment](/guides/cardiovascular-risk-assessment) — risk scoring and prevention
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — kidney function testing as preventive health
 - [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting in CKD, physical activity, and nutrition
 
 ---
 

--- a/src/content/guides/metabolic-health-hub.mdx
+++ b/src/content/guides/metabolic-health-hub.mdx
@@ -119,6 +119,7 @@ How weight-loss drugs interact with the biology of ageing, and what older adults
 Why preserving lean muscle is essential for long-term health, especially during GLP-1 therapy or aggressive dieting.
 - [Muscle Protection During Weight Loss](/guides/muscle-preservation)
 - [Muscle Preservation on GLP-1 Medications](/guides/muscle-preservation-glp-1)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — when muscle loss affects strength, function, and independence
 
 ---
 

--- a/src/content/guides/osteoporosis.mdx
+++ b/src/content/guides/osteoporosis.mdx
@@ -157,4 +157,5 @@ A: Osteopenia is “low bone mass” (mild bone loss). Osteoporosis is more seve
 - [Bone Health Hub](/guides/bone-health-basics)  
 - [Bone Health Basics](/guides/bone-health-basics)  
 - [Fractures and Falls](/guides/fractures-and-falls)  
-- [After a Fracture](/guides/after-a-fracture)  
+- [After a Fracture](/guides/after-a-fracture)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle loss and bone loss often coexist and share risk factors  

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -317,6 +317,7 @@ Palliative care is a broad approach to symptom management and support across any
 - [Chronic Kidney Disease: Stages, Symptoms, and Progression Explained](/guides/chronic-kidney-disease-stages-explained)
 - [Dementia Overview](/guides/dementia-overview)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
 - [Aging and Longevity Hub](/guides/aging-longevity-hub)
 - [Depression](/guides/depression)
 - [Anxiety](/guides/anxiety)

--- a/src/content/guides/sarcopenia.md
+++ b/src/content/guides/sarcopenia.md
@@ -1,0 +1,335 @@
+---
+title: "Sarcopenia: Muscle Loss, Strength, and Healthy Aging"
+description: "A patient-friendly guide to sarcopenia, including signs of muscle loss, causes, assessment, strength training, nutrition, falls risk, frailty, and when to seek help."
+category: "Aging & Longevity"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - sarcopenia
+  - muscle loss
+  - aging
+  - frailty
+  - falls prevention
+faq:
+  - question: "What is sarcopenia?"
+    answer: "Sarcopenia means a loss of muscle strength and muscle function, often with reduced muscle mass. It can affect balance, mobility, falls risk, and independence."
+  - question: "Is sarcopenia inevitable with aging?"
+    answer: "No. Muscle loss becomes more common with age, but strength training, nutrition, activity, and treating underlying health problems can help reduce risk and may improve or stabilise muscle function."
+  - question: "What are signs of sarcopenia?"
+    answer: "Possible signs include weaker grip, slower walking, difficulty rising from a chair, reduced stamina, more falls, or trouble carrying out usual daily activities."
+  - question: "Can sarcopenia improve?"
+    answer: "Sarcopenia can sometimes improve or stabilise with progressive strength exercise, adequate nutrition, treatment of contributing conditions, and support from clinicians or allied health professionals."
+  - question: "Who should ask about sarcopenia?"
+    answer: "People with repeated falls, frailty, unexplained weakness, weight loss, slow walking, reduced activity, or difficulty recovering after illness should ask a clinician about assessment."
+---
+
+## Introduction
+
+Sarcopenia is a condition involving the progressive loss of muscle strength and muscle function, typically accompanied by a reduction in muscle mass. Although more common with advancing age, sarcopenia is not simply an inevitable part of growing older — and it is not untreatable.
+
+Muscle is fundamental to movement, balance, metabolism, and independence. When muscle function declines significantly, the consequences reach well beyond reduced strength: fall risk increases, recovery from illness slows, metabolic health worsens, and the ability to carry out everyday tasks diminishes.
+
+This guide is for people who want to understand sarcopenia, recognise its signs, and learn what can help.
+
+---
+
+## Key Points
+
+- Sarcopenia means reduced muscle strength and function — not just the natural loss of muscle mass that comes with ageing
+- It is not inevitable: physical activity, nutrition, and treatment of contributing conditions can reduce risk and support improvement
+- Falls, frailty, fractures, and loss of independence are among its most serious consequences
+- It is linked with chronic conditions including diabetes, CKD, heart failure, and dementia
+- Assessment is based on strength, physical performance, and clinical history — not a single blood test
+- Allied health professionals including physiotherapists, exercise physiologists, and dietitians play a central role in management
+
+---
+
+## What Is Sarcopenia?
+
+The term sarcopenia — from the Greek for flesh and poverty — describes a syndrome in which muscle strength and physical performance decline to a level that affects health and function. Most definitions include impaired muscle strength (particularly grip strength or leg strength), reduced physical performance (such as slow walking speed or difficulty rising from a chair), and, where measured, reduced muscle mass.
+
+Sarcopenia is recognised as a medical condition by international bodies including the European Working Group on Sarcopenia in Older People (EWGSOP). It is more common with advancing age but is not equivalent to normal ageing.
+
+---
+
+## Sarcopenia Is Not Just "Getting Older"
+
+Some muscle loss with age is a normal part of biology — adults can begin losing a small amount of muscle mass from the fourth decade, with the rate accelerating in later life. But this gradual change is different from sarcopenia, where the decline in strength and function reaches a threshold that affects daily life and health.
+
+The distinction matters because:
+- Normal age-related muscle change does not necessarily cause clinical problems
+- Sarcopenia is associated with falls, frailty, hospitalisations, and poor outcomes after illness
+- Many contributors to sarcopenia — inactivity, inadequate nutrition, chronic disease, and prolonged bed rest — are modifiable
+- Early identification and intervention offer the best chance of maintaining or improving function
+
+Assuming muscle decline is inevitable can mean missing opportunities to intervene before function is significantly lost.
+
+---
+
+## Why Muscle Matters
+
+Skeletal muscle is not simply the tissue that powers movement. It plays a central role in multiple systems:
+
+### Mobility and Balance
+
+Leg and core muscle strength underpin walking, balance, and the ability to recover from a stumble. Weakness in these muscle groups is a primary driver of falls and reduced mobility.
+
+### Falls Risk
+
+Weaker muscles — particularly in the lower limbs — impair the ability to react quickly to balance disruption. Sarcopenia is one of the most important modifiable contributors to fall risk in older adults.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+### Bone Health
+
+Muscle and bone interact closely. Mechanical loading through muscle contraction stimulates bone formation and maintenance. Low muscle mass and reduced physical activity both contribute to bone loss and fracture risk.
+
+See: [Bone Health Basics](/guides/bone-health-basics) | [Osteoporosis](/guides/osteoporosis)
+
+### Metabolism and Glucose Control
+
+Skeletal muscle is the primary site of insulin-stimulated glucose uptake. Reduced muscle mass contributes to insulin resistance, impairs glucose metabolism, and increases the risk of type 2 diabetes — a relationship sometimes described as sarcopenic obesity when reduced muscle function occurs alongside excess adiposity.
+
+See: [Diabetes Hub](/guides/diabetes-hub) | [Metabolic Health Hub](/guides/metabolic-health-hub)
+
+### Recovery After Illness
+
+Adequate muscle reserve is critical for surviving and recovering from illness, surgery, or hospitalisation. People with sarcopenia are more vulnerable to complications, take longer to recover, and face a higher risk of prolonged disability following acute illness or surgery.
+
+### Independence
+
+The ability to rise from a chair, walk to the shops, carry groceries, climb stairs, and manage daily tasks depends on adequate muscle strength. When that reserve is reduced, these activities become effortful or impossible — directly limiting independence.
+
+---
+
+## Signs and Symptoms
+
+Sarcopenia can be difficult to recognise because it develops gradually. Signs to be aware of include:
+
+- **Weaker grip** — difficulty opening jars, holding objects securely, or using hands for tasks that were once easy
+- **Slower walking pace** — noticing that walking has become significantly slower or more effortful
+- **Difficulty rising from a chair** — needing to use arms to push up, or struggling to stand from low seats
+- **Trouble climbing stairs** — increased effort or needing support for stairs that were previously manageable
+- **Reduced stamina** — tiring more quickly during daily activities than previously
+- **Falls** — particularly repeated or unexplained falls, or near-falls
+- **Unintentional weight or muscle loss** — losing weight or noticing visible muscle wasting without trying
+- **Difficulty with usual daily tasks** — activities such as carrying shopping, housework, or dressing becoming harder than expected
+
+None of these signs alone is diagnostic, but several together — particularly in combination with age, chronic illness, or recent hospitalisation — warrant clinical assessment.
+
+---
+
+## Causes and Contributors
+
+Sarcopenia results from a combination of biological processes, lifestyle factors, and medical conditions:
+
+### Physical Inactivity
+
+Inactivity is the single most modifiable contributor. Skeletal muscle adapts rapidly to load — reduce it, and muscle weakens. Prolonged bed rest (even for a few days) causes significant muscle loss, particularly in older adults.
+
+### Ageing Biology
+
+With advancing age, muscle protein synthesis becomes less efficient, motor neurones are lost, and hormonal changes (including reductions in testosterone, oestrogen, and growth hormone) affect muscle maintenance. These biological changes are real but are substantially accelerated by inactivity and poor nutrition.
+
+### Inadequate Nutrition
+
+Insufficient dietary protein reduces the raw material for muscle maintenance. Inadequate total energy intake compounds this. Appetite often decreases with age, increasing nutritional vulnerability.
+
+### Chronic Disease
+
+Several conditions directly or indirectly accelerate muscle loss:
+- **Diabetes and metabolic disease** — insulin resistance impairs muscle protein synthesis; neuropathy and fatigue reduce activity
+- **Chronic kidney disease** — uraemic toxins, metabolic acidosis, reduced appetite, and hormonal disruption all promote muscle wasting; sarcopenia is extremely common in CKD
+- **Heart failure** — reduced cardiac output, systemic inflammation, and activity limitation drive muscle wasting
+- **Cancer** — cancer-associated inflammation and cachexia cause profound muscle loss
+- **COPD** — systemic inflammation and activity limitation reduce muscle mass
+
+See: [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) | [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) | [Heart & Circulation Hub](/guides/heart-circulation)
+
+### Hospitalisation and Bed Rest
+
+Even short hospital stays cause rapid muscle loss in older adults. Reduced mobility, poor nutrition during admission, sedative medications, and acute illness combine to accelerate sarcopenia. Early mobilisation during hospital care is recognised as a priority to reduce this risk.
+
+### Inflammation
+
+Chronic low-grade inflammation — common in many older adults and in most chronic diseases — impairs muscle protein synthesis and promotes muscle breakdown. Inflammatory markers are often elevated in people with sarcopenia.
+
+### Dementia and Cognitive Decline
+
+Cognitive impairment reduces motivation, impairs coordination and balance, and limits the ability to engage in exercise or maintain adequate nutrition. The relationship between cognitive decline and sarcopenia is bidirectional.
+
+See: [Brain Health Hub](/guides/brain-health-hub)
+
+### Medications
+
+Some medicines can contribute to muscle weakness, fatigue, or reduced activity — including corticosteroids (which directly cause muscle wasting with long-term use), sedatives, and certain other agents. A clinician or pharmacist can review whether medicines may be contributing.
+
+---
+
+## How Sarcopenia Is Assessed
+
+There is no single test that diagnoses sarcopenia. Clinicians assess it through:
+
+### Clinical History and Function
+
+A clinician will ask about activity levels, falls, weight change, fatigue, diet, and difficulty with daily tasks. Functional history — whether walking, rising from chairs, or climbing stairs has become harder — provides important context.
+
+### Grip Strength
+
+Hand grip strength (measured with a dynamometer) is a simple, reproducible marker of overall muscle strength and a predictor of health outcomes. A significantly low grip strength is one of the primary diagnostic criteria for sarcopenia.
+
+### Walking Speed and Physical Performance Tests
+
+Usual gait speed — typically measured over a short distance — is a well-validated, practical marker of functional reserve. The Timed Up and Go (TUG) test, chair stand test (how many times a person can rise from a chair in 30 seconds), and Short Physical Performance Battery (SPPB) are commonly used clinical tools.
+
+### Body Composition Assessment
+
+Where available, techniques such as DEXA (dual-energy X-ray absorptiometry) or bioelectrical impedance analysis can measure lean muscle mass. However, many clinical settings diagnose and manage sarcopenia based on function and strength tests alone.
+
+### Blood Tests
+
+Blood tests may identify contributing causes — including anaemia, thyroid problems, vitamin D deficiency, renal impairment, and markers of malnutrition — rather than diagnosing sarcopenia directly. Inflammatory markers and other tests may inform the broader clinical picture.
+
+---
+
+## What Can Help
+
+### Strength and Resistance Training
+
+Progressive resistance exercise is the most effective intervention for sarcopenia. It stimulates muscle protein synthesis, improves strength, and can maintain or improve muscle function even in older adults and people with chronic conditions. This includes activities such as resistance bands, weights, or chair-based strength exercises.
+
+The specific programme should be tailored to the individual's current fitness, health conditions, and any risk factors. A physiotherapist or exercise physiologist can design a safe and progressive programme. The goal is graduated challenge — not sudden high-intensity effort.
+
+### Balance and Mobility Work
+
+Balance training reduces fall risk and supports the functional benefits of strength training. Physiotherapy-supervised exercise addressing both strength and balance is particularly effective.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+### Nutrition and Protein Intake
+
+Adequate protein intake is essential for muscle maintenance and repair. Many older adults do not consume sufficient protein, particularly during illness or reduced appetite periods. General advice includes ensuring protein is present at each main meal and prioritising nutritious, palatable foods.
+
+Individual protein needs vary based on health status, kidney function, and other factors. A dietitian can advise on appropriate intake and whether supplementation is suitable. This is particularly important in CKD, where protein advice is individualised to kidney function.
+
+Vitamin D is relevant to both muscle function and bone health — deficiency is common in older adults and is worth assessing and correcting where low.
+
+### Treating Underlying Conditions
+
+Identifying and treating conditions that contribute to muscle loss — including anaemia, thyroid dysfunction, depression, nutritional deficiency, and poorly controlled diabetes or heart failure — can substantially improve function.
+
+### Medication Review
+
+A clinician or pharmacist can review whether any current medicines are contributing to weakness, fatigue, or reduced activity. Deprescribing — the deliberate reduction or stopping of unnecessary medicines — is an established part of geriatric care.
+
+### Physiotherapy and Allied Health Support
+
+Physiotherapists and exercise physiologists can assess function, design safe exercise programmes, and monitor progress. Occupational therapists can advise on assistive equipment and home modifications to support independence. Dietitians address nutritional needs. For complex presentations, a multidisciplinary team approach produces the best outcomes.
+
+---
+
+## Sarcopenia, Frailty, and Falls
+
+Sarcopenia, frailty, and falls are closely interconnected — but they are not the same thing.
+
+**Sarcopenia** refers specifically to the syndrome of reduced muscle strength and function. **Frailty** is a broader state of reduced physiological reserve and resilience, which sarcopenia significantly contributes to — but frailty also encompasses fatigue, low activity, weight loss, and slow gait from multiple causes. **Falls** are a consequence of both sarcopenia and frailty, through their combined effects on balance, walking, and reaction time.
+
+People can have sarcopenia without being frail, and frailty without meeting criteria for sarcopenia — though the two overlap substantially. Addressing muscle strength and function is central to managing both.
+
+See: [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) | [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+---
+
+## Sarcopenia and Chronic Disease
+
+### Diabetes and Metabolic Health
+
+Sarcopenia and type 2 diabetes are closely linked. Reduced muscle mass impairs glucose uptake and contributes to insulin resistance. Conversely, diabetes-related neuropathy, fatigue, inflammation, and medication effects can all accelerate muscle loss. Physical activity and resistance training are beneficial for both conditions.
+
+See: [Diabetes Hub](/guides/diabetes-hub) | [Metabolic Health Hub](/guides/metabolic-health-hub)
+
+### Chronic Kidney Disease
+
+Sarcopenia is particularly prevalent in CKD, where uraemic toxins, metabolic acidosis, chronic inflammation, and dietary restrictions combine to promote muscle wasting. Loss of muscle function in CKD is associated with poorer outcomes, reduced rehabilitation success, and greater frailty. Physical activity and nutrition management are important parts of CKD care.
+
+See: [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) | [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease)
+
+### Heart Disease
+
+Heart failure is associated with significant muscle wasting through inflammatory mechanisms, reduced physical capacity, and systemic effects of reduced cardiac output. Cardiac rehabilitation — a supervised exercise programme for people with heart disease — addresses muscle deconditioning alongside cardiovascular fitness.
+
+See: [Heart & Circulation Hub](/guides/heart-circulation)
+
+### Advanced Illness and Palliative Care
+
+In advanced illness including cancer, severe organ failure, or advanced frailty, muscle wasting (cachexia) can become profound and partly refractory to standard interventions. In these settings, goals shift toward maintaining function and quality of life for as long as possible, with support from palliative and supportive care teams.
+
+See: [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+
+---
+
+## When to Seek Medical Help
+
+Speak with a clinician if you or someone you care for:
+
+- Has had repeated falls or a significant fall without clear explanation
+- Is losing weight or muscle unintentionally
+- Has noticed marked changes in grip strength or walking ability
+- Is struggling to rise from a chair or climb stairs that were previously manageable
+- Is recovering much more slowly than expected after illness, surgery, or hospitalisation
+- Has been told by a clinician they have frailty, but has not been assessed for muscle loss
+- Has new neurological symptoms such as numbness, significant weakness in one area, or coordination problems (which should be assessed promptly)
+- Has a carer who is concerned about declining physical function
+
+Falls with injury, severe pain, sudden weakness, or very rapid decline warrant more urgent review.
+
+---
+
+## FAQ
+
+**What is sarcopenia?**
+Sarcopenia means a loss of muscle strength and muscle function, often with reduced muscle mass. It can affect balance, mobility, falls risk, and independence.
+
+**Is sarcopenia inevitable with aging?**
+No. Muscle loss becomes more common with age, but strength training, nutrition, activity, and treating underlying health problems can help reduce risk and may improve or stabilise muscle function.
+
+**What are signs of sarcopenia?**
+Possible signs include weaker grip, slower walking, difficulty rising from a chair, reduced stamina, more falls, or trouble carrying out usual daily activities.
+
+**Can sarcopenia improve?**
+Sarcopenia can sometimes improve or stabilise with progressive strength exercise, adequate nutrition, treatment of contributing conditions, and support from clinicians or allied health professionals.
+
+**Who should ask about sarcopenia?**
+People with repeated falls, frailty, unexplained weakness, weight loss, slow walking, reduced activity, or difficulty recovering after illness should ask a clinician about assessment.
+
+---
+
+## Further Reading
+
+- [National Institute on Aging — Maintaining Your Muscle Mass](https://www.nia.nih.gov/health/exercise-physical-activity/maintaining-your-muscle-mass) — strength, exercise, and aging from the US National Institute on Aging
+- [Healthdirect Australia — Sarcopenia](https://www.healthdirect.gov.au/sarcopenia) — patient overview from Australia's national health information service
+- [British Geriatrics Society — Fit for Frailty and Sarcopenia](https://www.bgs.org.uk/resources/fit-for-frailty-comprehensive-practical-guidance-for-primary-care-and-community-and) — clinical guidance on frailty and sarcopenia from the BGS
+- [Cleveland Clinic — Sarcopenia (Muscle Loss)](https://my.clevelandclinic.org/health/diseases/sarcopenia) — patient-facing overview and management information
+
+---
+
+## Related Guides
+
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — central hub for healthy aging content
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty and sarcopenia overlap; understanding the distinction
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — sarcopenia is a major falls risk factor
+- [Bone Health Basics](/guides/bone-health-basics) — muscle and bone health are closely linked
+- [Osteoporosis](/guides/osteoporosis) — bone loss, fracture risk, and management
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — sarcopenia is particularly common in CKD
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — physical activity, nutrition, and muscle health in kidney disease
+- [Diabetes Hub](/guides/diabetes-hub) — sarcopenia and diabetes share risk factors and interact
+- [Metabolic Health Hub](/guides/metabolic-health-hub) — insulin resistance, metabolic health, and muscle
+- [Heart & Circulation Hub](/guides/heart-circulation) — cardiac rehabilitation addresses deconditioning and muscle function
+- [Brain Health Hub](/guides/brain-health-hub) — cognitive decline and physical decline are bidirectionally linked
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — advanced illness, muscle wasting, and goals of care
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks and falls risk assessment
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice. Speak with your clinician about assessment, exercise recommendations, and any care plan appropriate for your individual situation.*


### PR DESCRIPTION
## Summary

* Adds a patient-facing sarcopenia guide (`/guides/sarcopenia/`) covering muscle loss, signs, causes, assessment, strength training, nutrition, falls risk, frailty, and when to seek help
* Connects sarcopenia with frailty, falls prevention, bone health, CKD, heart disease, diabetes/metabolic health, brain health, and palliative care
* Updates 12 existing guides with targeted internal links to sarcopenia where it genuinely improves the reader journey

## Files changed

**Created:**
- `src/content/guides/sarcopenia.md`

**Updated:**
- `src/content/guides/aging-longevity-hub.md` — added sarcopenia to Start Here and Strength sections and Related Guides
- `src/content/guides/falls-prevention.md` — added sarcopenia as a named falls risk factor with link; updated Related Guides
- `src/content/guides/frailty-overview.md` — expanded Muscle Loss section to explain sarcopenia/frailty distinction; updated Related Guides
- `src/content/guides/chronic-kidney-disease-hub.md` — added sarcopenia to Related Guides
- `src/content/guides/managing-chronic-kidney-disease.md` — added sarcopenia to Related Guides; updated updatedDate
- `src/content/guides/palliative-care.md` — added sarcopenia to Related Guides
- `src/content/guides/metabolic-health-hub.mdx` — added sarcopenia under Muscle Preservation section
- `src/content/guides/brain-health-hub.mdx` — added sarcopenia to Related Guides
- `src/content/guides/heart-circulation.md` — added sarcopenia to Related Guides
- `src/content/guides/bone-health-basics.mdx` — added sarcopenia to Related Guides
- `src/content/guides/osteoporosis.mdx` — added sarcopenia to Related Guides
- `src/content/guides/diabetes-hub.md` — added sarcopenia to Related Guides

## Checks

- `npm run content:check` — 0 errors, 13 warnings (unchanged baseline)
- `npm run build` — passed, 758 pages, `/guides/sarcopenia/` route confirmed