### PR TITLE
feat(womens-health): add gestational diabetes guide

### DIFF
--- a/src/content/guides/blood-glucose-testing.md
+++ b/src/content/guides/blood-glucose-testing.md
@@ -6,7 +6,7 @@ description: >-
   results, ketone testing basics, and when to seek urgent help.
 category: "Diabetes"
 publishDate: "2025-08-19"
-updatedDate: "2026-05-14"
+updatedDate: "2026-06-11"
 draft: false
 tags:
   - blood glucose
@@ -206,7 +206,7 @@ Targets may be **less strict** for older adults, people with frequent severe
 hypoglycaemia, or those with reduced hypoglycaemia awareness.
 
 Targets are **tighter** during pregnancy (gestational or pre-existing diabetes)
-— always follow your obstetric team's guidance.
+— always follow your obstetric team's guidance. See [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) for more on pregnancy blood glucose monitoring.
 
 ### How HbA1c Relates
 
@@ -394,6 +394,7 @@ rises. Recognising your personal patterns is as important as the numbers themsel
 - [Type 1 Diabetes — An Overview](/guides/type-1-diabetes)
 - [Early Signs of Type 1 Diabetes](/guides/early-signs-type-1-diabetes)
 - [Diabetes Emergencies — Hypos, Highs, and Ketones](/guides/diabetes-emergency-actions)
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — blood glucose monitoring in pregnancy and what pregnancy-specific targets mean
 
 ---
 

--- a/src/content/guides/continuous-glucose-monitors.md
+++ b/src/content/guides/continuous-glucose-monitors.md
@@ -193,6 +193,7 @@ A: Most modern CGMs are water-resistant and can be worn while swimming, showerin
 - [Prediabetes: Early Warning Signs and Prevention](/guides/prediabetes)
 - [Testing & Screening — Guide Hub](/guides/testing-and-screening)
 - [Diabetes — Guide Hub](/guides/diabetes-hub)
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — CGM use in gestational diabetes is an evolving clinical area; discuss suitability with your care team
 
 ---
 

--- a/src/content/guides/diabetes-hub.md
+++ b/src/content/guides/diabetes-hub.md
@@ -4,7 +4,7 @@ title: "Diabetes Hub"
 slug: "diabetes-hub"
 description: "A central hub for understanding diabetes: type 1, type 2, and prediabetes — symptoms, management, prevention, and resources."
 publishDate: "2025-09-13"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 hubKey: "Diabetes"
 draft: false
 tags: ["diabetes", "type 1 diabetes", "type 2 diabetes", "prediabetes", "insulin", "management"]
@@ -102,7 +102,7 @@ Type 1 and Type 2 diabetes are often discussed as though they sit on the same sp
 | **Can it be prevented?** | No known prevention | Risk can be substantially reduced through lifestyle changes |
 | **Proportion of cases** | ~5–10% of all diabetes | ~90–95% of all diabetes |
 
-Other forms of diabetes also exist, including gestational diabetes (during pregnancy), [LADA](/guides/latent-autoimmune-diabetes) (latent autoimmune diabetes in adults, sometimes called Type 1.5), and rarer monogenic forms. Each has its own characteristics, but Type 1 and Type 2 account for the vast majority of diagnoses.
+Other forms of diabetes also exist, including [gestational diabetes](/guides/gestational-diabetes) (diabetes first recognised during pregnancy), [LADA](/guides/latent-autoimmune-diabetes) (latent autoimmune diabetes in adults, sometimes called Type 1.5), and rarer monogenic forms. Each has its own characteristics, but Type 1 and Type 2 account for the vast majority of diagnoses.
 
 ---
 
