### PR TITLE
feat(general): add hospital discharge recovery guide

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -106,6 +106,7 @@ Bone loss accelerates with age and is often silent until a fracture occurs.
 
 Planning for later life — including medical, legal, and emotional preparation — allows people to retain choice and dignity.
 
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — what to check before going home; medicines, follow-up, mobility, carer support, and warning signs
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — what palliative care involves and when it applies
 - [Voluntary Assisted Dying in Australia](/guides/voluntary-assisted-dying) — the Australian framework for VAD
 
@@ -159,6 +160,7 @@ Key areas include movement, strength, nutrition, sleep, social connection, medic
 - [The Hallmarks of Aging Explained](/guides/hallmarks-of-aging)
 - [Brain Health Hub](/guides/brain-health-hub)
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — stroke as a cause of sudden functional decline in older adults; rehabilitation, falls risk, and secondary prevention
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — high-risk discharge transition; medicines, deconditioning, falls risk, carer support, and when to seek urgent help
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
 

--- a/src/content/guides/chronic-kidney-disease-hub.md
+++ b/src/content/guides/chronic-kidney-disease-hub.md
@@ -331,6 +331,7 @@ Specialist referral depends on kidney function, urine results, blood pressure, r
 - [Aging and Longevity Hub](/guides/aging-longevity-hub) — healthy aging, frailty, and falls prevention in the context of aging with chronic conditions
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty and CKD often coexist; a shared management approach improves outcomes
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting is particularly common in CKD and affects outcomes
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — kidney-relevant medicine changes, follow-up blood tests, and care planning after hospital admission
 
 ---
 

