### PR TITLE
feat(mental-health): add caregiver burnout guide

### DIFF
--- a/src/content/guides/aging-longevity-hub.md
+++ b/src/content/guides/aging-longevity-hub.md
@@ -165,6 +165,7 @@ Key areas include movement, strength, nutrition, sleep, social connection, medic
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy, medicines and falls, and medication review
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — recognising and managing burnout in carers of older adults; respite, support planning, and urgent red flags
 
 ---
 

--- a/src/content/guides/anxiety.md
+++ b/src/content/guides/anxiety.md
@@ -142,3 +142,4 @@ A: No. SSRIs and SNRIs may take 4–6 weeks to show full effect.
 - [Depression: Symptoms, Causes, and Treatment](/guides/depression)  
 - [Suicide Prevention and Support](/guides/suicide-prevention)  
 - [Global Mental Health](/guides/global-mental-health)  
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — anxiety in carers; recognising burnout and accessing mental health support  

--- a/src/content/guides/caregiver-burnout.md
+++ b/src/content/guides/caregiver-burnout.md
@@ -1,0 +1,363 @@
+---
+title: "Caregiver Burnout: Signs, Support, and When to Ask for Help"
+description: "A supportive guide to caregiver burnout and carer stress, including warning signs, emotional strain, respite, support planning, unsafe care situations, and when to seek urgent help."
+category: "Mental Health"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - caregiver burnout
+  - carer stress
+  - mental health
+  - dementia care
+  - palliative care
+faq:
+  - question: "What is caregiver burnout?"
+    answer: "Caregiver burnout is a state of emotional, physical, and mental exhaustion that can happen when caring demands exceed the support, rest, and resources available."
+  - question: "Does caregiver burnout mean I have failed?"
+    answer: "No. Burnout is not a personal failure. It is often a sign that the care situation needs more support, rest, planning, or professional input."
+  - question: "What are signs of caregiver burnout?"
+    answer: "Signs can include exhaustion, irritability, poor sleep, anxiety, low mood, resentment, social withdrawal, difficulty concentrating, neglecting your own health, or feeling unable to continue."
+  - question: "What can help caregiver burnout?"
+    answer: "Helpful steps can include respite, sharing tasks, medical review, counselling, support groups, practical services, safer routines, and asking for help before crisis point."
+  - question: "When should a caregiver seek urgent help?"
+    answer: "Seek urgent help if you feel unsafe, the person you care for is unsafe, you may harm yourself or someone else, there is abuse, severe neglect, sudden confusion, violence, or you cannot continue safely."
+---
+
+## Introduction
+
+Caring for a family member or loved one is meaningful, demanding, and often invisible work. It can also be exhausting — and when care demands consistently exceed the rest, support, and resources available, burnout is a predictable result.
+
+Caregiver burnout is not a sign of weakness or failure. It is a recognised consequence of sustained, intensive caregiving — and it has real consequences for both the carer and the person they are supporting. Recognising it early and seeking help before crisis point is one of the most important things a carer can do.
+
+This guide is for anyone supporting a person with a serious illness, age-related condition, or complex care needs — whether that is a partner, parent, sibling, child, or friend. It covers the signs of burnout, emotional strain, practical overload, when a care situation may be becoming unsafe, and how to ask for help.
+
+---
+
+## Key Points
+
+- Caregiver burnout is physical, emotional, and mental exhaustion caused by sustained caring demands without adequate support
+- Burnout is not a personal failure — it is a sign that more support, rest, or planning is needed
+- Warning signs include exhaustion, irritability, low mood, social withdrawal, and neglecting your own health
+- Asking for help early is more effective — and safer — than waiting until crisis point
+- Respite care, family task-sharing, support groups, and GP review are all important steps
+- Some care situations may become unsafe — for the carer, the person being cared for, or both — and need urgent review
+- Your wellbeing matters not only for yourself, but for the quality and safety of the care you provide
+
+---
+
+## What Caregiver Burnout Is
+
+Caregiver burnout describes a state of deep exhaustion — physical, emotional, and mental — that develops when the demands of caregiving consistently outstrip the support, rest, and resources available.
+
+It is not depression, though the two often overlap. It is not a sign of insufficient love or commitment. It is a predictable consequence of providing intensive care over an extended period — often without adequate help, breaks, or acknowledgement.
+
+Burnout can develop gradually. Many carers push through early warning signs without recognising them as significant. By the time burnout is acute, it can affect not only the carer's health, but the quality and safety of care they are able to provide.
+
+---
+
+## Burnout Is Not Failure
+
+Many carers feel guilty for struggling. They compare themselves to an ideal of selfless, unlimited care — and conclude that any difficulty reflects a personal shortcoming.
+
+This is not true, and it is important to say so plainly.
+
+Burnout does not mean you love the person less. It does not mean you are unsuited to caring. It means that the care situation — which is often objectively demanding — needs more support than one person can sustainably provide alone. Recognising this is not failure; it is honesty, and it is the first step toward getting the help both you and the person you care for need.
+
+---
+
+## Why Caregiving Becomes Overwhelming
+
+Many caregiving situations involve multiple overlapping demands, each manageable on its own but collectively exhausting.
+
+**Dementia** places unique demands on carers — including 24-hour supervision, managing behavioural changes, and navigating wandering or aggression, all while the relationship changes in profound ways. See: [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
+
+**Stroke recovery** requires intensive support across physical, communication, and emotional domains. Rehabilitation appointments, mobility assistance, and adapting to changed roles within a household can all weigh heavily on carers. See: [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation)
+
+**Frailty and falls risk** mean that carers are often in a constant state of vigilance — monitoring for falls, managing limited mobility, and coordinating a wide range of services. See: [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) · [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+**Palliative and end-of-life care** involves supporting someone through deteriorating health, managing complex symptoms, and anticipating loss — while maintaining practical care and managing family dynamics. See: [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+
+**Hospital discharge** often transfers significant care responsibilities to families and carers at short notice, sometimes without adequate training or support. See: [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery)
+
+**Medication management** — particularly when a person takes multiple medicines or has complex dosing needs — adds cognitive load and responsibility. See: [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety)
+
+Other common contributors include:
+
+- **Disrupted sleep** — night-time supervision, responding to distress, or simply worrying
+- **Financial and employment strain** — reduced work hours, lost income, or the cost of care
+- **Family conflict** — disagreements about care responsibilities or decisions
+- **Social isolation** — fewer opportunities to maintain friendships and relationships outside caregiving
+- **Lack of respite** — no regular breaks, or no plan for what happens when the carer needs rest
+
+---
+
+## Signs of Caregiver Burnout
+
+Signs of burnout can be physical, emotional, and behavioural. Many carers recognise some of these but attribute them to the circumstances rather than to their own need for support.
+
+**Physical signs:**
+- Persistent exhaustion that rest does not relieve
+- Poor sleep — difficulty falling asleep, staying asleep, or feeling unrefreshed
+- Frequent illness — the immune system is affected by chronic stress
+- Neglecting your own medical appointments, meals, or basic self-care
+
+**Emotional signs:**
+- Persistent low mood or sadness
+- Anxiety, dread, or a sense of being constantly on edge
+- Feeling trapped, resentful, or without hope
+- Guilt about feeling resentful
+- Emotional numbness — going through the motions without feeling present
+- Anger or irritability that is disproportionate or unexpected
+
+**Behavioural signs:**
+- Withdrawing from friends, family, and activities that used to bring satisfaction
+- Difficulty concentrating or making decisions
+- Increased use of alcohol or other substances to cope
+- Becoming impatient or short-tempered with the person you are caring for
+- Feeling unable to continue — but not knowing what else to do
+
+If several of these apply, it is time to speak with a GP or trusted clinician — not because you have failed, but because you need and deserve support.
+
+---
+
+## Emotional Strain
+
+The emotional experience of caregiving is complex and often conflicting. Many carers feel profound love and commitment alongside exhaustion, resentment, and grief — sometimes simultaneously.
+
+**Grief before loss** — caring for someone with a progressive illness often involves a series of losses: the person's independence, communication, shared plans for the future, and the relationship as it was. This anticipatory grief is real, even when the person is still alive.
+
+**Guilt** — carers frequently feel guilty: for struggling, for feeling resentful, for moments of impatience, for placing someone in care, for not doing enough. Guilt that is persistent or overwhelming warrants professional support.
+
+**Anger and resentment** — these are normal responses to a difficult situation, not evidence of bad character. Anger directed at the illness, the system, other family members, or even the person being cared for can be part of burnout and does not mean the carer is a bad person.
+
+**Loneliness** — caregiving can be profoundly isolating, even when you are rarely alone. The loss of reciprocal relationship, the inability to plan or socialise normally, and the feeling that others cannot understand your situation are all common.
+
+**Identity changes** — many carers find that their sense of self becomes absorbed by the caregiving role. Maintaining some sense of who you are outside of caring — interests, connections, goals — is both difficult and important.
+
+**Relationship changes** — caring for a partner, parent, or child changes the nature of that relationship. These changes — in roles, power, intimacy, and communication — are significant and may need professional support to navigate.
+
+---
+
+## Practical Overload
+
+Beyond emotional strain, caregiving involves a relentless accumulation of practical tasks that can feel overwhelming when carried by one person.
+
+Common practical demands include:
+
+- Attending and organising medical appointments
+- Managing medicines — dispensing, tracking, refilling, and monitoring for side effects
+- Transport to appointments and community activities
+- Preparing meals, managing nutrition, and supporting hydration
+- Assistance with personal care — bathing, dressing, toileting, and grooming
+- Supporting mobility, managing equipment, and preventing falls
+- Managing finances and administrative tasks on behalf of the person
+- Night-time supervision or attending to distress
+
+When these demands accumulate — particularly when they are ongoing without clear breaks or support — burnout is an inevitable outcome, not a character flaw.
+
+---
+
+## When the Care Situation May Be Unsafe
+
+In some circumstances, a care situation that began as manageable can gradually — or suddenly — become unsafe. Recognising this is important, and raising it with a clinician, social worker, or care coordinator is not a betrayal of the person you care for.
+
+Situations that may indicate unsafe care include:
+
+- **Repeated falls** — particularly with injury, or where supervision has not been adequate to prevent them
+- **Missed or incorrect medicines** — despite all safety measures in place
+- **Wandering or getting lost** — particularly overnight or in unsafe environments
+- **Aggression or unsafe behaviour** — that puts the carer or the person at physical risk
+- **Carer exhaustion to the point of impaired judgment** — where care decisions are affected by fatigue
+- **Inadequate food, fluids, or hygiene** — despite efforts to provide them
+- **Inability to meet basic needs** consistently — personal care, medical requirements, or safety
+- **The carer feeling at risk of losing control** — of their emotions or actions
+- **No reliable backup plan** — no clear arrangement for what happens if the carer becomes ill or incapacitated
+
+These are clinical and practical signals that require urgent review and planning — not reasons for shame. Speaking to a GP, hospital social worker, or care coordinator about options is the right response.
+
+---
+
+## What Can Help
+
+Burnout does not resolve by trying harder. What helps is reducing demand, increasing support, and ensuring both the carer and the person being cared for have their needs met.
+
+**Ask for a care needs review** — your GP or a local aged care or disability service coordinator can assess the care situation and identify what additional support may be available.
+
+**Involve your GP** — both for the person you are caring for, and for yourself. Carers are entitled to their own medical care. A GP can screen for depression and anxiety, assess physical health, provide a medical certificate if needed, and coordinate referrals.
+
+**Respite care** — formal respite provides the carer with regular planned breaks. This may be in-home respite, day programmes, or short-term residential respite stays. Accessing respite before reaching crisis point is much more effective than waiting.
+
+**Family task-sharing** — distributed caregiving is more sustainable than one person carrying everything. Naming specific tasks and responsibilities works better than open-ended offers of help. Family meetings — with or without professional facilitation — can help distribute the load.
+
+**A written care plan** — knowing what needs to happen, who is responsible, and what the backup plan is reduces the cognitive burden of constant improvisation.
+
+**Medication aids and pharmacist support** — dose administration aids, blister packs, and home medicines reviews can reduce the complexity of medicine management. See: [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety)
+
+**Home safety review** — an occupational therapist can assess the home environment and recommend changes that reduce falls risk and support safe independence. See: [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention)
+
+**Community services** — home care, personal care support, meal delivery, transport, and community nursing can all reduce the practical load on carers.
+
+**Support groups** — peer support from others who understand caregiving provides both practical knowledge and emotional validation. Dementia Australia, Carers Australia, and many condition-specific organisations offer carer helplines and support groups.
+
+**Counselling or psychological support** — a psychologist, counsellor, or social worker can provide space to process the emotional complexity of caregiving. See: [Depression](/guides/depression) · [Anxiety](/guides/anxiety)
+
+**Emergency backup plan** — having a clear plan for what happens if the carer suddenly cannot provide care (due to illness, injury, or emergency) protects the person being cared for and reduces the carer's anxiety.
+
+---
+
+## Boundaries and Asking for Help
+
+Many carers find it difficult to ask for help, accept help when offered, or acknowledge the limits of what they can sustainably provide alone.
+
+Some practical starting points:
+
+- **You do not have to do everything alone** — and attempting to is not in anyone's best interest
+- **Name specific tasks when asking for help** — "could you pick up the prescription on Thursday?" is more actionable than "let me know if you need anything"
+- **Involve other family members in concrete ways** — assign specific responsibilities rather than assuming others understand what is needed
+- **Plan regular breaks** — scheduled respite is more sustainable than ad hoc rest that never quite happens
+- **Keep your own appointments** — your health matters, and it affects your capacity to care safely
+
+Setting limits on what you can provide is not abandonment. It is honesty — and it creates the conditions for care that is safe, sustainable, and genuinely supportive.
+
+---
+
+## Caring for Someone with Dementia
+
+Dementia caregiving has specific challenges that make burnout particularly common.
+
+Behavioural and psychological symptoms of dementia — including agitation, wandering, sleep disruption, and aggression — are among the most exhausting aspects of care. These symptoms often worsen at night or in the evening, disrupting the carer's sleep over extended periods.
+
+As dementia progresses, the demands of care increase while the relationship becomes more difficult to sustain in the ways it previously was. The person may not be able to acknowledge care, express gratitude, or participate in reciprocal connection.
+
+Strategies that can help include:
+
+- Establishing consistent daily routines to reduce confusion and anxiety
+- Using clear, simple communication adapted to the person's current capacity
+- Planning for wandering risk — including door alarms, identification, and informing neighbours
+- Seeking early assessment and planning — rather than waiting for a crisis to force decisions
+
+Carers of people with dementia are particularly encouraged to access specialist dementia carer support. See: [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving)
+
+---
+
+## Caring After Hospital Discharge or Stroke
+
+Hospital discharge often places sudden and significant new responsibilities on carers — sometimes with little preparation or training. Medicines may have changed. Equipment may be new. The person may have reduced function or altered cognition compared to before admission.
+
+In stroke recovery specifically, carers may be supporting someone through rehabilitation appointments, mobility difficulties, speech or communication changes, and emotional adjustment — all while managing their own anxiety about another stroke occurring.
+
+Common sources of carer stress in this context include:
+
+- Uncertainty about the person's recovery trajectory
+- Managing medicines, equipment, and multiple appointments
+- Adjusting to changed roles within the household or relationship
+- Falls risk and the vigilance required to manage it safely
+
+See: [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) · [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation)
+
+---
+
+## Palliative and End-of-Life Caregiving
+
+Caring for someone who is approaching the end of life involves a particular kind of emotional weight — the management of serious physical symptoms alongside the knowledge of impending loss.
+
+Palliative carers often experience:
+
+- **Anticipatory grief** — grieving losses before they fully occur
+- **Symptom burden** — distress at witnessing pain, breathlessness, or confusion
+- **Family conflict** — disagreements about treatment decisions or care goals
+- **Isolation** — the difficulty of maintaining outside connections during this time
+
+Palliative care teams can support families as well as the person who is ill. They can provide guidance on what to expect, how to care safely at home, and when to call for help. Bereavement support — before and after the death — may also be offered.
+
+If you are caring for someone at end of life, you do not have to manage this alone. See: [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
+
+---
+
+## Mental Health Red Flags
+
+While caregiver stress is common and expected, some experiences require prompt professional attention:
+
+- **Persistent low mood** lasting more than two weeks, with loss of interest and motivation
+- **Panic or severe anxiety** that interferes with daily functioning
+- **Hopelessness** — feeling that things will not or cannot improve
+- **Thoughts of harming yourself**
+- **Thoughts of harming the person you care for** — these must be disclosed to a clinician
+- **Feeling unsafe** in the care situation
+- **Substance misuse** — increasing use of alcohol or other substances to cope
+
+These are not signs of weakness or bad character. They are signs that you need more support than you currently have, and that professional help is both available and appropriate.
+
+See: [Depression](/guides/depression) · [Anxiety](/guides/anxiety) · [Mental Health Hub](/guides/mental-health)
+
+---
+
+## When to Seek Urgent Help
+
+Contact your GP urgently, call a mental health crisis line, or go to an emergency department if:
+
+- You feel you may harm yourself or someone else
+- The person you care for has been harmed or is at immediate risk of harm
+- There is violence, abuse, or severe neglect occurring
+- The person shows sudden confusion, delirium, or a dramatic change in cognition — this is a medical emergency requiring same-day assessment
+- There has been a fall with serious injury
+- The person is unsafe and cannot be managed at home
+- You feel you cannot continue safely, even for the next few hours
+
+**In an emergency:** call 000 (Australia), 999 (UK), or 911 (US), or go immediately to the nearest emergency department.
+
+**For mental health crisis support:**
+- Australia: Lifeline 13 11 14 · Beyond Blue 1300 22 4636 · Carer Gateway 1800 422 737
+- UK: Samaritans 116 123 · Carers UK 0808 808 7777
+- US: 988 Suicide and Crisis Lifeline (call or text 988)
+
+---
+
+## FAQ
+
+**What is caregiver burnout?**
+Caregiver burnout is a state of emotional, physical, and mental exhaustion that can happen when caring demands exceed the support, rest, and resources available. It is not weakness — it is a predictable consequence of sustained intensive care without adequate support.
+
+**Does caregiver burnout mean I have failed?**
+No. Burnout is not a personal failure. It is often a sign that the care situation needs more support, rest, planning, or professional input. Many carers who are deeply committed to the person they care for still experience burnout.
+
+**What are signs of caregiver burnout?**
+Signs can include exhaustion, irritability, poor sleep, anxiety, low mood, resentment, social withdrawal, difficulty concentrating, neglecting your own health, or feeling unable to continue. If several of these apply, speak with your GP.
+
+**What can help caregiver burnout?**
+Helpful steps can include respite, sharing tasks, medical review, counselling, support groups, practical services, safer routines, and asking for help before crisis point. A GP is a good starting point for coordinating support.
+
+**When should a caregiver seek urgent help?**
+Seek urgent help if you feel unsafe, the person you care for is unsafe, you may harm yourself or someone else, there is abuse, severe neglect, sudden confusion, violence, or you cannot continue safely.
+
+---
+
+## Further Reading
+
+- [Dementia Australia — Carer Resources](https://www.dementia.org.au/support/carers) — practical support, helplines, and community resources for Australian dementia carers
+- [Carer Gateway (Australian Government)](https://www.carergateway.gov.au/) — services, planning tools, and support for Australian carers
+- [Alzheimer's Association — Caregiver Stress and Burnout](https://www.alz.org/help-support/caregiving/caregiver-health/caregiver-stress) — resources on recognising and managing caregiver stress
+- [Family Caregiver Alliance — Caregiver Health](https://www.caregiver.org/resource/caregiver-health/) — evidence-based guidance on carer wellbeing, respite, and support strategies
+- [National Institute on Aging — Caring for a Person with Alzheimer's](https://www.nia.nih.gov/health/caregiving/caring-person-alzheimers-disease) — practical guidance on caregiving for cognitive impairment
+- [NHS — Carer Support and Carer's Assessment](https://www.nhs.uk/conditions/social-care-and-support-guide/support-and-benefits-for-carers/) — UK guidance on carer entitlements, assessments, and local support services
+
+---
+
+## Related Guides
+
+- [Dementia Caregiving: Safety, Support, and Planning](/guides/dementia-caregiving) — comprehensive guidance on dementia care, home safety, and carer support
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — managing the transition home after hospital; carer responsibilities, medicines, and when to seek help
+- [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — palliative care for families and carers; end-of-life support and bereavement
+- [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation) — carer support and role changes in stroke recovery
+- [Frailty: What It Means and How to Reduce Risk](/guides/frailty-overview) — frailty, carer strain, and support planning
+- [Falls Prevention: How to Reduce Fall Risk](/guides/falls-prevention) — managing falls risk at home; relevant to carer safety planning
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — medicine management for carers; dose aids, pharmacist review, and high-risk medicines
+- [Aging and Longevity Hub](/guides/aging-longevity-hub) — broader context for healthy aging and later-life planning
+- [Depression](/guides/depression) — depression in carers; symptoms, treatment, and seeking help
+- [Anxiety](/guides/anxiety) — anxiety in carers; symptoms, treatment, and when to seek help
+- [Mental Health Hub](/guides/mental-health) — mental health support resources and crisis lines
+
+---
+
+*Educational only — not a substitute for professional medical advice. If you or the person you care for is in immediate danger, call emergency services or go to the nearest emergency department. For mental health crisis support, contact a crisis line in your country.*

--- a/src/content/guides/dementia-caregiving.md
+++ b/src/content/guides/dementia-caregiving.md
@@ -313,7 +313,7 @@ If any of these apply, speak with a GP as soon as possible — not when things b
 
 **Crisis planning** — knowing what to do if you are suddenly unable to care (due to illness, injury, or emotional breakdown) protects the person with dementia and reduces the carer's anxiety. Discuss an emergency care plan with the care team before it is needed.
 
-See: [Depression](/guides/depression) · [Anxiety](/guides/anxiety)
+See: [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) · [Depression](/guides/depression) · [Anxiety](/guides/anxiety)
 
 ---
 
@@ -431,6 +431,7 @@ Seek urgent help for sudden confusion, stroke-like symptoms, falls with injury, 
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — managing the transition home after hospital admission; delirium, medicines, carer planning, and when to seek help
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — dose administration aids, blister packs, polypharmacy, and medicines that carry specific risks in dementia
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — recognising and managing burnout in dementia caregiving; respite, support planning, and when to seek help
 
 ---
 

--- a/src/content/guides/depression.md
+++ b/src/content/guides/depression.md
@@ -159,3 +159,4 @@ A: Yes. Exercise, sleep, and nutrition aren’t cures on their own, but they str
 - [Anxiety Disorders](/guides/anxiety)  
 - [Suicide Prevention and Support](/guides/suicide-prevention)  
 - [Global Mental Health](/guides/global-mental-health)  
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — depression in carers; mental health support for people providing sustained care  

--- a/src/content/guides/falls-prevention.md
+++ b/src/content/guides/falls-prevention.md
@@ -309,6 +309,7 @@ Useful steps include improving lighting, removing loose rugs, installing handrai
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based health checks including bone density and vision
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — falls risk is elevated after any hospital admission; deconditioning, medication changes, and home hazards after discharge
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — medicines that raise fall risk, medication review, and polypharmacy
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — carer strain related to falls risk management and home safety planning
 
 ---
 

--- a/src/content/guides/frailty-overview.md
+++ b/src/content/guides/frailty-overview.md
@@ -234,7 +234,7 @@ Speak with a clinician if you or someone you care for:
 - Is struggling with daily tasks that were previously manageable
 - Is recovering slowly after illness or surgery
 - Is taking many medicines and seems more tired or unsteady than before
-- Is a carer who is struggling to provide safe support
+- Is a carer who is struggling to provide safe support — see also [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout)
 
 Early review — by a GP, geriatrician, or a multidisciplinary team — gives the best chance of identifying reversible causes and implementing changes before frailty becomes entrenched.
 
@@ -285,6 +285,7 @@ A GP or primary care clinician, geriatrician, physiotherapist, dietitian, pharma
 - [Heart and Circulation Hub](/guides/heart-circulation) — cardiovascular disease and frailty
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — hospital discharge as a high-risk transition; deconditioning, medicines, falls risk, and when home may not be safe
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — polypharmacy and frailty; medicines that increase falls risk; medication review
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — carer strain in frailty caregiving; recognising burnout and accessing support
 
 ---
 

--- a/src/content/guides/hospital-discharge-recovery.md
+++ b/src/content/guides/hospital-discharge-recovery.md
@@ -298,7 +298,7 @@ Hospital discharge does not just affect the patient — it places real demands o
 
 ### Carer Wellbeing and Respite
 
-Caring is demanding. Carer strain — burnout, exhaustion, anxiety, and social isolation — is a genuine health risk. Carers should be honest with themselves and with health providers about what they can manage. Respite services, community support programmes, and carer support organisations exist for this reason.
+Caring is demanding. Carer strain — burnout, exhaustion, anxiety, and social isolation — is a genuine health risk. Carers should be honest with themselves and with health providers about what they can manage. Respite services, community support programmes, and carer support organisations exist for this reason. For more on recognising and managing carer strain, see [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout).
 
 ---
 
@@ -382,6 +382,7 @@ The following are neutral, reputable sources of information on hospital discharg
 - [Sarcopenia](/guides/sarcopenia)
 - [Stroke Recovery and Rehabilitation](/guides/stroke-recovery-rehabilitation)
 - [Dementia Caregiving](/guides/dementia-caregiving)
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — carer strain after hospital discharge; respite, support planning, and when a care situation may be unsafe
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care)
 - [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub)
 - [Managing Chronic Kidney Disease](/guides/managing-chronic-kidney-disease)

--- a/src/content/guides/medication-safety.md
+++ b/src/content/guides/medication-safety.md
@@ -455,6 +455,7 @@ Seek urgent help for difficulty breathing, swelling of the face or throat, sever
 - [Diabetes Hub](/guides/diabetes-hub) — diabetes medicines, hypoglycaemia, sick days, and CKD
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — medication review in advanced illness; symptom medicines and simplifying regimens
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — medicines review as part of preventive health
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — medication management as a source of carer stress; respite and support planning
 
 ---
 

--- a/src/content/guides/mental-health.md
+++ b/src/content/guides/mental-health.md
@@ -171,6 +171,7 @@ If someone is in immediate danger of harming themselves or others, call emergenc
 ---
 
 ## Related Guides
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — mental health support for carers; burnout, depression, anxiety, respite, and urgent red flags
 - [Shared Genetics in Psychiatric Disorders](/guides/shared-genetics-psychiatric-disorders) — the biological overlap between depression, anxiety, and other conditions.
 - [Sleep and Mental Health](/guides/sleep) — poor sleep and mental illness are bidirectionally linked; sleep is a first-line modifiable factor.
 - [Smoking Cessation](/guides/smoking-cessation) — smoking rates are substantially higher in people with mental illness; quitting improves outcomes.

--- a/src/content/guides/palliative-care.md
+++ b/src/content/guides/palliative-care.md
@@ -212,7 +212,7 @@ Family support may include:
 - Financial and legal information (social workers can assist with benefits and entitlements)
 - Communication support — helping family members talk to each other and to the care team
 
-Carers of people with serious illness have high rates of [depression](/guides/depression), [anxiety](/guides/anxiety), physical exhaustion, and social isolation. Their wellbeing matters both for their own sake and for the sustainability of care at home.
+Carers of people with serious illness have high rates of [depression](/guides/depression), [anxiety](/guides/anxiety), physical exhaustion, and social isolation. Their wellbeing matters both for their own sake and for the sustainability of care at home. For a dedicated guide to recognising and managing carer strain, see [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout).
 
 Bereavement support — before and after the death of a loved one — is often offered by palliative care teams and connected hospice services.
 
@@ -327,6 +327,7 @@ Palliative care is a broad approach to symptom management and support across any
 - [Voluntary Assisted Dying — Guide Hub](/guides/voluntary-assisted-dying)
 - [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — planning for safe discharge; carer support, medicines, follow-up, and when home may not be safe
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — medication review in serious illness; simplifying regimens, symptom medicines, and polypharmacy
+- [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — carer strain in palliative caregiving; emotional support, respite, and urgent red flags
 
 ---
 

--- a/src/content/guides/stroke-recovery-rehabilitation.md
+++ b/src/content/guides/stroke-recovery-rehabilitation.md
@@ -315,7 +315,7 @@ Stroke may fundamentally change the roles within a household or relationship. A 
 
 ### Caregiver Burnout
 
-Caregiver burnout is real and common. Signs include persistent exhaustion, emotional withdrawal, feeling overwhelmed, resentment, depression, and neglect of personal health. Burnout is not a personal failing — it is a predictable consequence of sustained high-level caregiving without adequate support.
+Caregiver burnout is real and common. Signs include persistent exhaustion, emotional withdrawal, feeling overwhelmed, resentment, depression, and neglect of personal health. Burnout is not a personal failing — it is a predictable consequence of sustained high-level caregiving without adequate support. See: [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout)
 
 Carers should be encouraged to:
 - Accept help from others


### PR DESCRIPTION
## Summary

* Adds a supportive caregiver burnout / carer stress guide (`src/content/guides/caregiver-burnout.md`) — category: Mental Health
* Covers signs of burnout, emotional strain, practical overload, unsafe care situations, respite, support planning, and urgent red flags
* Wires caregiver support into dementia care, discharge planning, palliative care, stroke recovery, frailty, falls, medication safety, and mental health clusters

## Files changed

| File | Change |
|---|---|
| `src/content/guides/caregiver-burnout.md` | New guide |
| `src/content/guides/dementia-caregiving.md` | Link added in Carer Stress & Burnout section + Related Guides |
| `src/content/guides/hospital-discharge-recovery.md` | Link added in Carer Wellbeing & Respite section + Related Guides |
| `src/content/guides/palliative-care.md` | Link added in Family and Carer Support section + Related Guides |
| `src/content/guides/stroke-recovery-rehabilitation.md` | Link added in Caregiver Burnout section |
| `src/content/guides/frailty-overview.md` | Link added in When to Seek Help section + Related Guides |
| `src/content/guides/falls-prevention.md` | Link added to Related Guides |
| `src/content/guides/aging-longevity-hub.md` | Link added to Related Guides |
| `src/content/guides/medication-safety.md` | Link added to Related Guides |
| `src/content/guides/depression.md` | Link added to Related Guides |
| `src/content/guides/anxiety.md` | Link added to Related Guides |
| `src/content/guides/mental-health.md` | Link added to Related Guides |

## Checks

* `npm run content:check` — 0 errors, 13 warnings (baseline maintained)
* `npm run build` — passes, 763 pages indexed
* Route confirmed: `/guides/caregiver-burnout/`