@@ -185,6 +185,12 @@ Learn more: [CGM vs Finger Prick](/guides/cgm-vs-finger-prick) | [Continuous Glu
 - [Insulin Administration](/guides/insulin-administration)
 - [Latent Autoimmune Diabetes (LADA)](/guides/latent-autoimmune-diabetes)
 - [Diabetes Hormones](/guides/diabetes-hormones)
+
+### Gestational Diabetes
+
+Gestational diabetes is diabetes first recognised during pregnancy. It arises because pregnancy hormones cause insulin resistance that the pancreas cannot fully compensate for. Blood glucose usually returns to normal after birth, but gestational diabetes significantly increases the risk of developing type 2 diabetes in the years that follow — making postpartum follow-up testing and long-term metabolic health monitoring an important part of care.
+
+- **[Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes)** — screening, risk factors, blood glucose monitoring, food and activity changes, insulin when needed, birth planning, and postpartum follow-up
 
 ### Complications
 - [Long-Term Complications of Type 1 Diabetes](/guides/type-1-diabetes-long-term-complications) — retinopathy, nephropathy, neuropathy, and cardiovascular risk: why they occur, screening, and how consistent management reduces risk.

--- a/src/content/guides/gestational-diabetes.md
+++ b/src/content/guides/gestational-diabetes.md
@@ -1,0 +1,329 @@
+---
+title: "Gestational Diabetes: Screening, Treatment, and Follow-Up"
+description: "A patient-friendly guide to gestational diabetes, including screening, risk factors, blood glucose monitoring, food and activity changes, medication or insulin when needed, birth planning, and follow-up after pregnancy."
+category: "Women's Health"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - gestational diabetes
+  - pregnancy
+  - diabetes
+  - blood glucose
+  - women's health
+faq:
+  - question: "What is gestational diabetes?"
+    answer: "Gestational diabetes is diabetes first recognised during pregnancy. It means blood glucose levels are higher than expected and need monitoring and treatment to reduce risk for the parent and baby."
+  - question: "Is gestational diabetes my fault?"
+    answer: "No. Gestational diabetes is influenced by pregnancy hormones, insulin resistance, genetics, age, metabolic health, and other factors. It is not a personal failure."
+  - question: "How is gestational diabetes diagnosed?"
+    answer: "Gestational diabetes is usually diagnosed with pregnancy glucose testing, often an oral glucose tolerance test (OGTT), based on local screening recommendations."
+  - question: "How is gestational diabetes treated?"
+    answer: "Treatment may include blood glucose monitoring, food and activity changes, pregnancy care follow-up, and sometimes medication or insulin if glucose levels remain above the target set by the care team."
+  - question: "Does gestational diabetes go away after birth?"
+    answer: "Blood glucose often improves after birth, but follow-up testing is important because gestational diabetes increases the future risk of type 2 diabetes."
+  - question: "Do I need insulin if I have gestational diabetes?"
+    answer: "Not everyone does. Many people manage gestational diabetes with food and activity changes alone. Insulin or other medication is recommended when blood glucose levels stay above the targets your care team has set despite these changes. Needing insulin is not a sign of failure."
+  - question: "Can I breastfeed with gestational diabetes?"
+    answer: "Yes. Breastfeeding is generally encouraged after a gestational diabetes pregnancy. Discuss any medication adjustments with your care team before or shortly after birth."
+---
+
+## Introduction
+
+Gestational diabetes is a form of diabetes that is first recognised during pregnancy. It means blood glucose (blood sugar) levels are higher than expected, which requires monitoring and management during the pregnancy.
+
+Being told you have gestational diabetes can feel worrying, especially in the middle of a pregnancy. But gestational diabetes is a manageable condition. With the right support — blood glucose monitoring, food and activity adjustments, and clinical care — most people with gestational diabetes have healthy pregnancies and babies.
+
+This guide explains what gestational diabetes is, why it happens, how it is screened for and diagnosed, how it is managed, and what follow-up you will need after the baby is born.
+
+---
+
+## Key Points
+
+- Gestational diabetes is diabetes first recognised during pregnancy — it is not type 1 or type 2 diabetes, though it shares some features
+- It is not caused by personal failure; pregnancy hormones, insulin resistance, genetics, and metabolic factors all play a role
+- It is usually identified through routine pregnancy glucose testing
+- Management includes blood glucose monitoring and food and activity changes; some people also need medication or insulin
+- Targets for blood glucose should be set by your care team — do not adjust management without clinical guidance
+- Blood glucose usually improves after birth, but follow-up testing is important because gestational diabetes increases future risk of type 2 diabetes
+- Most people with well-managed gestational diabetes have healthy pregnancies and babies
+
+---
+
+## What Is Gestational Diabetes?
+
+Gestational diabetes is defined as diabetes first diagnosed during pregnancy. It means the body is not producing enough insulin to keep blood glucose at the levels needed during pregnancy — a time when the body's demand for insulin is naturally higher than usual.
+
+It is distinct from type 1 and type 2 diabetes, though it shares the same fundamental feature: glucose is not being taken up from the bloodstream efficiently. In most cases, blood glucose returns to normal after birth — but gestational diabetes is a sign that the body's insulin regulation has been challenged, and that the risk of type 2 diabetes is elevated in the years that follow.
+
+Gestational diabetes is one of the most common complications of pregnancy, affecting a significant proportion of pregnancies globally. Estimates vary by country, population, and diagnostic criteria, but prevalence is rising in many regions alongside broader metabolic health trends.
+
+---
+
+## Why Does Gestational Diabetes Happen?
+
+During pregnancy, the placenta produces hormones that are essential for the baby's development. Some of these hormones — including human placental lactogen — make the body's cells less responsive to insulin. This is known as **insulin resistance**.
+
+In most pregnancies, the pancreas compensates by producing extra insulin. In gestational diabetes, the pancreas cannot keep pace with the increased demand, and blood glucose rises above the expected range.
+
+Several factors contribute:
+
+- **Pregnancy hormones** — particularly in the second and third trimesters, when placental hormone levels are highest
+- **Insulin resistance** — the body's reduced response to insulin, which is a normal feature of pregnancy but more pronounced in some people
+- **Metabolic risk** — including weight, pre-existing insulin sensitivity, and metabolic health before pregnancy
+- **Genetics** — family history of diabetes increases the risk
+- **Age** — the risk of gestational diabetes rises with increasing maternal age
+- **Placental biology** — the placenta's function and the hormonal environment of pregnancy vary between individuals
+
+Gestational diabetes is not caused by eating too much sugar. It is not a sign of negligence or insufficient effort. It is a metabolic response to the demands of pregnancy, shaped by biology and circumstance — not personal behaviour.
+
+---
+
+## Who Is at Higher Risk?
+
+Anyone can develop gestational diabetes, but some factors are associated with higher risk:
+
+- **Previous gestational diabetes** — the most significant single risk factor; the chance of recurrence is substantially higher in subsequent pregnancies
+- **Family history of diabetes** — particularly in first-degree relatives
+- **Previous large baby** — delivering a baby above a certain birth weight (macrosomia) is associated with higher gestational diabetes risk in future pregnancies
+- **Pre-existing insulin resistance or prediabetes** — or metabolic features associated with higher insulin demand
+- **PCOS (polycystic ovary syndrome)** — associated with insulin resistance; see [PCOS: Understanding Polycystic Ovary Syndrome](/guides/pcos) for more detail
+- **Higher pre-pregnancy weight** — excess visceral fat is associated with greater insulin resistance
+- **Older maternal age** — risk increases from the mid-30s onwards
+- **Certain ethnic backgrounds** — including South Asian, East Asian, Middle Eastern, Pacific Islander, and Aboriginal and Torres Strait Islander backgrounds in Australia, among others; rates of gestational diabetes vary significantly across populations
+- **Multiple pregnancy** — twins or higher-order multiples
+- **Previous unexplained pregnancy loss** — in some guidelines, this is listed as a factor warranting additional screening consideration
+
+Having one or more of these factors increases the likelihood of gestational diabetes but is not a guarantee. Gestational diabetes can also occur without any identifiable risk factors — which is why screening is offered broadly and not only to high-risk groups.
+
+---
+
+## Screening and Diagnosis
+
+### When Screening Happens
+
+Most healthcare systems recommend glucose screening during pregnancy, typically between **24 and 28 weeks** for people at average risk. This is the window when placental hormones are high enough to reveal gestational diabetes in those susceptible.
+
+People at **higher risk** may be tested earlier — sometimes in the first trimester — to identify pre-existing but previously undiagnosed diabetes, or to allow earlier intervention if gestational diabetes is detected.
+
+Screening protocols vary between countries and healthcare systems. Your midwife or obstetrician will advise you on the recommended approach in your region and clinical situation.
+
+### The Oral Glucose Tolerance Test (OGTT)
+
+The most widely used diagnostic test for gestational diabetes is the **oral glucose tolerance test (OGTT)**. This typically involves:
+
+1. Fasting overnight or for a specified number of hours before the test
+2. A fasting blood glucose measurement at the laboratory
+3. Drinking a glucose solution (the concentration and volume vary by local protocol)
+4. One or more further blood glucose measurements over the following one to two hours
+
+The results are compared against diagnostic thresholds. These thresholds vary by country and by which guideline (such as IADPSG, ADIPS, or WHO) the local health service follows. Your care team will explain what applies to you.
+
+### Understanding Your Result
+
+A positive result does not mean something has gone seriously wrong. It means glucose levels were above the threshold, and your care team will now work with you to bring blood glucose into a safe range for the remainder of the pregnancy.
+
+If the test is negative but symptoms such as excessive thirst, very frequent urination, or unusual fatigue develop, inform your care team. Repeat testing may be warranted.
+
+### Screening Is Not the Same as Diagnosis
+
+In some gestational diabetes programmes, a shorter initial screening test (such as a glucose challenge test) is used first to identify who needs the full OGTT. In other systems, the OGTT is used as the primary test directly. Your care team will explain which process applies to you.
+
+---
+
+## Monitoring Blood Glucose
+
+Once gestational diabetes is diagnosed, regular blood glucose monitoring becomes a core part of your pregnancy care. Your care team will advise on:
+
+- **When to test** — typically before meals and one to two hours after meals, though the schedule is tailored to your situation
+- **How to test** — usually with a finger-prick glucose meter; a small drop of blood is placed on a test strip and read by the device
+- **Your target range** — blood glucose targets in pregnancy are tailored to pregnancy and will be set by your care team; do not try to interpret your results without clinical guidance
+- **Keeping a log** — recording results in a diary or app helps your care team adjust your management plan over time
+
+Testing technique and what results mean are covered in more detail in [Blood Glucose Testing — How and When to Check](/guides/blood-glucose-testing).
+
+### Continuous Glucose Monitoring in Gestational Diabetes
+
+Continuous glucose monitors (CGMs) — small wearable sensors that measure glucose levels throughout the day — are used by some people with gestational diabetes, particularly those on insulin. CGM use in gestational diabetes is an area of active clinical interest, and evidence is evolving. Discuss with your care team whether a CGM is appropriate for your situation. See [Continuous Glucose Monitors](/guides/continuous-glucose-monitors) for an overview of how they work and who benefits most.
+
+---
+
+## Food and Activity Changes
+
+For many people with gestational diabetes, adjustments to eating patterns and physical activity are the first-line treatment — and for some, they are sufficient to bring blood glucose into range without medication.
+
+### Eating Patterns
+
+There is no single "gestational diabetes diet." The aim is to balance the nutritional needs of pregnancy — which are significant — with blood glucose management. Key principles:
+
+- **Regular meals and snacks** — avoiding long gaps between eating helps keep blood glucose stable
+- **Carbohydrate choices** — all carbohydrates raise blood glucose; choosing carbohydrates with more fibre and a lower glycaemic impact (wholegrains, legumes, most vegetables) generally produces a gentler glucose rise than refined carbohydrates and sugary foods
+- **Spreading carbohydrates across the day** — distributing carbohydrate intake rather than having large amounts at one sitting helps manage post-meal glucose levels
+- **Protein and fibre at each meal** — these slow glucose absorption and support satiety
+- **Adequate overall nutrition** — pregnancy has increased requirements for folate, iron, calcium, iodine, and other nutrients; dietary changes should never compromise total nutritional intake
+- **Avoiding very restrictive eating** — cutting calories or carbohydrates severely during pregnancy is not recommended and may affect fetal growth; the goal is balance, not restriction
+
+A referral to a **dietitian with experience in gestational diabetes** is strongly recommended. They can provide personalised guidance based on your glucose results, pregnancy stage, and food preferences — and help you find a pattern that is both sustainable and effective.
+
+### Physical Activity
+
+Regular physical activity helps the body use insulin more effectively. For people with gestational diabetes, even light to moderate activity — such as a short walk after meals — can help lower post-meal glucose levels.
+
+The type and intensity of activity that is appropriate depends on your overall health, any pregnancy complications, and the stage of pregnancy. Always discuss exercise changes with your obstetric care team before starting or increasing activity. Activities generally considered safe in uncomplicated pregnancies include walking, swimming, and appropriately modified strength work.
+
+---
+
+## Medication and Insulin
+
+If blood glucose remains above the targets set by your care team despite food and activity changes, medication or insulin may be recommended.
+
+### Why Some People Need Medication
+
+Not everyone's pancreas can compensate adequately for pregnancy-related insulin resistance, even with dietary and lifestyle changes. This reflects the degree of insulin resistance in that individual's pregnancy — not a failure of effort or discipline.
+
+### Insulin in Gestational Diabetes
+
+Insulin is the most commonly used and most thoroughly studied medication for gestational diabetes requiring pharmacological management. It does not cross the placenta and is considered safe in pregnancy.
+
+Insulin is given by injection (pen or syringe) and may be prescribed as a background (basal) insulin, a mealtime (bolus) insulin, or a combination, depending on your glucose pattern. For an overview of insulin types and delivery methods, see [Insulin Administration — Pens, Syringes, and Pumps](/guides/insulin-administration).
+
+Needing insulin does not mean your gestational diabetes is serious or that something has gone wrong. It means the clinical team wants to bring your blood glucose into range by the most reliable route available — and treating effectively is a positive outcome, not a negative one.
+
+### Other Medications
+
+In some health systems and clinical situations, oral medications such as metformin are used in gestational diabetes management. Your care team will discuss the available options, the current evidence, and any considerations relevant to your individual situation.
+
+Do not adjust insulin or other medication doses without guidance from your care team. For general information about medicine safety in pregnancy and beyond, see [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety).
+
+---
+
+## How Gestational Diabetes Can Affect Pregnancy
+
+Managing gestational diabetes reduces the risks associated with elevated blood glucose in pregnancy. Understanding these risks is useful — but they are not inevitable, and the goal of care is to minimise them through good management.
+
+When blood glucose is well managed, most people with gestational diabetes have healthy pregnancies and babies.
+
+### For the Baby
+
+- **Larger-than-average birth size (macrosomia)** — excess glucose in the bloodstream passes to the baby, who may grow larger than average. This can affect the mode or timing of birth and requires monitoring
+- **Low blood glucose after birth (neonatal hypoglycaemia)** — the baby's pancreas may have been producing extra insulin in response to high maternal glucose; after birth, when this glucose source stops, blood glucose can fall. Early and regular feeding, including breastfeeding, usually helps; the midwifery team will monitor the baby
+- **Jaundice** — slightly higher rates in babies of mothers with gestational diabetes; usually resolves with standard newborn management
+
+### For the Parent
+
+- **Likelihood of induction or caesarean birth** — depending on glucose control, the baby's estimated size, and other clinical factors; decisions are individualised and made with your obstetric team
+- **Pre-eclampsia** — gestational diabetes is associated with a modestly higher risk of high blood pressure in pregnancy; blood pressure monitoring is a standard part of antenatal care. For background on hypertension, see [High Blood Pressure (Hypertension)](/guides/high-blood-pressure)
+
+These outcomes are not certain. The care you receive, and the management you put in place, meaningfully affects the risk.
+
+---
+
+## Birth Planning
+
+As pregnancy progresses, your obstetric team will discuss:
+
+- **Timing of birth** — guided by glucose control, the estimated size of the baby, the wellbeing of parent and baby, and local clinical guidelines
+- **Mode of birth** — vaginal birth is the aim for most people with gestational diabetes; caesarean may be recommended if specific clinical circumstances apply
+- **Blood glucose monitoring during labour** — glucose is monitored closely during labour; insulin may be administered intravenously if needed
+- **What to do with medication on the day of birth** — your care team will advise whether to take insulin or other medication
+
+Discuss your individual situation, preferences, and questions with your midwife or obstetrician well before the due date. If you are using a birth centre or planning a particular type of birth, inform your care team so they can plan accordingly.
+
+---
+
+## After Birth
+
+### Glucose Usually Improves
+
+For most people, blood glucose returns to the normal range within days of delivery once the placenta — and its insulin-blocking hormones — has been delivered. Insulin or medication for gestational diabetes is usually stopped or significantly adjusted at birth, but always under clinical guidance. Do not change or stop medication without advice from your care team.
+
+### Baby Monitoring
+
+Newborns of mothers with gestational diabetes are monitored for low blood glucose (neonatal hypoglycaemia) in the period after birth. Feeding early and regularly — including breastfeeding if you choose to — helps maintain the baby's blood glucose. The midwifery team will check the baby's glucose levels and guide you through any monitoring that is needed.
+
+### Breastfeeding
+
+Breastfeeding is generally encouraged after a gestational diabetes pregnancy. It has metabolic benefits for both parent and baby and may reduce the baby's long-term metabolic risk. If you were on insulin or medication during pregnancy, speak with your care team before or shortly after birth about any adjustments.
+
+### Your Own Health After Birth
+
+The period after birth is demanding — caring for a newborn, recovering physically, and managing the emotional transition. Your own health matters during this time. Key steps after a gestational diabetes pregnancy include:
+
+- **Postpartum glucose testing** — see below
+- **Seeking support** if you are struggling emotionally — [Postpartum Depression: Symptoms, Risks, and Treatment](/guides/postpartum-depression) may be relevant if you are experiencing low mood, anxiety, or difficulty coping after birth
+
+---
+
+## Future Health After Gestational Diabetes
+
+Gestational diabetes is an important signal about long-term metabolic health. It does not mean you will develop type 2 diabetes — but it does mean the risk is higher than average, and that follow-up matters.
+
+### Postpartum Glucose Testing
+
+Most guidelines recommend a glucose test **4–12 weeks after birth** — typically an OGTT or fasting glucose, depending on local protocol — to confirm that blood glucose has returned to normal.
+
+Do not assume your glucose has normalised without testing. Testing is needed to exclude type 2 diabetes and to identify prediabetes, which requires ongoing monitoring and lifestyle support.
+
+### Long-Term Screening
+
+After a gestational diabetes pregnancy, periodic screening for type 2 diabetes is recommended — typically every one to three years, usually with fasting glucose or HbA1c (your care team will advise on the recommended interval).
+
+The [Diabetes Hub](/guides/diabetes-hub) and [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes) explain what to expect from diabetes monitoring if needed. [Prediabetes: Early Warning Signs and Prevention](/guides/prediabetes) covers the intermediate state where lifestyle intervention can prevent or delay progression.
+
+### Lifestyle and Metabolic Health
+
+Supporting your metabolic health after pregnancy — through sustainable dietary habits, regular physical activity, adequate sleep, and managing stress — reduces the likelihood of progressing to type 2 diabetes. These habits also support energy, mood, and long-term health more broadly.
+
+This is not about correcting a personal failure. It is about using what gestational diabetes has revealed about your body to take care of your long-term health — on your terms, with appropriate clinical support.
+
+### Future Pregnancies
+
+Gestational diabetes is likely to recur in future pregnancies. If you are planning another pregnancy, let your care team know. Early glucose testing is usually recommended, and attention to metabolic health before conception may reduce risk.
+
+---
+
+## When to Seek Urgent Help
+
+During a gestational diabetes pregnancy, seek urgent medical attention if you experience:
+
+- **Reduced or absent fetal movements** — contact your maternity unit immediately; this is always urgent
+- **Heavy vaginal bleeding**
+- **Severe abdominal pain or cramping**
+- **Severe headache, visual disturbances, or sudden swelling of the face, hands, or feet** — possible signs of pre-eclampsia; seek urgent review
+- **Feeling very unwell with nausea, vomiting, or inability to keep fluids down**
+- **Symptoms of very high blood glucose** — excessive thirst, very frequent urination, severe fatigue, blurred vision
+- **Symptoms of low blood glucose if on insulin or medication** — shakiness, sweating, confusion, or loss of consciousness
+- **Fainting, dizziness, or collapse**
+
+If you are unsure whether something needs urgent attention, contact your midwife or maternity unit. Do not wait.
+
+---
+
+## Further Reading
+
+- [NHS — Gestational Diabetes](https://www.nhs.uk/conditions/gestational-diabetes/)
+- [CDC — Gestational Diabetes](https://www.cdc.gov/diabetes/gestational/index.html)
+- [Diabetes Australia — Gestational Diabetes](https://www.diabetesaustralia.com.au/about-diabetes/gestational-diabetes/)
+- [American Diabetes Association — Gestational Diabetes](https://diabetes.org/diabetes/gestational-diabetes)
+- [ACOG — Gestational Diabetes Patient FAQ](https://www.acog.org/womens-health/faqs/gestational-diabetes)
+
+---
+
+## Related Guides
+
+- [Diabetes Hub](/guides/diabetes-hub) — central navigation for all diabetes content: type 1, type 2, prediabetes, and management
+- [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes) — gestational diabetes increases lifetime risk of type 2 diabetes; understand what this means for follow-up care
+- [Blood Glucose Testing — How and When to Check](/guides/blood-glucose-testing) — how finger-prick testing works, what results mean, and when to test
+- [Continuous Glucose Monitors](/guides/continuous-glucose-monitors) — how CGMs work and who benefits most
+- [Insulin Administration — Pens, Syringes, and Pumps](/guides/insulin-administration) — how to use insulin safely if it is prescribed during pregnancy
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — safe medicine use in pregnancy and beyond
+- [PCOS: Understanding Polycystic Ovary Syndrome](/guides/pcos) — PCOS is associated with insulin resistance and higher gestational diabetes risk
+- [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — pre-eclampsia risk is relevant to gestational diabetes management
+- [Postpartum Depression: Symptoms, Risks, and Treatment](/guides/postpartum-depression) — emotional health support after a complex pregnancy
+- [Women's Health Hub](/guides/womens-health-hub) — all women's health content on PatientGuide
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — screening programmes and follow-up testing explained
+- [Metabolic Health & Weight-Loss Medicines Hub](/guides/metabolic-health-hub) — metabolic health, insulin resistance, and long-term risk management
+
+---
+
+*Educational only; not a substitute for professional medical advice. Gestational diabetes management varies by country and clinical situation. Follow the guidance of your obstetric and diabetes care team.*

--- a/src/content/guides/insulin-administration.md
+++ b/src/content/guides/insulin-administration.md
@@ -94,6 +94,7 @@ Insulin delivery is about two things: **the insulin you use** and **how you deli
 - [Continuous Glucose Monitors (CGMs) vs Finger‑Prick Testing](/guides/cgm-vs-finger-prick)
 - [Emergency Actions — Hypos, Highs, and Ketones](/guides/diabetes-emergency-actions)
 - [Understanding HbA1c and Why It Matters](/guides/understanding-hba1c)
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — insulin is commonly used in gestational diabetes that cannot be managed with food and activity changes alone
 
 
 ## References (plain text)

--- a/src/content/guides/metabolic-health-hub.mdx
+++ b/src/content/guides/metabolic-health-hub.mdx
@@ -4,7 +4,7 @@ slug: "metabolic-health-hub"
 description: "A starting point for understanding obesity, GLP-1 weight-loss drugs like Ozempic, and how to protect long-term metabolic health."
 category: "Guide Hubs"
 publishDate: "2025-11-27"
-updatedDate: "2026-06-09"
+updatedDate: "2026-06-11"
 tags: ["metabolic health", "obesity", "glp1", "weight loss"]
 draft: false
 jsonld:
@@ -194,6 +194,7 @@ Bariatric surgery typically produces greater and more durable weight loss (25–
 - [Sleep and Mental Health](/guides/sleep) — poor sleep directly impairs insulin sensitivity and metabolic regulation.
 - [Preventive Exercise](/guides/preventive-exercise) — resistance and aerobic exercise are first-line tools for metabolic health.
 - [Aging and Longevity Basics](/guides/aging-and-longevity-basics) — metabolic health is one of the strongest determinants of healthspan.
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — gestational diabetes is a pregnancy-specific metabolic risk window; a history of gestational diabetes significantly elevates the long-term risk of type 2 diabetes and metabolic dysfunction.
 
 ## Related Hubs
 

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -214,8 +214,9 @@ Type 2 diabetes develops slowly — prediabetes often precedes it by years and i
 - [Prediabetes: Early Warning Signs and Prevention](/guides/prediabetes) — who is at risk, what the blood tests show, and how reversal works
 - [Type 2 Diabetes](/guides/type-2-diabetes) — diagnosis, management, and cardiometabolic risk
 - [Understanding HbA1c — What It Means and How to Use It](/guides/understanding-hba1c) — interpreting the most common diabetes monitoring test
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — pregnancy glucose screening, OGTT, management, and postpartum follow-up testing
 
-**Who should screen:** Adults over 40 with one or more risk factors (overweight, family history, gestational diabetes history, hypertension, or certain ethnicities with higher baseline risk). Screening uses fasting blood glucose or HbA1c.
+**Who should screen:** Adults over 40 with one or more risk factors (overweight, family history, gestational diabetes history, hypertension, or certain ethnicities with higher baseline risk). Screening uses fasting blood glucose or HbA1c. People with a history of gestational diabetes should have ongoing glucose screening after pregnancy, typically every one to three years.
 
 ---
 
@@ -289,6 +290,7 @@ Women face specific screening requirements across the reproductive years, the me
 - [Mammography and Breast Cancer Screening](/guides/mammography-breast-screening) — when to start, what results mean
 - [Bone Density and Osteoporosis: What You Need to Know](/guides/bone-density-osteoporosis) — bone loss accelerates at menopause; DXA scanning and prevention
 - [Bone Density Testing (DEXA): Who Should Be Screened and When](/guides/bone-density-testing-dexa-screening) — how DEXA works, T-score interpretation, screening eligibility, and what to do after results
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — pregnancy glucose screening (OGTT), management, and postpartum follow-up; a history of gestational diabetes is a significant risk factor for type 2 diabetes
 - [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause) — cardiovascular risk rises after menopause; prevention implications
 - [Women's Health Hub](/guides/womens-health-hub) — centralised hub for all women's health content
 

--- a/src/content/guides/type-2-diabetes.mdx
+++ b/src/content/guides/type-2-diabetes.mdx
@@ -6,7 +6,7 @@ hubKey: "diabetes-type-2"
 publishDate: "2026-02-04"
 draft: false
 tags: ["type 2 diabetes","t2d","a1c","metformin","glp-1","sglt2","insulin resistance","cardiometabolic"]
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 faq:
   - q: "What causes Type 2 diabetes?"
     a: "Type 2 diabetes develops from a combination of insulin resistance (cells becoming less responsive to insulin) and a gradual decline in the pancreas's ability to produce enough insulin. Risk factors include excess weight, inactivity, family history, age, and ethnicity."
@@ -226,3 +226,4 @@ A: This varies by individual circumstances, but most guidelines recommend HbA1c 
 - [Chronic Kidney Disease Hub](/guides/chronic-kidney-disease-hub) — diabetes is the leading cause of CKD; regular kidney monitoring is part of diabetes care
 - [Metabolic Syndrome](/guides/metabolic-syndrome)
 - [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — hypoglycaemia risk, sick day advice, kidney function and diabetes medicines, and polypharmacy
+- [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — gestational diabetes is a major risk factor for type 2 diabetes; postpartum screening and long-term monitoring are important

--- a/src/content/guides/womens-health-hub.md
+++ b/src/content/guides/womens-health-hub.md
@@ -70,6 +70,9 @@ Endometriosis — tissue similar to the uterine lining growing outside the uteru
 ### [Contraception Options](/guides/contraception-options)
 An overview of all contraceptive methods — hormonal and non-hormonal, short-acting and long-acting, reversible and permanent — with effectiveness data and considerations for different life stages.
 
+### [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes)
+Gestational diabetes is diabetes first recognised during pregnancy. It arises when pregnancy hormones cause insulin resistance the pancreas cannot fully compensate for. Management includes blood glucose monitoring, food and activity adjustments, and sometimes insulin or medication. Blood glucose usually improves after birth, but gestational diabetes significantly increases the future risk of type 2 diabetes — making postpartum follow-up testing and long-term screening an essential part of care.
+
 ---
 
 ## Screening and Prevention


### PR DESCRIPTION
## Summary

* Adds a patient-facing gestational diabetes guide covering screening (OGTT, timing, risk factors), blood glucose monitoring, food and activity changes, medication or insulin when needed, birth planning, postpartum follow-up, and future type 2 diabetes risk
* Category: Women's Health — connects the pregnancy/gestational cluster to diabetes, preventive screening, and metabolic health
* Wires gestational diabetes into six existing guides and hubs: diabetes hub, women's health hub, preventive screening hub, metabolic health hub, type-2-diabetes, blood-glucose-testing, continuous-glucose-monitors, insulin-administration

## Checks

* `npm run content:check` — 0 errors, 13 warnings (baseline unchanged)
* `npm run build` — passes, route /guides/gestational-diabetes/ confirmed generated