--- a/src/content/guides/dementia-caregiving.md
+++ b/src/content/guides/dementia-caregiving.md
@@ -429,6 +429,7 @@ Seek urgent help for sudden confusion, stroke-like symptoms, falls with injury, 
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — neurological disability, rehabilitation, and caregiver support after stroke
 - [TIA Warning Signs](/guides/tia-warning-signs)
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — managing the transition home after hospital admission; delirium, medicines, carer planning, and when to seek help
 
 ---
 

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -305,6 +305,7 @@ Useful steps include improving lighting, removing loose rugs, installing handrai
 - [Dementia Overview](/guides/dementia-overview) — cognitive impairment and fall risk
 - [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — home safety, fall risk, and daily routines for people with dementia
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks including bone density and vision
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — falls risk is elevated after any hospital admission; deconditioning, medication changes, and home hazards after discharge
 
 ---
 

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -281,6 +281,7 @@ A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharma
 - [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — CKD and its interaction with frailty
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — stroke as a cause of sudden functional decline and frailty; rehabilitation, falls risk, and secondary prevention
 - [Heart and Circulation Hub](/guides/heart-circulation) — cardiovascular disease and frailty
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — hospital discharge as a high-risk transition; deconditioning, medicines, falls risk, and when home may not be safe
 
 ---
 

--- a/src/content/guides/heart-circulation.md
+++ b/src/content/guides/heart-circulation.md
@@ -226,6 +226,7 @@ Immediately for severe chest pain, chest pain with arm or jaw pain, sudden breat
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle deconditioning in heart failure and cardiac rehabilitation
 - [Cancer — Guide Hub](/guides/cancer) — Some cancers affect the heart; cardiac toxicity from cancer treatment is an important shared topic.
 - [Preventive Health — Guide Hub](/guides/preventive-health)
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — cardiac discharge planning; medicines, follow-up, warning signs, and cardiac rehabilitation referral
 
 ---
 

--- a/src/content/guides/hospital-discharge-recovery.md
+++ b/src/content/guides/hospital-discharge-recovery.md
@@ -1,0 +1,391 @@
+---
+title: "Hospital Discharge and Recovery: What to Check Before Going Home"
+description: "A patient-friendly guide to hospital discharge and recovery, including medicines, follow-up, warning signs, mobility, falls risk, home support, carer planning, and when to seek urgent help."
+category: "General Health"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+tags: ["hospital discharge", "recovery", "care planning", "medication safety", "falls prevention"]
+draft: false
+faq:
+  - question: "What should I check before leaving hospital?"
+    answer: "Before leaving hospital, check your medicines, follow-up appointments, warning signs, wound or activity instructions, transport home, home support, and who to contact if symptoms worsen."
+  - question: "Why is hospital discharge a risky time?"
+    answer: "Discharge can be risky because medicines may change, recovery instructions can be confusing, symptoms may return, and support at home may not yet be in place."
+  - question: "Who should review medicines after hospital?"
+    answer: "A doctor, pharmacist, or primary care clinician can help review medicine changes, check for duplicates, and explain what to take, stop, or monitor."
+  - question: "When should I seek urgent help after discharge?"
+    answer: "Seek urgent help for chest pain, severe breathlessness, fainting, confusion, new weakness, signs of stroke, severe pain, uncontrolled bleeding, high fever, or rapidly worsening symptoms."
+  - question: "What if I do not feel safe going home?"
+    answer: "Tell the hospital team before discharge if you cannot manage medicines, walking, toileting, meals, wound care, transport, or basic safety at home."
+---
+
+## Introduction
+
+Leaving hospital can feel like a relief — but the transition home is one of the highest-risk moments in a person's healthcare journey. Medicines change, instructions can be complex, and the support needed at home may not yet be in place.
+
+This guide is for patients, families, and carers preparing for hospital discharge or recovering at home after an admission. It covers what to check before leaving, how to manage medicines safely, when to follow up, how to recognise warning signs, and when to seek urgent help.
+
+It does not replace the discharge instructions provided by your hospital. Each admission and each person is different. This guide is intended to help you understand the process, ask better questions, and feel more prepared — not to serve as individual medical advice.
+
+---
+
+## Key Points
+
+- Hospital discharge is a high-risk transition — preparation reduces the chance of readmission
+- Know your medicines: what changed, what stopped, what was added, and who to ask if you are unsure
+- Book follow-up appointments before or immediately after discharge — do not wait until symptoms return
+- Know the warning signs specific to your condition, and know exactly who to call or where to go
+- Falls risk is elevated after any hospital stay; address home safety before discharge if possible
+- If you do not feel safe going home, say so — it is always better to raise concerns before leaving
+- Carers and family need information and support too; include them in discharge conversations where possible
+
+---
+
+## Why Hospital Discharge Matters
+
+Research consistently shows that the weeks immediately after hospital discharge carry an elevated risk of complications, readmission, and medication errors. This is not because the hospital has done anything wrong — it reflects the genuine complexity of transitioning from a highly monitored clinical environment back to everyday life.
+
+Common problems in the post-discharge period include:
+
+- **Medication errors** — doses changed in hospital may not be communicated clearly; old supplies at home may conflict with new prescriptions
+- **Missed follow-up** — blood tests, specialist review, or wound checks not arranged before discharge
+- **Unrecognised warning signs** — symptoms that indicate deterioration are not understood or acted on promptly
+- **Inadequate support** — the level of help needed at home is greater than what is available
+- **Deconditioning** — muscle weakness, fatigue, and reduced mobility after even short admissions
+
+Understanding these risks is the first step to managing them.
+
+---
+
+## Before Leaving Hospital: The Essential Checklist
+
+Before you leave, make sure you have clear answers to the following. If anything is unclear, ask your nurse, doctor, or discharge coordinator before you go.
+
+### Your Diagnosis and What Happened
+
+- What was the main reason for admission?
+- Were any new diagnoses made during the stay?
+- What investigations were done, and what did they show?
+- Are any test results still pending, and how will you be notified?
+
+### Your Medicines
+
+- Do you have a complete updated medication list?
+- Which medicines were started, stopped, or had doses changed?
+- Do you have enough supply to last until your GP review?
+- Who should you contact if you have questions about your medicines?
+
+### Follow-Up Appointments
+
+- When do you need to see your GP or primary care clinician?
+- Are there specialist follow-up appointments, and have they been booked?
+- Are there blood tests or imaging arranged, and when?
+- Who books these, and do you have the details?
+
+### Wound, Procedure, or Device Instructions
+
+- Are there written instructions for wound care, dressing changes, or restrictions?
+- What signs should prompt you to contact the team?
+- When should stitches, clips, or drains be reviewed or removed?
+
+### Activity and Physical Restrictions
+
+- Are there limits on driving, lifting, stairs, or exercise?
+- When can you return to work or usual activities?
+- Is physiotherapy or rehabilitation needed?
+
+### Warning Signs
+
+- What specific symptoms mean you should seek urgent help?
+- Is there a hospital helpline you can call with questions?
+
+### Transport and Practical Matters
+
+- Has transport home been arranged?
+- Do you have someone to stay with you, or check in on you, in the first 24–48 hours?
+- Will you be able to manage meals, medications, and basic personal care at home?
+
+---
+
+## Medicines After Discharge
+
+Medicines are the most common source of problems after hospital discharge. A hospital admission often involves medicines being started, stopped, or changed — and getting this right at home requires clarity.
+
+### What May Have Changed
+
+- **New medicines** — started during admission to treat your condition
+- **Stopped medicines** — medicines that were paused or ceased; do not restart old medicines without advice from your GP or pharmacist
+- **Changed doses** — a medicine you were taking may now be prescribed at a different dose
+- **Medicines held temporarily** — some medicines (particularly blood pressure, diabetes, and kidney medicines) are held during acute illness and need to be restarted when your condition stabilises; your GP or pharmacist will advise on timing
+
+### Important Medicine Groups to Clarify
+
+**Blood thinners (anticoagulants and antiplatelets):** Medicines such as warfarin, rivaroxaban, apixaban, clopidogrel, and aspirin require specific instructions about when and how to take them. Missed doses or incorrect doses carry real risks. Check with your team before discharge.
+
+**Diabetes medicines:** Insulin doses and oral medicines may need adjustment during recovery, particularly if your appetite or food intake changes. Do not adjust doses on your own — contact your GP or diabetes team promptly.
+
+**Blood pressure and heart medicines:** These are sometimes held during acute illness and restarted when blood pressure and kidney function have stabilised. Ask explicitly whether these should be restarted and when.
+
+**Kidney medicine considerations:** Many medicines are dose-adjusted based on kidney function. If your kidneys were stressed during admission, your team may have changed doses or stopped certain medicines. See [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) for more on this.
+
+**Pain medicines:** Short-term pain medicines (including opioids after surgery) need clear instructions about dose, duration, and when to taper or stop. Do not continue them beyond the intended course without review.
+
+**Antibiotics:** If you were prescribed antibiotics, complete the full course as directed — even if you feel better. Do not share antibiotics or use old supplies.
+
+### Pharmacist Review
+
+A pharmacist — in the hospital, at a community pharmacy, or through a home medicines review programme — can help you understand your full medicine list, identify duplicates or conflicts, check doses, and explain any changes. This is one of the most valuable things you can arrange after discharge.
+
+---
+
+## Follow-Up Appointments and Tests
+
+Follow-up is not optional. Many complications of hospitalisation — infection, medication problems, recurrent symptoms, missed diagnoses — are identified at follow-up. Do not wait until you feel unwell to book an appointment.
+
+### General Practitioner (GP) or Primary Care Clinician
+
+Most people should see their GP within one to two weeks of discharge, or sooner if recommended. Your GP can review the discharge summary, check your medicines, arrange blood tests, and coordinate ongoing care. If you do not have a regular GP, arrange one as a priority.
+
+### Specialist Review
+
+If you were under the care of a cardiologist, renal physician, neurologist, respiratory physician, surgeon, or other specialist, confirm whether and when follow-up with that team is needed. This is sometimes arranged by the hospital, but not always — check before you leave.
+
+### Blood Tests and Imaging
+
+After some admissions, blood tests are needed to check kidney function, electrolytes, blood counts, medication levels, or other parameters. Confirm what tests are needed, when they should be done, and who reviews the results. Do not assume no news is good news.
+
+### Rehabilitation and Allied Health
+
+Physiotherapy, occupational therapy, speech pathology, dietitian review, or other allied health input may be needed as part of your recovery plan. If these were recommended in hospital, ask how they will be arranged at home or in the community.
+
+### Wound Checks
+
+If you had surgery, a procedure, or a wound, confirm when it should be checked and by whom. Some wounds require specialist review; others can be managed by your GP or practice nurse.
+
+---
+
+## Mobility and Falls Risk
+
+Any hospital admission carries a risk of deconditioning — a reduction in physical function caused by bed rest, reduced activity, illness, and the hospital environment itself. Even a short admission can cause meaningful loss of muscle strength, balance, and confidence.
+
+This matters because deconditioning and falls risk are closely linked. Falling after discharge is one of the most common causes of readmission in older adults.
+
+### Why Deconditioning Happens
+
+- Reduced activity and time in bed weaken muscles quickly
+- Illness itself depletes energy and muscle mass
+- Medicines may affect balance, blood pressure, and alertness
+- The home environment may be less safe than it was before admission
+
+### What Helps
+
+- **Early mobilisation** — getting up and moving as soon as it is safe to do so, with support if needed
+- **Physiotherapy** — a physiotherapist can assess your strength, balance, and gait, and provide an exercise programme matched to your current ability
+- **Walking aids** — if a frame, cane, or other aid is recommended, use it consistently until it is safe not to
+- **Home safety assessment** — an occupational therapist can identify and help address hazards such as loose rugs, poor lighting, stairs without rails, or a bathroom without grab rails
+
+For a detailed guide to managing fall risk, see [Falls Prevention](/guides/falls-prevention). For those with pre-existing frailty, see [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) and [Sarcopenia](/guides/sarcopenia).
+
+---
+
+## Eating, Hydration, Bowels, and Sleep
+
+Recovery requires adequate nutrition, hydration, and rest. These can all be disrupted after hospital.
+
+### Appetite and Nutrition
+
+Reduced appetite after illness is common. It can be caused by the illness itself, medicines, nausea, pain, or simply the disruption of routine. Poor nutrition after hospital admission slows recovery, contributes to muscle loss, and can increase falls risk.
+
+- Aim for regular meals even if appetite is reduced; small, frequent meals may help
+- Prioritise protein-rich foods to support muscle repair and recovery
+- If appetite remains very poor or you are losing weight unintentionally, contact your GP
+- If you were referred to a dietitian, follow through with this referral
+
+### Hydration
+
+Dehydration can worsen kidney function, cause dizziness and falls, impair cognition, and slow recovery. Aim to drink adequate fluids — usually around 6–8 cups daily for most adults — unless your team has advised fluid restriction for heart failure, kidney problems, or another reason.
+
+### Bowels
+
+Constipation is extremely common after hospitalisation and is often underestimated as a cause of discomfort and distress. Contributing factors include reduced activity, dehydration, changes in diet, and opiate pain medicines. If you were prescribed pain medicines on discharge, ask about a bowel care plan.
+
+### Sleep
+
+Sleep is often disrupted during hospital admission and in the early weeks at home. This is normal but can affect recovery, mood, and cognitive function. If sleep problems are persistent or severe, discuss this with your GP.
+
+---
+
+## Wound, Procedure, or Device Care
+
+If you had surgery, a procedure, or have wounds, drains, catheters, or other devices, you should leave hospital with clear written instructions. If these were not provided, ask before discharge.
+
+### Signs of Wound Infection
+
+Contact your doctor promptly if you notice:
+
+- Increasing redness, warmth, or swelling around a wound
+- New or worsening pain at a wound site
+- Discharge of pus or fluid with an unusual smell
+- Wound edges opening or separating
+- Fever alongside wound concerns
+
+### Bleeding
+
+Some ooze from wounds in the first day or two is normal. Heavier or increasing bleeding from a wound, procedure site, or drain site should be assessed urgently.
+
+### Drains, Catheters, and Lines
+
+If you go home with a drain, urinary catheter, peripherally inserted central catheter (PICC line), or other device, you should have specific written instructions about care, output monitoring, and signs to watch for. Community nursing can support management at home where needed.
+
+---
+
+## Recovery After Common Hospital Problems
+
+Different admissions have different recovery trajectories. Below are brief notes on conditions that frequently lead to hospitalisation.
+
+### After Stroke
+
+Stroke recovery is a prolonged process involving rehabilitation across physical, communication, cognitive, and emotional domains. Medicines for secondary prevention — blood pressure, cholesterol, antiplatelet or anticoagulant therapy — are critical. Falls risk is elevated. See [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) for a detailed guide.
+
+### After Heart Attack or Heart Failure
+
+After a heart attack, cardiac rehabilitation — a structured programme of exercise, education, and psychological support — is strongly recommended. Medicines including antiplatelets, beta-blockers, ACE inhibitors or ARBs, and cholesterol-lowering therapy are typically continued long-term. If you have heart failure, daily weight monitoring and fluid management are important. See [Heart Disease and Circulation](/guides/heart-circulation) and [Heart Failure Overview](/guides/heart-failure-overview).
+
+### After COPD or Pneumonia
+
+Recovery from acute respiratory illness requires attention to breathing, activity, nutrition, and — for COPD — optimised inhaler technique and smoking cessation. Pulmonary rehabilitation may be recommended. Return to smoking significantly worsens prognosis. See [COPD](/guides/copd).
+
+### After Surgery
+
+Post-surgical recovery depends on the type and extent of surgery. General principles include: wound care as instructed, gradual return to activity as guided by your team, pain management, and awareness of complications including infection, bleeding, and deep vein thrombosis.
+
+### After Sepsis
+
+Sepsis is a life-threatening response to infection that can leave lasting effects including fatigue, weakness, sleep problems, anxiety, and cognitive changes — sometimes called post-sepsis syndrome. Recovery can take weeks to months. Contact your GP if you are struggling more than expected in the weeks after discharge. See [Sepsis](/guides/sepsis).
+
+### After Kidney Problems
+
+Acute kidney injury during hospitalisation requires careful monitoring of kidney function after discharge, review of medicines that may affect the kidneys, and attention to hydration. Some people may need nephrology follow-up. See [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) and [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease).
+
+### After Falls or Fractures
+
+Recovery from a fall-related fracture — particularly hip fracture — requires rehabilitation, bone health assessment, and a fall prevention plan. See [Falls Prevention](/guides/falls-prevention) and [Frailty](/guides/frailty-overview).
+
+### After Delirium or Confusion
+
+Delirium — acute confusion that develops during illness or hospitalisation — can take weeks or months to fully resolve. Cognitive function may remain impaired for a period. If there was delirium during admission, inform the GP and family. This can sometimes trigger or accelerate underlying dementia. See [Dementia Caregiving](/guides/dementia-caregiving) if ongoing cognitive concerns arise.
+
+---
+
+## Carer and Family Planning
+
+Hospital discharge does not just affect the patient — it places real demands on carers and family members. Planning ahead reduces stress and reduces the risk of problems being missed.
+
+### What Carers and Family Should Know
+
+- The diagnosis, what happened during the admission, and what changed
+- The current medicine list and how to manage or help with medicines
+- Appointment dates and what needs to be arranged
+- Warning signs to watch for, and who to call or where to go
+- What physical tasks the person can and cannot manage independently
+- How to support nutrition, hydration, and personal care where needed
+
+### Practical Coordination
+
+- Who is responsible for meals, shopping, and transport?
+- Who is checking in each day, particularly in the first two weeks?
+- If multiple people are helping, is there a shared plan or communication approach?
+
+### Carer Wellbeing and Respite
+
+Caring is demanding. Carer strain — burnout, exhaustion, anxiety, and social isolation — is a genuine health risk. Carers should be honest with themselves and with health providers about what they can manage. Respite services, community support programmes, and carer support organisations exist for this reason.
+
+---
+
+## When Home May Not Be Safe
+
+Some people are not ready to go home when discharge is planned. It is important to say so before leaving hospital, rather than struggling or deteriorating at home.
+
+Tell the hospital team if you have concerns about managing:
+
+- **Medicines** — if you cannot reliably take the right medicines at the right times
+- **Mobility** — if you cannot walk safely, manage stairs, transfer from bed or chair, or reach the toilet
+- **Meals** — if no-one will be providing food or you cannot prepare meals independently
+- **Wound or device care** — if dressing changes or device care cannot be managed at home without support
+- **Personal hygiene** — if showering, dressing, or toileting are not manageable without help
+- **Carer capacity** — if the person who was going to help you cannot manage the level of care needed
+- **Home hazards** — if the home environment (stairs, bathroom, bed height, clutter) makes safe function impossible
+- **Worsening or unresolved symptoms** — if you are still unwell and worried about coping alone
+
+In Australia, hospital social workers, discharge planners, and My Aged Care services can assist with home care packages, transitional care, and residential care assessment if a return home is not safe at this time.
+
+---
+
+## When to Seek Urgent Help
+
+After discharge, seek emergency care (call 000 in Australia, 999 in the UK, or 911 in the US, or go to the nearest emergency department) if you develop:
+
+- **Chest pain, pressure, or tightness** — particularly if radiating to the arm, jaw, or back
+- **Severe or worsening breathlessness** — especially at rest or lying flat
+- **Fainting or collapse**
+- **Signs of stroke** — sudden facial drooping, arm or leg weakness, speech difficulty, or vision changes (see [FAST/BEFAST](https://www.stroke.org.au/resources/befast/))
+- **New confusion, disorientation, or delirium**
+- **Uncontrolled bleeding** from a wound, device site, or internally
+- **High fever with worsening illness** — particularly if infection is a concern
+- **Severe or rapidly worsening pain**
+- **Signs of wound infection that are spreading rapidly or associated with fever**
+- **Inability to pass urine** — particularly after urological surgery, catheter removal, or prostate procedures
+- **Severe vomiting or diarrhoea** with inability to keep down medicines or fluids
+- **Sudden, severe, or rapidly worsening swelling** in a limb (which may indicate deep vein thrombosis)
+- **Any sudden neurological change** in someone recovering from stroke or neurosurgery
+
+If you are unsure, call your local health advice line (healthdirect on 1800 022 222 in Australia, 111 in the UK) before going to an emergency department. If in doubt about serious symptoms, do not wait — seek emergency help.
+
+---
+
+## Questions to Ask Before Discharge
+
+Use these as prompts before leaving hospital. You may wish to write down the answers.
+
+1. What was I admitted for, and what is my current diagnosis?
+2. Are there any test results still pending, and who will contact me with results?
+3. What medicines have changed — what was started, stopped, or adjusted?
+4. Do I have enough supply of all medicines to last until my GP review?
+5. When do I need to see my GP, and has the appointment been booked?
+6. Are there specialist appointments or blood tests I need to arrange?
+7. What warning signs should prompt me to seek urgent help?
+8. Who can I call with questions about my medicines or recovery?
+9. Are there restrictions on driving, lifting, work, or exercise?
+10. If I have a wound or device, what do I need to watch for at home?
+11. Has home support been arranged if I need it?
+12. Is there written information I can take home about my condition and recovery?
+
+---
+
+## Further Reading
+
+The following are neutral, reputable sources of information on hospital discharge and care transitions. They do not replace the instructions provided by your hospital or healthcare team.
+
+- **AHRQ Care Transitions** — Agency for Healthcare Research and Quality, US: resources on improving hospital-to-home transitions ([www.ahrq.gov](https://www.ahrq.gov/patient-safety/settings/hospital/red/toolkit/index.html))
+- **MedlinePlus: Going Home From the Hospital** — National Library of Medicine, US: plain-language overview of discharge planning ([medlineplus.gov](https://medlineplus.gov/ency/patientinstructions/000508.htm))
+- **NHS: Leaving Hospital** — National Health Service, UK: practical guidance on discharge, transport, and follow-up ([www.nhs.uk](https://www.nhs.uk/nhs-services/hospitals/going-into-hospital/leaving-hospital/))
+- **Healthdirect: Going Home From Hospital** — Australian Government health information: discharge planning and home care ([www.healthdirect.gov.au](https://www.healthdirect.gov.au/going-home-from-hospital))
+- **Institute for Healthcare Improvement: Care Transitions** — resources on reducing avoidable readmissions and improving care handovers ([www.ihi.org](https://www.ihi.org/topics/transitions-in-care))
+
+---
+
+## Related Guides
+
+- [Falls Prevention](/guides/falls-prevention)
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
+- [Sarcopenia](/guides/sarcopenia)
+- [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation)
+- [Dementia Caregiving](/guides/dementia-caregiving)
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub)
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease)
+- [Heart Disease and Circulation](/guides/heart-circulation)
+- [Heart Failure Overview](/guides/heart-failure-overview)
+- [COPD](/guides/copd)
+- [Sepsis](/guides/sepsis)
+- [Preventive Screening Hub](/guides/preventive-screening-hub)

--- a/src/content/guides/managing-chronic-kidney-disease.md
+++ b/src/content/guides/managing-chronic-kidney-disease.md
@@ -327,6 +327,7 @@ Planning begins when kidney function has declined significantly and progression 
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — kidney function testing as preventive health
 - [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting in CKD, physical activity, and nutrition
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — medicine review, kidney function monitoring, and follow-up planning after a hospital admission
 
 ---
 

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -325,6 +325,7 @@ Palliative care is a broad approach to symptom management and support across any
 - [Anxiety](/guides/anxiety)
 - [Shortness of Breath — When to Seek Urgent Help](/guides/shortness-of-breath)
 - [Voluntary Assisted Dying — Guide Hub](/guides/voluntary-assisted-dying)
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — planning for safe discharge; carer support, medicines, follow-up, and when home may not be safe
 
 ---
 

--- a/src/content/guides/sarcopenia.md
+++ b/src/content/guides/sarcopenia.md
@@ -332,6 +332,7 @@ People with repeated falls, frailty, unexplained weakness, weight loss, slow wal
 - [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — falls risk, frailty, and safety planning for people with dementia
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — advanced illness, muscle wasting, and goals of care
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks and falls risk assessment
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — post-discharge deconditioning, rehabilitation, mobility, and falls risk after hospital admission
 
 ---
 

--- a/src/content/guides/stroke-recovery-rehabilitation.md
+++ b/src/content/guides/stroke-recovery-rehabilitation.md
@@ -438,6 +438,7 @@ Aphasia is difficulty with language — speaking, understanding, reading, or wri
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — preparing for safe discharge after stroke; medicines, follow-up, warning signs, and home support
 
 ---
 


### PR DESCRIPTION
## Summary

* Adds a patient-facing hospital discharge and recovery guide
* Covers medicines, follow-up appointments, warning signs, mobility, falls risk, home support, carer planning, deconditioning, wound care, common post-admission scenarios, and urgent red flags
* Wires discharge planning into aging, frailty, falls, stroke recovery, CKD, heart, palliative care, and dementia clusters via Related Guides cross-links

## Files changed

* `src/content/guides/hospital-discharge-recovery.md` — new guide (category: General Health)
* `src/content/guides/aging-longevity-hub.md` — added to Planning and Support section + Related Guides
* `src/content/guides/falls-prevention.md` — added to Related Guides
* `src/content/guides/frailty-overview.md` — added to Related Guides
* `src/content/guides/sarcopenia.md` — added to Related Guides
* `src/content/guides/stroke-recovery-rehabilitation.md` — added to Related Guides
* `src/content/guides/dementia-caregiving.md` — added to Related Guides
* `src/content/guides/palliative-care.md` — added to Related Guides
* `src/content/guides/chronic-kidney-disease-hub.md` — added to Related Guides
* `src/content/guides/managing-chronic-kidney-disease.md` — added to Related Guides
* `src/content/guides/heart-circulation.md` — added to Related Guides

## Checks

* `npm run content:check` — 0 errors, 13 warnings (baseline unchanged)
* `npm run build` — passes, 761 pages, route /guides/hospital-discharge-recovery/ confirmed