### PR TITLE
feat(general): add medication safety guide

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -119,6 +119,7 @@ Preventive health care is especially valuable in later life — screening, vacci
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based screening recommendations from 50s onward, including bone density, cardiovascular risk, and cancer checks
 - [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — practical fall risk reduction
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — clinical assessment and what can help
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy, falls risk from medicines, and medication review in older adults
 
 ---
 
@@ -161,6 +162,7 @@ Key areas include movement, strength, nutrition, sleep, social connection, medic
 - [Brain Health Hub](/guides/brain-health-hub)
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — stroke as a cause of sudden functional decline in older adults; rehabilitation, falls risk, and secondary prevention
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — high-risk discharge transition; medicines, deconditioning, falls risk, carer support, and when to seek urgent help
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy, medicines and falls, and medication review
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
 

--- a/src/content/guides/atrial-fibrillation.md
+++ b/src/content/guides/atrial-fibrillation.md
@@ -175,6 +175,7 @@ Catheter ablation restores normal rhythm in many people, particularly with parox
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — for people who have had a stroke related to atrial fibrillation: rehabilitation, secondary prevention, and recovery
 - [Heart & Circulation — Guide Hub](/guides/heart-circulation)
 - [Sleep Apnoea — Causes, Risks, and Treatment](/guides/sleep-apnoea)
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — blood thinners in AF; anticoagulation safety, bleeding risk, missed doses, and interactions
 
 ---
 

--- a/src/content/guides/chronic-kidney-disease-hub.md
+++ b/src/content/guides/chronic-kidney-disease-hub.md
@@ -167,7 +167,7 @@ Iodinated contrast dyes used in CT scans and some other procedures can also affe
 
 A pharmacist or clinician can review medicines for kidney-related safety considerations.
 
-See: [Managing Chronic Kidney Disease — Medication Safety](/guides/managing-chronic-kidney-disease)
+See: [Managing Chronic Kidney Disease — Medication Safety](/guides/managing-chronic-kidney-disease) | [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety)
 
 ---
 
@@ -332,6 +332,7 @@ Specialist referral depends on kidney function, urine results, blood pressure, r
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty and CKD often coexist; a shared management approach improves outcomes
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting is particularly common in CKD and affects outcomes
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — kidney-relevant medicine changes, follow-up blood tests, and care planning after hospital admission
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — NSAIDs, contrast, sick day rules, and polypharmacy in kidney disease
 
 ---
 

--- a/src/content/guides/common-heart-medications.md
+++ b/src/content/guides/common-heart-medications.md
@@ -93,6 +93,7 @@ Many heart conditions require **long-term medication**. Understanding what your 
 - [Understanding Coronary Angiography](/guides/understanding-coronary-angiography)  
 - [Cardiac Rehabilitation After a Heart Event](/guides/cardiac-rehabilitation)  
 - [Atrial Fibrillation: Symptoms, Risks, and Treatment](/guides/atrial-fibrillation)  
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy, blood thinners, interactions, and when to seek urgent help
 
 ---
 

--- a/src/content/guides/dementia-caregiving.md
+++ b/src/content/guides/dementia-caregiving.md
@@ -204,7 +204,7 @@ See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) · [F
 
 ## Medication Safety
 
-Medication errors are common in dementia caregiving and can have serious consequences.
+Medication errors are common in dementia caregiving and can have serious consequences. For a comprehensive overview of medication safety including polypharmacy, dose aids, and high-risk medicines, see [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety).
 
 ### Preventing Missed or Double Doses
 
@@ -430,6 +430,7 @@ Seek urgent help for sudden confusion, stroke-like symptoms, falls with injury, 
 - [TIA Warning Signs](/guides/tia-warning-signs)
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — managing the transition home after hospital admission; delirium, medicines, carer planning, and when to seek help
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — dose administration aids, blister packs, polypharmacy, and medicines that carry specific risks in dementia
 
 ---
 

--- a/src/content/guides/diabetes-hub.md
+++ b/src/content/guides/diabetes-hub.md
@@ -250,6 +250,7 @@ Yes. With modern insulin therapy, continuous glucose monitoring, and good self-m
 - [Healthy Weight Loss Guide](/guides/healthy-weight-loss-guide) — weight reduction is a core strategy for Type 2 diabetes risk reduction and remission.
 - [Aging and Longevity Basics](/guides/aging-and-longevity-basics) — how metabolic health shapes healthspan and long-term disease risk.
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — sarcopenia and diabetes interact through insulin resistance and reduced physical capacity
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — hypoglycaemia risk, sick day rules, kidney function and diabetes medicines, and polypharmacy
 
 ## Related Hubs
 - [Metabolic Health & Weight-Loss Medicines Hub](/guides/metabolic-health-hub)

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -219,6 +219,8 @@ Medication review is an important and often overlooked component of falls preven
 
 Never stop or reduce prescribed medicines without speaking with a clinician first.
 
+See: [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — for a detailed overview of which medicines raise fall risk and how to approach a medication review.
+
 ---
 
 ## Vision, Hearing, Feet, and Footwear
@@ -306,6 +308,7 @@ Useful steps include improving lighting, removing loose rugs, installing handrai
 - [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — home safety, fall risk, and daily routines for people with dementia
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks including bone density and vision
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — falls risk is elevated after any hospital admission; deconditioning, medication changes, and home hazards after discharge
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — medicines that raise fall risk, medication review, and polypharmacy
 
 ---
 

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -114,6 +114,8 @@ Social isolation is independently associated with faster physical decline, depre
 
 Taking multiple medicines — particularly sedatives, strong pain medicines, antidepressants, and blood pressure medicines — can cause fatigue, dizziness, appetite suppression, and sedation that together mimic or worsen frailty. Medication review is an important part of frailty management.
 
+See: [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety)
+
 ### Hospitalisation
 
 Hospital admissions — even brief ones — can cause significant deconditioning in frail older adults, through bedrest, poor nutrition, disruption to routine, and exposure to infection. Early mobilisation and nutritional support during hospital stays are now recognised priorities in geriatric care.
@@ -282,6 +284,7 @@ A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharma
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — stroke as a cause of sudden functional decline and frailty; rehabilitation, falls risk, and secondary prevention
 - [Heart and Circulation Hub](/guides/heart-circulation) — cardiovascular disease and frailty
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — hospital discharge as a high-risk transition; deconditioning, medicines, falls risk, and when home may not be safe
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy and frailty; medicines that increase falls risk; medication review
 
 ---
 

--- a/src/content/guides/heart-circulation.md
+++ b/src/content/guides/heart-circulation.md
@@ -227,6 +227,7 @@ Immediately for severe chest pain, chest pain with arm or jaw pain, sudden breat
 - [Cancer — Guide Hub](/guides/cancer) — Some cancers affect the heart; cardiac toxicity from cancer treatment is an important shared topic.
 - [Preventive Health — Guide Hub](/guides/preventive-health)
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — cardiac discharge planning; medicines, follow-up, warning signs, and cardiac rehabilitation referral
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — blood thinners, blood pressure medicines, polypharmacy, and medication review
 
 ---
 

--- a/src/content/guides/high-blood-pressure.md
+++ b/src/content/guides/high-blood-pressure.md
@@ -183,3 +183,4 @@ A: Causes may include medication resistance, underlying conditions, or persisten
 - [Heart & Circulation Overview](/guides/heart-circulation-overview)
 - [Stroke](/guides/stroke-symptoms-fast-response)
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — secondary prevention, blood pressure management, and rehabilitation after stroke
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — blood pressure medicines, falls risk from dizziness, and medication review

--- a/src/content/guides/hospital-discharge-recovery.md
+++ b/src/content/guides/hospital-discharge-recovery.md
@@ -134,7 +134,7 @@ Medicines are the most common source of problems after hospital discharge. A hos
 
 ### Pharmacist Review
 
-A pharmacist — in the hospital, at a community pharmacy, or through a home medicines review programme — can help you understand your full medicine list, identify duplicates or conflicts, check doses, and explain any changes. This is one of the most valuable things you can arrange after discharge.
+A pharmacist — in the hospital, at a community pharmacy, or through a home medicines review programme — can help you understand your full medicine list, identify duplicates or conflicts, check doses, and explain any changes. This is one of the most valuable things you can arrange after discharge. For a detailed guide to medicine safety at and after discharge, see [Medication Safety](/guides/medication-safety).
 
 ---
 
@@ -376,6 +376,7 @@ The following are neutral, reputable sources of information on hospital discharg
 
 ## Related Guides
 
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — a practical guide to medicine lists, side effects, interactions, and high-risk times including hospital discharge
 - [Falls Prevention](/guides/falls-prevention)
 - [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview)
 - [Sarcopenia](/guides/sarcopenia)

--- a/src/content/guides/managing-chronic-kidney-disease.md
+++ b/src/content/guides/managing-chronic-kidney-disease.md
@@ -139,7 +139,7 @@ Additional medicines may be used to manage specific complications — for anaemi
 
 ## Medication Safety
 
-Kidney disease changes how many medicines behave in the body.
+Kidney disease changes how many medicines behave in the body. For a broader overview covering polypharmacy, discharge transitions, blood thinners, and supplements, see [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety).
 
 ### NSAIDs (Anti-inflammatory Medicines)
 
@@ -328,6 +328,7 @@ Planning begins when kidney function has declined significantly and progression 
 - [Palliative Care — Guide Hub](/guides/palliative-care) — supportive care in advanced kidney disease
 - [Sarcopenia: Muscle Loss, Strength, and Healthy Aging](/guides/sarcopenia) — muscle wasting in CKD, physical activity, and nutrition
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — medicine review, kidney function monitoring, and follow-up planning after a hospital admission
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — NSAIDs, contrast, sick day advice, polypharmacy, and medication review in CKD
 
 ---
 

--- a/src/content/guides/medication-safety.md
+++ b/src/content/guides/medication-safety.md
@@ -1,0 +1,461 @@
+---
+title: "Medication Safety: How to Avoid Common Medicine Problems"
+description: "A patient-friendly guide to medication safety, including medicine lists, side effects, duplicate medicines, hospital discharge changes, kidney function, falls risk, blood thinners, diabetes medicines, supplements, and when to seek help."
+category: "General Health"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+tags: ["medication safety", "medicines", "polypharmacy", "hospital discharge", "pharmacist"]
+draft: false
+faq:
+  - question: "What is medication safety?"
+    answer: "Medication safety means using medicines in a way that reduces the risk of errors, side effects, interactions, duplicate treatment, missed doses, or unsafe changes."
+  - question: "Why is a medicine list important?"
+    answer: "An up-to-date medicine list helps clinicians and pharmacists check what you take, what has changed, and whether any medicines may interact or duplicate each other."
+  - question: "Should I stop a medicine if I think it is causing side effects?"
+    answer: "Do not stop or change prescribed medicines without medical or pharmacist advice unless you have been told to do so. Some medicines need careful review or gradual changes."
+  - question: "Why does kidney function matter for medicines?"
+    answer: "Some medicines are processed through the kidneys or can affect kidney function, so doses, choices, or monitoring may need adjustment in people with kidney disease."
+  - question: "When should I seek urgent help for a medicine problem?"
+    answer: "Seek urgent help for trouble breathing, swelling of the face or throat, severe rash, fainting, chest pain, severe bleeding, confusion, severe drowsiness, or symptoms of low blood sugar."
+---
+
+## Introduction
+
+Medicines are among the most effective tools available in modern healthcare — and among the most common sources of preventable harm. Medication errors, unrecognised side effects, harmful drug interactions, and unsafe transitions between care settings affect people across all ages and conditions.
+
+This guide is for patients, families, and carers who want to understand medication safety: how to keep an accurate medicine list, what to watch for, when to seek a pharmacist review, and when a medicine problem needs urgent attention.
+
+It does not replace advice from your clinician or pharmacist, and it does not provide dosing guidance. Every person's situation is different. Use this guide to ask better questions and recognise warning signs — not to make medicine changes independently.
+
+---
+
+## Key Points
+
+- Keep an accurate, up-to-date list of all your medicines, including over-the-counter products and supplements
+- Hospital discharge, new diagnoses, and seeing multiple specialists are high-risk times for medicine problems
+- Never stop or change prescribed medicines without advice from your clinician or pharmacist
+- A pharmacist medicines review is one of the most valuable steps you can take after a hospital admission or when taking multiple medicines
+- Some medicines require dose adjustment or extra caution in kidney disease, liver disease, older age, or pregnancy
+- Falls, confusion, bleeding, and low blood sugar are common medicine-related harms that are often preventable
+- Supplements and herbal products can interact with prescribed medicines — always disclose them to your clinician and pharmacist
+
+---
+
+## Why Medication Safety Matters
+
+Taking multiple medicines — particularly in the context of multiple chronic conditions, older age, or recent hospitalisation — creates real complexity. The risks are not rare:
+
+- **Medicine errors** affect millions of people each year worldwide and are a leading cause of preventable hospital admissions
+- **Drug interactions** occur when two or more medicines affect each other's action, sometimes dangerously
+- **Duplicate treatment** happens when the same medicine (or medicines from the same class) is prescribed by different clinicians without coordination
+- **Polypharmacy** — taking five or more medicines simultaneously — is increasingly common and increases the risk of side effects and interactions
+- **Discharge transitions** are among the highest-risk times: medicines may be started, stopped, or changed in hospital without clear communication home
+- **Self-medication** with over-the-counter products, supplements, or old prescriptions adds further complexity that clinicians may not know about
+
+Understanding these risks is not meant to cause alarm. Most people take their medicines safely. But knowing where the risks lie — and how to reduce them — makes a genuine difference.
+
+---
+
+## Keep an Accurate Medicine List
+
+An up-to-date medicine list is the single most practical tool for medication safety. Take it to every appointment, every hospital visit, and every pharmacy.
+
+### What Your Medicine List Should Include
+
+For each medicine:
+
+- The name of the medicine (both generic and brand name if known)
+- The dose as written on the label
+- When you take it (morning, evening, with food, etc.)
+- What it is for (blood pressure, pain, depression, etc.)
+- Who prescribed it
+- When it was started
+
+Also include:
+
+- **Over-the-counter medicines** — pain relievers, antacids, antihistamines, cold and flu products, sleep aids
+- **Vitamins and mineral supplements** — including vitamin D, calcium, iron, fish oil, magnesium
+- **Herbal and complementary products** — including St John's Wort, ginkgo, garlic supplements, valerian, and others
+- **Skin patches, inhalers, eye drops, and creams** — these are medicines too
+- **Known allergies and adverse reactions** — note the medicine and what happened
+
+### Keeping It Current
+
+- Update your list after every hospital admission, specialist visit, or medicine change
+- Carry it in your wallet, phone, or medication bag
+- Make sure your pharmacist and GP have the same list
+- If a family member or carer manages your medicines, they should have a copy
+
+---
+
+## High-Risk Times for Medicine Problems
+
+Medicine problems can happen at any time, but certain situations significantly raise the risk.
+
+### Hospital Discharge
+
+Medicines are the most common source of problems after discharge. A hospital admission often involves medicines being started, stopped, or changed — and getting this right at home requires careful planning. Old supplies of medicines at home may conflict with new prescriptions; instructions may be unclear. See [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) for a detailed guide to managing this transition.
+
+### After Surgery
+
+Pain medicines prescribed after surgery may interact with regular medicines or cause side effects such as constipation, drowsiness, or falls. Instructions about duration — how long to take them — are essential.
+
+### Seeing Multiple Specialists
+
+When a GP, cardiologist, nephrologist, endocrinologist, and other clinicians are all prescribing, the risk of duplicated medicines or conflicting treatment increases. No single clinician may have the complete picture. A pharmacist or GP can review the full list for conflicts.
+
+### After a New Diagnosis
+
+Starting a medicine for a new condition may interact with existing medicines. This is particularly common when adding blood pressure medicines, diabetes medicines, or pain medicines.
+
+### After Kidney Function Changes
+
+Many medicines are processed through the kidneys. If kidney function declines — including after an acute illness — doses may need adjustment or medicines may need to be paused or changed. See [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease).
+
+### After Falls or Confusion
+
+A fall or new episode of confusion can be caused by a medicine — particularly sedating medicines, blood pressure medicines, or diabetes medicines causing low blood sugar. A medicine review after a fall is a standard and valuable step.
+
+### When Carers Change
+
+When responsibility for medicines shifts — between family members, between home and hospital, or between care providers — errors are more likely. Clear handover communication is essential.
+
+---
+
+## New, Stopped, and Changed Medicines
+
+When your medicine list changes, it is important to understand exactly what has changed and why.
+
+### Reconcile Your Lists
+
+After any hospitalisation or major medical encounter, compare your old medicine list with the new one. Identify what was added, what was stopped, and what was changed. If anything is unclear, ask before leaving hospital or at your first post-discharge pharmacist or GP visit.
+
+### Do Not Restart Old Medicines Without Advice
+
+Medicines that were stopped in hospital — including blood pressure medicines, diabetes medicines, and kidney medicines — may have been stopped for a good reason. Do not restart them without advice from your GP or pharmacist.
+
+### Check for Duplicate Medicines
+
+Duplication can occur when a medicine from the same class is prescribed by two different clinicians, or when a brand-name medicine and a generic version of the same drug are both supplied. Ask your pharmacist to check for duplicates.
+
+### Ask What Each Medicine Is For
+
+You have the right to understand why you are taking each medicine. Knowing its purpose helps you recognise relevant side effects and understand why it should or should not be continued.
+
+### Ask About Short-Term Medicines
+
+Some medicines — antibiotics, pain medicines, short-term steroids — are intended for a defined period. Confirm when they should be stopped.
+
+---
+
+## Side Effects and Interactions
+
+All medicines carry the possibility of side effects. Many are mild or manageable; some are serious and need prompt attention.
+
+### Common Side Effects to Know About
+
+- **Dizziness and light-headedness** — particularly with blood pressure medicines; can cause falls
+- **Sedation and drowsiness** — with sleeping tablets, antihistamines, strong pain medicines, some antidepressants, and muscle relaxants
+- **Confusion** — particularly in older adults; can be caused by anticholinergic medicines, sedatives, or opioids
+- **Nausea and stomach upset** — common with antibiotics, anti-inflammatory medicines, and some heart medicines
+- **Constipation** — very common with opioid pain medicines
+- **Low blood pressure on standing** — can cause dizziness and falls; related to blood pressure medicines and diuretics
+- **Low blood sugar (hypoglycaemia)** — with certain diabetes medicines; see Diabetes Medicines section below
+- **Easy bruising and bleeding** — with blood thinners
+- **Rash or skin reactions** — ranging from mild to severe allergic reactions
+- **Cough** — a recognised effect of ACE inhibitor blood pressure medicines
+
+Not every side effect means a medicine needs to be stopped — discuss any concerns with your clinician or pharmacist before making changes.
+
+### Drug Interactions
+
+Interactions can increase or decrease how well a medicine works, or cause new side effects when two medicines are combined. Common interaction categories include:
+
+- Medicines that both thin the blood (increased bleeding risk when combined)
+- Medicines that both lower blood pressure (additive low blood pressure)
+- Medicines that both cause drowsiness (additive sedation)
+- Medicines that affect liver enzymes, which process many drugs
+
+Alcohol can also interact with many medicines — including sedatives, pain medicines, blood thinners, and diabetes medicines. Ask your pharmacist about alcohol and your specific medicines.
+
+---
+
+## Medicines and Falls Risk
+
+Several types of medicine increase the risk of falls. This is particularly important for older adults and anyone who has already had a fall.
+
+### Medicines That Raise Fall Risk
+
+- **Sleeping tablets, sedatives, and benzodiazepines** — cause drowsiness, impaired balance, and slowed reaction time
+- **Strong pain medicines (opioids)** — cause drowsiness and can impair balance
+- **Blood pressure medicines** — particularly if causing dizziness when standing (orthostatic hypotension)
+- **Diuretics (fluid tablets)** — can cause low blood pressure and dizziness
+- **Diabetes medicines** — if causing hypoglycaemia (low blood sugar), which causes weakness and confusion
+- **Some antidepressants and nerve pain medicines** — can cause dizziness, sedation, or low blood pressure
+- **Antihistamines** — older antihistamines have sedating effects
+
+Taking multiple medicines that each modestly raise fall risk can together create significant hazard. A pharmacist or clinician can assess fall-related medicine risks.
+
+Seek a medication review after any fall. Never stop prescribed medicines without clinician or pharmacist guidance.
+
+See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+---
+
+## Medicines and Kidney Disease
+
+Kidney function affects how many medicines work in the body, and some medicines can affect the kidneys themselves.
+
+### How CKD Affects Medicine Safety
+
+In people with chronic kidney disease (CKD), some medicines may:
+
+- Accumulate to higher levels than intended because the kidneys cannot clear them efficiently
+- Cause direct damage to the kidneys
+- Require dose adjustment or substitution
+
+### NSAIDs and Anti-inflammatory Medicines
+
+Ibuprofen, naproxen, and other non-steroidal anti-inflammatory drugs (NSAIDs) reduce blood flow to the kidneys and can worsen kidney function, particularly with regular use. People with known kidney disease are generally advised to avoid them, or use them only briefly and under clinical guidance. Always ask a pharmacist or clinician before using anti-inflammatory medicines regularly.
+
+### Contrast Dyes for Scans
+
+Iodinated contrast agents used in CT scans and some other imaging procedures can affect kidney function in people with CKD. Always inform the imaging team of your kidney function before any contrast procedure.
+
+### Sick Day Advice
+
+During acute illness — particularly with vomiting, diarrhoea, fever, or reduced fluid intake — some medicines (including blood pressure medicines, diuretics, and certain diabetes medicines) may need to be temporarily paused. Your clinical team can advise on a personalised sick day plan. Do not stop medicines without guidance; seek advice promptly when acutely unwell.
+
+See: [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) and [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease)
+
+---
+
+## Blood Thinners and Bleeding Risk
+
+Blood-thinning medicines — including anticoagulants and antiplatelet agents — are prescribed for important reasons such as preventing stroke in atrial fibrillation, or preventing clots after a heart attack. They require careful management.
+
+### Types of Blood-Thinning Medicine
+
+- **Direct oral anticoagulants (DOACs)** — apixaban, rivaroxaban, dabigatran, edoxaban
+- **Warfarin** — requires regular INR blood tests and dietary consistency
+- **Antiplatelets** — aspirin, clopidogrel, ticagrelor
+
+### Bleeding Risk
+
+People taking blood thinners bruise more easily. More serious bleeding — including into the gut, brain, or from cuts that are hard to stop — is a genuine risk that should be discussed with your prescriber.
+
+Signs of normal, expected bruising are different from serious bleeding. Serious bleeding requires urgent medical attention.
+
+### Interactions and Missed Doses
+
+Many medicines, supplements (including fish oil and garlic at high doses), and foods (for warfarin, particularly vitamin K-containing foods) can affect blood-thinning medicines. Always tell your pharmacist and clinician about everything you take.
+
+If you miss a dose of a blood-thinning medicine, do not double up — ask your pharmacist or clinician for guidance specific to your medicine.
+
+### Urgent Red Flags for Bleeding
+
+Seek emergency help for:
+
+- Heavy or uncontrollable bleeding from any site
+- Blood in urine (red or dark brown)
+- Black, tarry, or blood-streaked stools
+- Vomiting blood or material that looks like coffee grounds
+- Sudden severe headache (possible brain bleed)
+- Bruising that is rapidly spreading or unusually large
+
+See: [Atrial Fibrillation](/guides/atrial-fibrillation) and [Common Heart Medications and Their Side Effects](/guides/common-heart-medications)
+
+---
+
+## Diabetes Medicines
+
+Medicines for diabetes carry specific safety considerations, particularly around low blood sugar and changes during illness or hospital admission.
+
+### Low Blood Sugar (Hypoglycaemia)
+
+Some diabetes medicines — including insulin and certain tablet medicines (sulphonylureas such as glipizide and glibenclamide) — can cause the blood sugar to fall too low. Symptoms include shakiness, sweating, pale skin, confusion, rapid heartbeat, and weakness.
+
+Treatment involves raising blood sugar with a fast-acting carbohydrate source. If someone is unconscious or unable to swallow safely, call emergency services immediately.
+
+### Sick Days and Hospital Admissions
+
+During illness or hospital admission, blood sugar control may change significantly. Some diabetes medicines need to be paused during illness, surgery, or when eating is restricted. Your clinical team will advise — do not stop or adjust medicines without guidance.
+
+### Kidney Function and Diabetes Medicines
+
+Some diabetes medicines require dose adjustment or are not suitable at lower levels of kidney function. This is reviewed by a clinician as part of ongoing diabetes and CKD management.
+
+### Changed Eating Patterns
+
+Significant changes in food intake — during illness, after surgery, or at hospital discharge — can affect blood sugar and how diabetes medicines work. Contact your diabetes team or GP promptly if you are unwell or eating much less than usual.
+
+See: [Diabetes Hub](/guides/diabetes-hub) and [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease)
+
+---
+
+## Pain Medicines
+
+Pain medicines range from mild and well-tolerated to potent and high-risk. Understanding which type you are taking matters.
+
+### Paracetamol (Acetaminophen)
+
+Paracetamol is widely used and generally well tolerated at recommended doses. Exceeding the recommended dose — or combining paracetamol from multiple sources (such as taking a paracetamol product separately from a combined cold and flu preparation that also contains paracetamol) — carries risk of liver harm. Check labels carefully.
+
+### NSAIDs (Anti-inflammatory Medicines)
+
+Ibuprofen, naproxen, and similar medicines are effective for pain and inflammation but carry risks with regular use — including stomach ulcers and bleeding, raised blood pressure, worsening kidney function, and fluid retention. They are generally not suitable for people with kidney disease, certain heart conditions, or stomach ulcer history. Ask a pharmacist before using them regularly.
+
+### Opioid and Strong Pain Medicines
+
+Opioids (codeine, tramadol, oxycodone, morphine, hydromorphone, fentanyl) carry risks of sedation, constipation, respiratory depression (with high doses), dependence, and falls. They should be used at the lowest effective dose for the shortest appropriate time. Constipation with opioids is almost universal — a bowel management plan is standard when these medicines are prescribed.
+
+Always check with your clinician or pharmacist before combining pain medicines, and before using any pain medicines with other sedating drugs or alcohol.
+
+---
+
+## Antibiotics and Short-Term Medicines
+
+### Completing a Course
+
+If you are prescribed a course of antibiotics, complete it as directed — even if you feel better before it is finished. Stopping early can allow the infection to recur and contribute to antibiotic resistance.
+
+### Side Effects
+
+Antibiotics can cause nausea, stomach upset, diarrhoea, and occasionally allergic reactions. Thrush (oral or vaginal) is common after antibiotics because they affect the normal bacterial environment. Some antibiotics interact significantly with other medicines, including warfarin.
+
+### When to Call Back
+
+Contact your clinician if symptoms are not improving as expected, if you develop a rash or any sign of an allergic reaction, or if you develop diarrhoea that is severe or contains blood or mucus.
+
+---
+
+## Supplements and Herbal Products
+
+Natural does not mean safe when combined with prescribed medicines.
+
+### Known Interactions
+
+Several supplements interact with prescribed medicines:
+
+- **St John's Wort** — interacts with many medicines including antidepressants, contraceptives, anticoagulants, and HIV medicines
+- **Fish oil and garlic** at high doses — may increase bleeding risk when combined with blood thinners
+- **Ginkgo biloba** — potential interactions with anticoagulants and antiplatelets
+- **Valerian and kava** — sedating effects that combine with other sedating medicines
+- **Vitamin K** (in high-dose supplements or fortified foods) — affects warfarin's activity
+
+### Always Disclose
+
+Tell every clinician and pharmacist about all supplements and herbal products you take. This includes products described as "natural", "traditional", or "complementary". They can interact with prescribed medicines in ways that are not always obvious from the labels.
+
+---
+
+## Medication Safety for Dementia or Carer Support
+
+When a person has dementia or significant cognitive difficulties, medicine management requires additional planning.
+
+### Practical Safety Tools
+
+- **Blister packs / dose administration aids** — pharmacists can pack medicines into labelled blister packs organised by day and time, reducing the risk of missed or double doses
+- **Pharmacy packing services** — available through most community pharmacies; discuss this with your regular pharmacist
+- **Alarms and reminders** — phone alarms, smart dispensing devices, or written charts can prompt medicine taking
+- **Locked storage** — where there is a risk of accidental overdose, double-dosing, or medicine being taken by a child, secure storage is an important safety measure
+- **Carer communication** — when multiple people help with medicines, a clear written plan and regular communication prevents errors
+
+### Medicines Review for People with Dementia
+
+Some medicines carry specific risks for people with dementia — including sedatives, antipsychotics, anticholinergic medicines (found in some bladder, allergy, and stomach preparations), and antihistamines. A pharmacist medicines review can identify these and suggest safer alternatives where possible.
+
+Do not stop or change medicines without speaking to the treating clinician.
+
+See: [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
+
+---
+
+## What to Ask a Pharmacist or Clinician
+
+These questions help you get the most useful information from any medicine-related appointment:
+
+1. What is this medicine for?
+2. What has changed from my previous medicines, and why?
+3. What should I not take with it?
+4. What side effects should I watch for, and when do they need attention?
+5. What monitoring does this medicine require (blood tests, blood pressure, etc.)?
+6. What should I do if I miss a dose?
+7. When should this medicine be reviewed or stopped?
+8. Can I take this medicine with my other medicines, supplements, and over-the-counter products?
+9. Does this medicine affect my kidneys or require dose adjustment?
+10. Are there any medicines I should avoid while taking this?
+
+Pharmacists are accessible, highly trained medicines experts. You do not need a referral to speak with a community pharmacist, and a Home Medicines Review (in Australia) or Structured Medication Review (in the UK) can be arranged through your GP to provide a comprehensive assessment at home.
+
+---
+
+## When to Seek Urgent Help
+
+Seek emergency care if you or someone in your care develops:
+
+- **Difficulty breathing, throat tightening, or severe swelling of the face, lips, or tongue** — possible severe allergic reaction (anaphylaxis)
+- **Severe or rapidly spreading rash** — particularly if associated with fever or mouth involvement
+- **Fainting or collapse**
+- **Chest pain**
+- **Severe or uncontrollable bleeding** — including from the gut (black stools, vomiting blood), urinary tract, or other sites
+- **Sudden severe headache** — particularly if on blood thinners
+- **Confusion, severe drowsiness, or inability to stay awake** — particularly after a dose change or new medicine
+- **Seizure**
+- **Signs of severe low blood sugar** — shaking, sweating, pale skin, rapid heartbeat, confusion, loss of consciousness
+- **Accidental overdose** — contact emergency services or a poisons information line immediately
+- **A child or pet who has swallowed medicines** — contact emergency services or a poisons information line immediately
+
+If in doubt, do not wait — contact emergency services, a nurse advice line (healthdirect 1800 022 222 in Australia, 111 in the UK), or go to the nearest emergency department.
+
+---
+
+## FAQ
+
+**What is medication safety?**
+Medication safety means using medicines in a way that reduces the risk of errors, side effects, interactions, duplicate treatment, missed doses, or unsafe changes. It involves keeping an accurate medicine list, asking the right questions, and knowing when to seek help.
+
+**Why is a medicine list important?**
+An up-to-date medicine list helps clinicians and pharmacists check what you take, what has changed, and whether any medicines may interact or duplicate each other. It is especially important at hospital discharge, emergency presentations, and new appointments.
+
+**Should I stop a medicine if I think it is causing side effects?**
+Do not stop or change prescribed medicines without medical or pharmacist advice unless you have been explicitly told to do so. Some medicines need careful tapering or review before stopping. Discuss concerns with your clinician or pharmacist first.
+
+**Why does kidney function matter for medicines?**
+Some medicines are processed through the kidneys or can damage them. If kidney function is reduced, medicines may accumulate, and doses or choices may need adjustment. This is particularly important in chronic kidney disease and during acute illness.
+
+**When should I seek urgent help for a medicine problem?**
+Seek urgent help for difficulty breathing, swelling of the face or throat, severe rash, fainting, chest pain, severe or uncontrollable bleeding, confusion, severe drowsiness, signs of severe low blood sugar, accidental overdose, or if a child has swallowed medicines.
+
+---
+
+## Further Reading
+
+- **NPS MedicineWise — Medicines information** (Australia): practical, independent information on medicines for consumers — [www.nps.org.au](https://www.nps.org.au/consumers)
+- **Healthdirect Australia — Medicines and your health**: overview of medicines safety for Australian consumers — [www.healthdirect.gov.au](https://www.healthdirect.gov.au/medicines)
+- **MedlinePlus — Medicines**: plain-language medicines information from the US National Library of Medicine — [medlineplus.gov](https://medlineplus.gov/medicines.html)
+- **NHS — Medicines A to Z**: information on specific medicines and how to use them safely — [www.nhs.uk/medicines](https://www.nhs.uk/medicines/)
+- **AHRQ — Medication Safety**: resources on preventing medication errors and improving medication use — [www.ahrq.gov](https://www.ahrq.gov/patient-safety/settings/hospital/medication/index.html)
+- **FDA — Medication Safety** (US): patient resources on safe medicine use, drug interactions, and disposal — [www.fda.gov](https://www.fda.gov/drugs/resources-drugs/consumers-drugs)
+
+---
+
+## Related Guides
+
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — the highest-risk transition for medicine changes; what to check before going home
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — medicines and falls; medication review after a fall
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — polypharmacy and frailty; medication review as part of frailty management
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — dose administration aids, blister packs, and medicines that carry specific risks in dementia
+- [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — how kidney disease affects medicine safety
+- [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease) — NSAIDs, contrast, sick day rules, and medication review in CKD
+- [Heart & Circulation Hub](/guides/heart-circulation) — blood thinners, blood pressure medicines, and heart medicines
+- [Common Heart Medications and Their Side Effects](/guides/common-heart-medications) — plain-language guide to statins, ACE inhibitors, beta-blockers, anticoagulants, and more
+- [Atrial Fibrillation](/guides/atrial-fibrillation) — anticoagulation in AF; stroke prevention and bleeding risk
+- [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — blood pressure medicines, monitoring, and side effects
+- [Diabetes Hub](/guides/diabetes-hub) — diabetes medicines, hypoglycaemia, sick days, and CKD
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — medication review in advanced illness; symptom medicines and simplifying regimens
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — medicines review as part of preventive health
+
+---
+
+*This content is for educational purposes only and is not a substitute for professional medical advice. Do not start, stop, or change medicines without speaking with your clinician or pharmacist. For urgent medicine problems, seek emergency care immediately.*

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -98,7 +98,7 @@ Palliative care teams are multidisciplinary — they bring together doctors, nur
 Expert assessment and management of physical symptoms including pain, breathlessness, nausea, fatigue, and confusion. Palliative care specialists are trained in complex symptom management and have access to a wide range of medications and techniques that may not be available in other settings.
 
 ### Medication Review
-Reviewing existing medications to simplify regimens, reduce side effects, stop medications that are no longer beneficial, and add or adjust medications for symptom control.
+Reviewing existing medications to simplify regimens, reduce side effects, stop medications that are no longer beneficial, and add or adjust medications for symptom control. For a broader patient-facing overview of medication safety in serious illness, see [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety).
 
 ### Emotional Support
 Addressing anxiety, depression, fear, grief, and existential distress. Palliative care teams acknowledge the psychological impact of serious illness on patients and families. Referral to psychologists or counsellors may be part of care.
@@ -326,6 +326,7 @@ Palliative care is a broad approach to symptom management and support across any
 - [Shortness of Breath — When to Seek Urgent Help](/guides/shortness-of-breath)
 - [Voluntary Assisted Dying — Guide Hub](/guides/voluntary-assisted-dying)
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — planning for safe discharge; carer support, medicines, follow-up, and when home may not be safe
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — medication review in serious illness; simplifying regimens, symptom medicines, and polypharmacy
 
 ---
 

--- a/src/content/guides/type-2-diabetes.mdx
+++ b/src/content/guides/type-2-diabetes.mdx
@@ -225,3 +225,4 @@ A: This varies by individual circumstances, but most guidelines recommend HbA1c 
 - [Prediabetes: Early Warning Signs and Prevention](/guides/prediabetes)
 - [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — diabetes is the leading cause of CKD; regular kidney monitoring is part of diabetes care
 - [Metabolic Syndrome](/guides/metabolic-syndrome)
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — hypoglycaemia risk, sick day advice, kidney function and diabetes medicines, and polypharmacy


### PR DESCRIPTION
## Summary

* Adds a patient-facing medication safety guide (`/guides/medication-safety/`) covering medicine lists, side effects, duplicate medicines, hospital discharge changes, kidney function, falls risk, blood thinners, diabetes medicines, supplements, and urgent red flags
* Wires medication safety into 14 existing guides across the discharge planning, frailty/falls/aging, dementia caregiving, CKD, heart, diabetes, and palliative care clusters
* Preventive Screening Hub skipped (no existing medication safety content — adding would be noise)

## Checks

* `npm run content:check` — 0 errors, 13 warnings (unchanged baseline)
* `npm run build` — passes, 762 pages, route `/guides/medication-safety/` confirmed