### PR TITLE
feat(brain-health): add dementia caregiving guide

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -154,6 +154,7 @@ Key areas include movement, strength, nutrition, sleep, social connection, medic
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 - [Healthspan vs Lifespan: What's the Difference?](/guides/healthspan-vs-lifespan)
 - [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging)
 - [Brain Health Hub](/guides/brain-health-hub)

--- a/src/content/guides/alzheimers-disease-overview.mdx
+++ b/src/content/guides/alzheimers-disease-overview.mdx
@@ -229,6 +229,8 @@ The impact of Alzheimer's disease on family members and caregivers is profound a
 - **Caregiver wellbeing** — maintaining one's own health is not optional; caregiver breakdown leads to worse outcomes for everyone. Peer support, counselling, and regular health check-ups for caregivers should not be deferred
 - **Advance care planning** — discussions about future medical care preferences, including resuscitation and hospitalisation in late-stage disease, are important to have early and document formally
 
+For a comprehensive guide to practical caregiving — including home safety, daily routines, medication safety, and caregiver burnout — see: [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
+
 ---
 
 ## Prognosis
@@ -305,6 +307,7 @@ Many people with mild to moderate Alzheimer's disease live at home with appropri
 ## Related Guides
 
 - [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview) — Alzheimer's disease is the most common cause of dementia; this guide covers the broader syndrome, types, and prevention.
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — practical guide for families and carers: home safety, daily routines, medication, caregiver burnout, and advance care planning.
 - [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment) — the intermediate state between normal ageing and dementia, including assessment, trajectories, and what helps.
 - [Can a Blood Test Predict When Alzheimer's Symptoms Will Begin?](/guides/blood-test-predict-alzheimers-symptom-onset) — plasma p-tau217 biomarkers and what they mean in clinical context.
 - [Amyloid vs Tau: What's the Difference?](/guides/amyloid-vs-tau) — the two key proteins in Alzheimer's pathology explained.

--- a/src/content/guides/brain-health-hub.mdx
+++ b/src/content/guides/brain-health-hub.mdx
@@ -3,7 +3,7 @@ title: "Brain Health Hub: Stroke, Dementia, Sleep, and Prevention"
 description: "A structured hub for brain health — covering stroke recognition, dementia, sleep and cognition, vascular risk, and neurological conditions."
 category: "Neurology"
 publishDate: "2026-04-02"
-updatedDate: "2026-04-15"
+updatedDate: "2026-06-11"
 tags: ["neurology", "stroke", "dementia", "brain health", "sleep", "cognitive health", "alzheimers", "patientguide"]
 draft: false
 faq:
@@ -93,6 +93,7 @@ Many of the most disabling brain conditions — stroke, vascular dementia, Alzhe
 
 ### Understanding Brain Health
 - [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview) — types, risk factors, and evidence on what reduces risk
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — practical guide for families and carers: home safety, routines, medication, burnout, and planning
 - [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment) — the intermediate state between normal aging and dementia: recognition, risk, and what helps
 - [Alzheimer's Disease: Symptoms, Diagnosis, and Treatment](/guides/alzheimers-disease-overview) — how Alzheimer's develops and what the evidence says about prevention
 - [Alzheimer's Prevention and Exercise](/guides/alzheimers-prevention-and-exercise) — the role of physical activity in reducing the most common dementia
@@ -227,6 +228,7 @@ A: Yes — stroke symptoms appear abruptly. If symptoms pass quickly, that may b
 - [Stroke Prevention](/guides/stroke-prevention)
 - [Transient Ischemic Attack (TIA)](/guides/tia-warning-signs)
 - [Dementia: Early Signs, Causes, and Prevention](/guides/dementia-overview)
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 - [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment)
 - [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)
 - [Cognitive Testing and Memory Assessment](/guides/cognitive-testing-memory-assessment)

--- a/src/content/guides/dementia-caregiving.md
+++ b/src/content/guides/dementia-caregiving.md
@@ -1,0 +1,434 @@
+---
+title: "Dementia Caregiving: Safety, Support, and Planning"
+description: "A patient- and family-friendly guide to dementia caregiving, including home safety, daily routines, communication, falls risk, medication safety, caregiver burnout, advance care planning, and when to seek help."
+category: "Neurology"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - dementia
+  - caregiving
+  - neurology
+  - aging
+  - carer support
+faq:
+  - question: "What does dementia caregiving involve?"
+    answer: "Dementia caregiving can include help with routines, medicines, appointments, meals, safety, finances, emotional support, and planning as memory and function change over time."
+  - question: "How can a home be made safer for someone with dementia?"
+    answer: "Useful steps include reducing trip hazards, improving lighting, simplifying routines, checking appliances, storing medicines safely, and planning for wandering or getting lost."
+  - question: "When is home no longer safe for someone with dementia?"
+    answer: "Home may become unsafe if there are repeated falls, wandering, fires or appliance risks, missed medicines, severe confusion, carer exhaustion, or inability to meet basic needs. These situations warrant urgent review."
+  - question: "How can carers reduce burnout?"
+    answer: "Carers benefit from practical support, respite, realistic routines, regular medical review, social connection, and permission to ask for help before reaching crisis point."
+  - question: "When should urgent help be sought?"
+    answer: "Seek urgent help for sudden confusion or delirium, stroke-like symptoms, falls with injury, chest pain, severe breathlessness, fever with worsening confusion, aggression that cannot be safely managed, or concern that the person or carer is unsafe."
+---
+
+## Introduction
+
+A diagnosis of dementia marks the beginning of a journey — not just for the person living with the condition, but for the people who care for and about them. Dementia caregiving is demanding, meaningful, and often invisible work. It changes over time as the condition progresses, and the needs of both the person with dementia and those supporting them deserve attention.
+
+This guide is for families, partners, and carers navigating dementia caregiving. It covers practical safety, daily routines, communication, planning, carer wellbeing, and knowing when to seek help. It is intended as a starting point, not a substitute for advice from clinicians who know the individual situation.
+
+---
+
+## Key Points
+
+- Dementia caregiving encompasses safety, daily routines, communication, planning, and emotional support — not only medical care
+- The person with dementia should be involved in decisions and planning to the extent they are able and wish to be
+- Home safety, medication safety, and falls risk are practical priorities that can be meaningfully improved
+- Dementia affects every person differently; there is no single trajectory or care approach that fits all
+- Carer wellbeing is not a luxury — carer burnout has real consequences for everyone
+- Advance care planning is best done early, while the person can actively participate
+- Recognise when home may no longer be safe, and plan for transitions before crisis point
+
+---
+
+## What Dementia Caregiving Involves
+
+Caregiving for someone with dementia typically extends across:
+
+- **Daily personal care** — washing, dressing, meals, toileting, and sleep
+- **Medication management** — ensuring medicines are taken correctly and safely
+- **Appointments and health monitoring** — attending medical reviews, communicating changes to clinicians
+- **Safety at home** — reducing fall risk, managing appliance and wandering risks
+- **Financial and legal matters** — managing bills, accounts, and formal legal arrangements
+- **Emotional support** — reassurance, social connection, managing distress
+- **Planning** — advance care planning, future care needs, residential care decisions if needed
+
+No two situations are identical. The amount of support needed depends on the type of dementia, the stage, the living situation, available family support, and the person's own preferences and capacity.
+
+---
+
+## Caregiving Changes Over Time
+
+Dementia is a progressive condition. Needs that are manageable in the early stages may change substantially over months or years.
+
+**Early stages** — the person may manage most tasks with prompts and support. The main role may be monitoring, organising systems (pill boxes, reminders), and attending appointments together.
+
+**Middle stages** — personal care assistance, closer supervision for safety, and management of behavioural changes become more prominent. This stage often places the heaviest demands on carers.
+
+**Advanced stages** — the person may require full assistance with all activities, experience significant communication difficulties, and have complex medical needs. Planning for the level of care required — and who can provide it — becomes critical.
+
+Planning ahead during earlier, more stable phases is generally easier than making decisions under pressure during a crisis.
+
+---
+
+## Communication and Behaviour
+
+### Simple, Calm Communication
+
+- Use short, clear sentences and allow extra time for responses
+- Speak calmly and directly; reduce background noise where possible
+- Use the person's name and maintain eye contact
+- Avoid talking about the person as if they are not in the room
+- Repeat gently if needed — rather than showing frustration
+
+### Maintaining Dignity
+
+- Involve the person in decisions and conversations to the extent they are able and wish to be
+- Avoid correcting memory errors aggressively; gentle redirection is often more effective than confrontation
+- Acknowledge feelings rather than disputing facts — "that sounds frustrating" rather than "that didn't happen"
+
+### Understanding Behaviour Changes
+
+Behaviour that seems challenging — agitation, repetition, resistance to care, distress at certain times — usually has a cause. Common triggers include:
+
+- **Pain or discomfort** — which the person may not be able to communicate clearly
+- **Infection** — urinary tract infections in particular can cause sudden confusion and behavioural change
+- **Hunger, thirst, or needing the toilet** — basic unmet needs
+- **Fear, anxiety, or a sense of being rushed**
+- **Overstimulation** — too much noise, activity, or change
+- **Fatigue** — particularly in the afternoon or early evening (sundowning)
+- **Unfamiliar environments or people**
+
+Identifying the underlying cause of a behaviour is more productive than responding to the behaviour alone.
+
+---
+
+## Daily Routines
+
+Consistent, predictable routines reduce confusion and anxiety. Abrupt changes to routine can be unsettling.
+
+### Meals and Hydration
+
+- Regular meal times help structure the day
+- Finger foods or simplified meals may help if cutlery use becomes difficult
+- Adequate hydration is important; some people forget to drink — offer fluids regularly
+- Watch for significant unintentional weight loss, which warrants clinical review
+
+### Sleep
+
+- Maintain consistent sleep and wake times
+- Exposure to natural light during the day supports the sleep-wake cycle
+- Evening agitation or confusion (sundowning) is common; a calm, familiar routine at night helps
+- Pain, infection, constipation, and some medicines can disrupt sleep — these are treatable causes worth reviewing
+
+### Personal Care
+
+- Allow time for dressing and bathing — rushing is a common source of distress
+- Simplify choices where possible — lay out one outfit rather than presenting many
+- Adapt approach as physical and cognitive capacity changes; an occupational therapist can advise
+
+### Appointments and Health Monitoring
+
+- Keep a written record of symptoms, medicines, and changes to share with treating clinicians
+- A consistent GP or care coordinator makes communication easier over time
+
+---
+
+## Home Safety
+
+Home modification can significantly reduce risks without eliminating the person's independence and autonomy.
+
+### Falls Hazards
+
+- Remove loose rugs and cords from walkways
+- Improve lighting — particularly on stairs, in corridors, and in bathrooms at night
+- Ensure frequently used items are at waist height to reduce stooping and reaching
+- Install grab rails in the shower, bath, and near the toilet
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+### Appliances and Fire Risk
+
+- Consider hob or stove safety devices or automatic shut-offs
+- Check that the person can safely use the microwave; consider removing access to high-risk appliances if necessary
+- Ensure smoke alarms are working; consider a monitored alarm system
+
+### Medicines
+
+- Store medicines securely and out of reach if there is a risk of accidental overdose, double-dosing, or refusal to take them
+- Locked medicine cabinets or blister packs dispensed by a pharmacist reduce errors
+- A pharmacist can conduct a medicines review and advise on safe storage and administration
+
+### Sharps, Chemicals, and Hazardous Items
+
+- Store cleaning products, sharp objects, and tools securely
+- Check that the person can safely manage self-care items (razors, scissors)
+
+### Wandering and Getting Lost
+
+- Some people with dementia leave the home and become lost — this is a serious safety risk
+- Strategies include door alarms, door sensor alerts, or securing exits in a non-punitive way
+- Ensure the person carries identification; medical alert jewellery or GPS tracking devices are available
+- Inform neighbours and local services that the person may become disoriented if found outside alone
+- An occupational therapist or community dementia service can advise on appropriate, dignity-preserving safety measures
+
+### Emergency Contacts
+
+- Keep a list of emergency contacts and key medical information in an accessible place (on the fridge, in a wallet card)
+- Ensure the person knows how to contact a carer or trusted person if alone
+
+---
+
+## Falls and Frailty
+
+Dementia significantly increases fall risk — through reduced spatial awareness, impulsive behaviour, difficulty following safety strategies, and the sedating effects of some medicines used to manage behavioural symptoms.
+
+Falls in people with dementia tend to be more frequent and to result in more serious injury than in people without cognitive impairment.
+
+Reducing fall risk includes:
+
+- Addressing home hazards (see above)
+- Appropriate footwear — well-fitting, non-slip shoes rather than loose slippers or socks
+- Vision review — uncorrected visual impairment compounds fall risk significantly
+- Mobility aids — a physiotherapist can assess whether a walking frame or stick is appropriate and fitted correctly
+- Supervised exercise — strength and balance training benefits people with mild to moderate dementia; a physiotherapist or exercise physiologist can advise
+- Medication review — particularly for sedating medicines, antipsychotics, and blood pressure medicines that cause dizziness on standing
+- Bone health — people with dementia have higher rates of osteoporosis; a fall that might bruise a more robust person can fracture a hip. Ask a clinician about bone health and calcium and vitamin D
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) · [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) · [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
+
+---
+
+## Medication Safety
+
+Medication errors are common in dementia caregiving and can have serious consequences.
+
+### Preventing Missed or Double Doses
+
+- Use a weekly pill organiser or blister pack dispensed by a pharmacist
+- Set phone reminders or medication alarms
+- Keep a written medicine list that goes to every appointment
+- Confirm who is responsible for administration — communication gaps between carers cause errors
+
+### Medicines That Increase Risk
+
+Some medicines — including sedatives, strong opioids, antihistamines, and antipsychotics — can cause falls, worsening confusion, or dangerous sedation in people with dementia. Anticholinergic medicines (found in some bladder, allergy, and stomach preparations) are a particular concern for cognition.
+
+A pharmacist medicines review — sometimes called a Home Medicines Review or structured medication review — can identify risky medicines and suggest safer alternatives.
+
+### Medicines for Behavioural Symptoms
+
+Medicines to manage agitation, hallucinations, or sleep disturbance are sometimes necessary but carry risks in older adults and in people with certain dementia types (particularly Lewy body dementia, where some antipsychotics are dangerous). Behavioural and environmental approaches are first-line; when medicines are used, regular review and dose minimisation matter.
+
+**Do not stop or alter prescribed medicines without first speaking with the treating clinician.**
+
+---
+
+## Driving and Community Safety
+
+Dementia affects driving ability through impaired attention, reaction time, spatial judgement, and navigation. This is one of the most sensitive practical issues in early and middle-stage dementia.
+
+- Clinicians are often required or expected to assess driving capacity and notify relevant licensing authorities
+- Rules vary significantly by jurisdiction — a GP or specialist can explain local requirements
+- Losing driving independence is a significant loss of autonomy; it requires sensitive planning and alternatives to be in place
+- Public transport, community transport, ride-share, and family support for travel are all worth organising early
+- Driving concerns that family members have noticed should be raised with the treating clinician — this is not a betrayal; it is a safety responsibility
+
+---
+
+## Eating, Swallowing, and Weight
+
+### Appetite Changes
+
+Reduced appetite and forgetting meals are common. Strategies include:
+- Smaller, more frequent meals
+- Preferred, familiar foods
+- Eating together where possible — social cues support appetite
+- Monitoring weight regularly
+
+### Significant Unintentional Weight Loss
+
+Unexplained weight loss requires clinical review — it may reflect inadequate intake, depression, swallowing difficulties, or another contributing illness.
+
+### Swallowing Concerns
+
+Swallowing difficulties (dysphagia) become more common in moderate to advanced dementia. Warning signs include coughing, choking, food or liquid coming back up, or repeated chest infections.
+
+A speech pathologist can assess swallowing function and recommend safer food and fluid textures. A dietitian can advise on meeting nutrition needs with modified diets.
+
+---
+
+## Sleep, Agitation, and Sundowning
+
+Disrupted sleep and late-day agitation (sundowning) are among the most exhausting challenges for carers.
+
+### Practical Strategies
+
+- Maintain consistent sleep and wake times
+- Encourage physical activity and outdoor light exposure during the day
+- Reduce stimulation and noise in the evening; maintain a familiar, calm routine
+- Avoid caffeinated drinks in the afternoon and evening
+- Check for pain — untreated pain is a common and under-recognised cause of nighttime agitation
+- Check for constipation, urinary discomfort, or other physical sources of distress
+
+### When to Seek Clinical Review
+
+Sudden or rapidly worsening confusion — particularly overnight — may indicate delirium caused by infection, medication change, or another acute illness. This is a medical matter and warrants clinical review.
+
+Persistent sundowning or severe sleep disruption that affects carer safety warrants discussion with a GP or geriatrician. Medication options exist, but should be weighed against risks.
+
+See: [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)
+
+---
+
+## Carer Stress and Burnout
+
+Carer burnout is not a sign of weakness or failure. It is a predictable consequence of sustained, intensive caregiving that is often underappreciated and undersupported.
+
+### Warning Signs
+
+- Persistent exhaustion that rest does not relieve
+- Feeling trapped, resentful, or without hope
+- Withdrawing from other relationships and activities
+- Physical health declining — missed meals, missed medical appointments, sleep deprivation
+- Becoming short-tempered, tearful, or numb
+- Thinking about harming yourself or the person you are caring for
+
+If any of these apply, speak with a GP as soon as possible — not when things become unbearable.
+
+### What Helps
+
+**Respite care** — formal respite (day programmes, in-home respite, residential respite stays) allows carers regular breaks. Accessing respite before reaching crisis point is much more effective than waiting.
+
+**Support services** — dementia organisations in most countries provide carer helplines, support groups, online communities, and practical guidance. These are worth contacting early, not as a last resort.
+
+**Family roles** — distributed caregiving is usually more sustainable than one person taking everything on. Specific, clear task allocation works better than vague offers of help.
+
+**GP support** — carers are entitled to medical care for themselves. A GP can screen for depression and anxiety, provide a medical certificate if needed, and coordinate access to services.
+
+**Peer support** — hearing from others who understand the experience of dementia caregiving can reduce isolation and provide practical knowledge.
+
+**Crisis planning** — knowing what to do if you are suddenly unable to care (due to illness, injury, or emotional breakdown) protects the person with dementia and reduces the carer's anxiety. Discuss an emergency care plan with the care team before it is needed.
+
+See: [Depression](/guides/depression) · [Anxiety](/guides/anxiety)
+
+---
+
+## Legal, Financial, and Advance Care Planning
+
+### Plan While the Person Can Participate
+
+Dementia progressively affects decision-making capacity. Legal and financial arrangements are easiest to put in place while the person is still able to actively participate, express preferences, and consent.
+
+Waiting until a crisis — hospitalisation, loss of capacity — can mean decisions are made by clinicians or courts rather than by the person and family together.
+
+### Key Areas to Address
+
+**Advance care planning** — a process of thinking and talking about the person's values, treatment preferences, and wishes for future care, including in the event they cannot communicate. Involves discussion with clinicians and documentation through a formal advance care directive or plan.
+
+**Substitute decision-maker / Power of attorney** — most jurisdictions allow someone to be formally appointed to make medical, financial, or legal decisions on another person's behalf. The terminology (enduring power of attorney, enduring guardian, health care proxy, lasting power of attorney) varies by country and state. Legal advice from a solicitor or legal aid service can explain local options.
+
+**Finances** — reviewing accounts, direct debits, investments, and superannuation or pension arrangements. Protecting the person from financial exploitation is an important consideration.
+
+**Wills and estate planning** — arranging or reviewing a will while the person retains capacity.
+
+### Note on Jurisdiction
+
+Advance care planning documents, powers of attorney, and legal capacity frameworks differ significantly between countries, states, and territories. This guide can only describe concepts in general terms. Speak with a GP, social worker, or local legal service for advice specific to your situation.
+
+---
+
+## When Home May No Longer Be Safe
+
+Home care is the preferred arrangement for most families and many people with dementia — and with appropriate supports, many people remain safely at home for years.
+
+However, some situations indicate that a higher level of support or a different care setting may be necessary:
+
+- Repeated falls, particularly with injury
+- Wandering outside, getting lost, or being found in dangerous situations
+- Fire or appliance incidents (leaving gas on, burns)
+- Consistent missed medicines despite all safety measures
+- Severe agitation or aggression that cannot be safely managed
+- Malnutrition or significant dehydration despite support
+- Swallowing difficulties creating recurrent aspiration or infection
+- Carer exhaustion to the point of unsafe care
+- A new acute illness requiring care that cannot be managed at home
+
+These are not reasons for guilt. They are clinical and practical signals that the person's care needs have grown beyond what home supports can safely provide.
+
+Discussing residential care options before a crisis — rather than during one — allows the family to research options, visit facilities, and make choices rather than emergency decisions under pressure.
+
+A GP, social worker, or aged care service coordinator can explain the assessment and funding processes in your area.
+
+---
+
+## When to Seek Urgent Help
+
+Contact emergency services or go to the nearest emergency department for:
+
+- **Sudden confusion or dramatic worsening of cognition** — this is delirium until proven otherwise; it has a cause and needs urgent assessment
+- **Stroke symptoms** — sudden face drooping, arm weakness, or speech difficulty
+- **Fall with head injury, severe pain, or suspected fracture**
+- **Chest pain or severe breathlessness**
+- **Fever with acute confusion or significant functional decline** — often signals infection
+- **Aggression or behaviour that cannot be safely managed and creates genuine risk of harm**
+- **A carer who is no longer able to cope safely** — this is a legitimate emergency
+
+Many dementia care services and palliative care teams also have 24-hour on-call lines for crisis support outside emergency hours.
+
+See: [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia) · [Stroke: Symptoms and Emergency Response](/guides/stroke-symptoms-fast-response) · [TIA Warning Signs](/guides/tia-warning-signs)
+
+---
+
+## FAQ
+
+**What does dementia caregiving involve?**
+Dementia caregiving can include help with routines, medicines, appointments, meals, safety, finances, emotional support, and planning as memory and function change over time.
+
+**How can a home be made safer for someone with dementia?**
+Useful steps include reducing trip hazards, improving lighting, simplifying routines, checking appliances, storing medicines safely, and planning for wandering or getting lost. An occupational therapist can advise on specific changes.
+
+**When is home no longer safe for someone with dementia?**
+Home may become unsafe if there are repeated falls, wandering, fires or appliance risks, missed medicines, severe confusion, carer exhaustion, or inability to meet basic needs. These situations warrant urgent clinical review and planning.
+
+**How can carers reduce burnout?**
+Carers benefit from practical support, respite, realistic routines, regular medical review, social connection, and permission to ask for help before reaching crisis point. Speaking with a GP is an important first step.
+
+**When should urgent help be sought?**
+Seek urgent help for sudden confusion, stroke-like symptoms, falls with injury, chest pain, severe breathlessness, fever with worsening confusion, aggression that cannot be safely managed, or concern that the person or carer is unsafe.
+
+---
+
+## Further Reading
+
+- [Dementia Australia — Support for Carers](https://www.dementia.org.au/support/carers) — practical resources and support services for Australian carers
+- [Alzheimer's Association — Caregiving](https://www.alz.org/help-support/caregiving) — US-based caregiving guides, safety resources, and carer support
+- [NHS — Dementia Care and Support](https://www.nhs.uk/conditions/dementia/social-care-and-support/) — UK guidance on dementia care, support services, and carer entitlements
+- [National Institute on Aging — Caring for a Person with Alzheimer's](https://www.nia.nih.gov/health/caregiving/caring-person-alzheimers-disease) — evidence-based caregiving guidance from the US NIA
+- [WHO — Dementia](https://www.who.int/news-room/fact-sheets/detail/dementia) — global context and burden
+
+---
+
+## Related Guides
+
+- [Brain Health Hub](/guides/brain-health-hub)
+- [Dementia: Early Signs, Types, Causes, and Prevention](/guides/dementia-overview)
+- [Alzheimer's Disease: Symptoms, Diagnosis, and Treatment](/guides/alzheimers-disease-overview)
+- [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)
+- [Aging and Longevity Hub](/guides/aging-longevity-hub)
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+- [Depression](/guides/depression)
+- [Anxiety](/guides/anxiety)
+- [Stroke: Symptoms and Emergency Response](/guides/stroke-symptoms-fast-response)
+- [TIA Warning Signs](/guides/tia-warning-signs)
+- [Preventive Screening Hub](/guides/preventive-screening-hub)
+
+---
+
+*Educational only; not a substitute for professional medical advice. For concerns about a person's safety, cognition, or care needs, speak with your GP or treating team. For sudden severe symptoms, seek emergency care immediately.*

--- a/src/content/guides/dementia-overview.mdx
+++ b/src/content/guides/dementia-overview.mdx
@@ -3,7 +3,7 @@ title: "Dementia: Early Signs, Types, Causes, and Prevention"
 description: "A comprehensive guide to dementia — covering types, early warning signs, diagnosis, treatment, risk factors, and what the evidence says about prevention."
 category: "Neurology"
 publishDate: "2026-04-02"
-updatedDate: "2026-04-15"
+updatedDate: "2026-06-11"
 tags: ["dementia", "cognitive decline", "neurology", "alzheimers", "brain health", "prevention", "memory loss"]
 draft: false
 faq:
@@ -182,11 +182,13 @@ Strong evidence supports:
 
 ### Planning and Support
 
-Early diagnosis enables:
+Diagnosis is only one part of the journey. Safety, daily support, carer wellbeing, and advance care planning matter at every stage. Early diagnosis enables:
 - Legal and financial planning while capacity is retained (lasting power of attorney)
 - Advance care planning
 - Access to local dementia support services and national organisations
 - Driving assessment if appropriate
+
+See: [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 
 ---
 
@@ -291,6 +293,7 @@ A: See your doctor if symptoms are getting worse over time, affecting daily acti
 
 - [Neurology Hub](/guides/neurology-hub)
 - [Brain Health Hub](/guides/brain-health-hub)
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 - [Mild Cognitive Impairment (MCI)](/guides/mild-cognitive-impairment)
 - [Delirium vs Dementia: How to Tell the Difference](/guides/delirium-vs-dementia)
 - [Cognitive Testing and Memory Assessment](/guides/cognitive-testing-memory-assessment)

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -303,6 +303,7 @@ Useful steps include improving lighting, removing loose rugs, installing handrai
 - [Dizziness — When to Worry](/guides/dizziness-when-to-worry) — causes of dizziness relevant to fall risk
 - [Syncope and Fainting](/guides/syncope-fainting-overview) — causes and management of fainting
 - [Dementia Overview](/guides/dementia-overview) — cognitive impairment and fall risk
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — home safety, fall risk, and daily routines for people with dementia
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks including bone density and vision
 
 ---

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -102,9 +102,9 @@ See: [Heart and Circulation Hub](/guides/heart-circulation) | [Chronic Kidney Di
 
 ### Cognitive Impairment
 
-Dementia and mild cognitive impairment are associated with frailty, both as contributors and as consequences. They reduce motivation, activity, and the ability to organise daily tasks — which can accelerate physical decline.
+Dementia and mild cognitive impairment are associated with frailty, both as contributors and as consequences. They reduce motivation, activity, and the ability to organise daily tasks — which can accelerate physical decline. For families supporting someone with dementia, safety planning and carer support are integral to managing the frailty that often accompanies cognitive decline.
 
-See: [Dementia Overview](/guides/dementia-overview)
+See: [Dementia Overview](/guides/dementia-overview) · [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 
 ### Social Isolation
 
@@ -274,6 +274,7 @@ A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharma
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle loss as a major contributor to frailty
 - [Bone Health Basics](/guides/bone-health-basics) — bone health in the context of frailty
 - [Dementia Overview](/guides/dementia-overview) — cognitive impairment and frailty
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — practical carer support for families managing dementia alongside frailty
 - [Depression](/guides/depression) — depression as a contributor to frailty
 - [Anxiety](/guides/anxiety) — emotional health and physical decline
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — goals of care in severe frailty

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -83,7 +83,7 @@ Breathlessness, fatigue, and recurrent exacerbations in advanced lung disease si
 Advanced kidney disease causes fatigue, fluid retention, nausea, and difficult treatment decisions including dialysis choices. Palliative care input can be valuable whether or not dialysis is pursued. See: [Chronic Kidney Disease: Stages, Symptoms, and Progression Explained](/guides/chronic-kidney-disease-stages-explained)
 
 **Dementia and Neurological Disease**
-Dementia, motor neurone disease, Parkinson's disease, and other neurological conditions create complex symptom and care needs over years. Palliative care helps at multiple stages — not only when death is near. See: [Dementia Overview](/guides/dementia-overview)
+Dementia, motor neurone disease, Parkinson's disease, and other neurological conditions create complex symptom and care needs over years. Palliative and supportive care can help with symptom burden, family support, goals of care, and advance care planning at multiple stages — not only when death is near. See: [Dementia Overview](/guides/dementia-overview) · [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 
 **Frailty and Multiple Serious Illnesses**
 Older adults with multiple chronic conditions and functional decline often have complex symptom burdens and care goals that palliative care teams are well placed to support.
@@ -316,6 +316,7 @@ Palliative care is a broad approach to symptom management and support across any
 - [COPD: Chronic Obstructive Pulmonary Disease](/guides/copd)
 - [Chronic Kidney Disease: Stages, Symptoms, and Progression Explained](/guides/chronic-kidney-disease-stages-explained)
 - [Dementia Overview](/guides/dementia-overview)
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia)
 - [Aging and Longevity Hub](/guides/aging-longevity-hub)

--- a/src/content/guides/sarcopenia.md
+++ b/src/content/guides/sarcopenia.md
@@ -327,6 +327,7 @@ People with repeated falls, frailty, unexplained weakness, weight loss, slow wal
 - [Metabolic Health Hub](/guides/metabolic-health-hub) — insulin resistance, metabolic health, and muscle
 - [Heart & Circulation Hub](/guides/heart-circulation) — cardiac rehabilitation addresses deconditioning and muscle function
 - [Brain Health Hub](/guides/brain-health-hub) — cognitive decline and physical decline are bidirectionally linked
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — falls risk, frailty, and safety planning for people with dementia
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — advanced illness, muscle wasting, and goals of care
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks and falls risk assessment
 


### PR DESCRIPTION
## Summary

* Adds a patient- and family-facing dementia caregiving guide (`dementia-caregiving.md`) covering home safety, daily routines, communication, falls risk, medication safety, caregiver burnout, advance care planning, and urgent red flags
* Wires dementia caregiving into brain health, aging, frailty, falls prevention, palliative care, dementia overview, and Alzheimer's guide
* Category: `Neurology` — consistent with all peer dementia and brain health guides

## Files changed

* **New:** `src/content/guides/dementia-caregiving.md`
* **Updated:** `brain-health-hub.mdx`, `dementia-overview.mdx`, `alzheimers-disease-overview.mdx`, `aging-longevity-hub.md`, `falls-prevention.md`, `frailty-overview.md`, `sarcopenia.md`, `palliative-care.md`

## Checks

* `npm run content:check` — 0 errors, 13 warnings (unchanged baseline)
* `npm run build` — passes, 759 pages indexed
* Route `/guides/dementia-caregiving/` confirmed generated