### PR TITLE
feat(cancer): add colorectal polyps surveillance guide

### DIFF
--- a/src/content/guides/bowel-cancer-screening.md
+++ b/src/content/guides/bowel-cancer-screening.md
@@ -179,6 +179,7 @@ A: Seek prompt medical assessment if you notice blood in your stool, a persisten
 
 ## Related Guides
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — what to expect after a positive FIT or polyps found at colonoscopy; pathology, surveillance intervals, and red flags
 - [Understanding Bowel Cancer](/guides/understanding-bowel-cancer)
 - [Bowel Cancer — Guide Hub](/guides/bowel-cancer)
 - [Living with Bowel Cancer](/guides/living-with-bowel-cancer)

--- a/src/content/guides/bowel-cancer.md
+++ b/src/content/guides/bowel-cancer.md
@@ -4,7 +4,7 @@ slug: "bowel-cancer"
 description: "Guides on risks, screening, treatment, living well, and family risk for bowel cancer."
 category: "Guide Hubs"
 publishDate: "2025-08-20"
-updatedDate: "2026-02-24"
+updatedDate: "2026-06-11"
 hubKey: "Bowel Cancer"
 draft: false
 tags: ["cancer", "bowel cancer", "patientguide", "hub"]
@@ -93,6 +93,7 @@ See also: [Emergencies — Guide Hub](/guides/emergencies) | [Severe Bleeding �
 ### Screening and Early Detection
 - [Bowel Cancer Screening — Early Detection Matters](/guides/bowel-cancer-screening) — Who needs screening, FIT test vs colonoscopy, and how to prepare.
 - [Bowel Cancer Screening Explained](/guides/bowel-cancer-screening-explained) — Plain-language guide to what happens at each stage of the screening process.
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — What polyps are found at colonoscopy, how pathology guides surveillance, and when to seek urgent help after polypectomy.
 
 ### Living Well During Treatment
 - [Living With Bowel Cancer](/guides/living-with-bowel-cancer) — Coping with side effects, maintaining activity, emotional health, and practical support.

--- a/src/content/guides/cancer.md
+++ b/src/content/guides/cancer.md
@@ -4,7 +4,7 @@ slug: "cancer"
 description: "Cancer is a group of diseases where abnormal cells grow uncontrollably and may spread. Explore guides on lung, bowel, breast, prostate, skin, cervical, liver, and other cancers."
 category: "Cancer"
 publishDate: "2025-08-20"
-updatedDate: "2026-06-08"
+updatedDate: "2026-06-11"
 hubKey: "Cancer"
 draft: false
 tags: ["cancer", "oncology", "patientguide", "hub"]
@@ -122,6 +122,8 @@ See also: [Emergencies — Guide Hub](/guides/emergencies) | [Sepsis](/guides/se
 - [Nicotinamide and Skin Cancer Prevention](/guides/nicotinamide-skin-cancer-prevention) — Evidence on vitamin B3 supplementation for high-risk patients.
 
 ### Screening and Prevention
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — Adenomas, serrated polyps, pathology results, colonoscopy removal, surveillance after polypectomy, family history, and post-procedure warning signs.
+- [Bowel Cancer Screening — Early Detection Matters](/guides/bowel-cancer-screening) — FIT testing, colonoscopy, and the preventive power of polyp removal.
 - [Lung Cancer: Symptoms, Diagnosis, and Treatment](/guides/lung-cancer-overview) — Patient overview: types, symptoms, risk factors, and treatment.
 - [Lung Cancer Screening: Low-Dose CT, Benefits, Risks, and Eligibility](/guides/lung-cancer-screening-low-dose-ct) — Who qualifies for annual LDCT, what pack-years means, the evidence base, and shared decision-making.
 - [Skin Cancer — Prevention](/guides/skin-cancer-prevention) — Sun protection, sunscreen, and reducing UV exposure.

--- a/src/content/guides/colorectal-polyps-surveillance.md
+++ b/src/content/guides/colorectal-polyps-surveillance.md
@@ -1,0 +1,379 @@
+---
+title: "Colorectal Polyps: What They Mean and When Follow-Up Is Needed"
+description: "A patient-friendly guide to colorectal polyps, including adenomas, serrated polyps, pathology results, colonoscopy removal, bowel cancer risk, surveillance follow-up, family history, and urgent post-colonoscopy warning signs."
+category: "Cancer"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+tags:
+  - colorectal polyps
+  - bowel cancer
+  - colonoscopy
+  - screening
+  - surveillance
+  - adenoma
+  - polyp removal
+  - pathology
+  - bowel cancer prevention
+draft: false
+faq:
+  - question: "Are colorectal polyps cancer?"
+    answer: "Most colorectal polyps are not cancer. Some types, especially adenomas and some serrated polyps, can develop into bowel cancer over time, which is why they are removed and monitored."
+  - question: "What happens if polyps are found during colonoscopy?"
+    answer: "Many polyps can be removed during colonoscopy and sent to pathology. The pathology result helps determine whether and when follow-up colonoscopy is needed."
+  - question: "How soon do I need another colonoscopy after polyps?"
+    answer: "Follow-up timing depends on the number, size, type, and features of the polyps, bowel preparation quality, family history, and local guidelines. Your specialist should provide a personalised interval."
+  - question: "What is the difference between adenomas and hyperplastic polyps?"
+    answer: "Adenomas have the potential to become cancer over time. Small hyperplastic polyps, especially in the lower bowel, are usually low risk, though some serrated polyps need closer follow-up."
+  - question: "When should I seek urgent help after colonoscopy?"
+    answer: "Seek urgent help for severe or worsening abdominal pain, heavy rectal bleeding, black stools, fever, dizziness, fainting, repeated vomiting, or feeling very unwell after colonoscopy."
+---
+
+# Colorectal Polyps: What They Mean and When Follow-Up Is Needed
+
+Finding polyps during a colonoscopy is common — and for most people, it is good news. Polyps were found before they caused trouble, and for many types, removal during the same procedure substantially reduces the risk of bowel cancer developing in the future. What happens next depends on what the pathology report shows.
+
+---
+
+## Key Points
+
+- Colorectal polyps are small growths on the inner lining of the bowel; most are not cancer
+- Some types — particularly adenomas and certain serrated polyps — can develop into bowel cancer over years if left untreated
+- Most polyps can be removed during colonoscopy and sent to pathology
+- The pathology result determines the type, size, grade, and any high-risk features — and guides surveillance decisions
+- Surveillance colonoscopy intervals are personalised; they depend on polyp number, size, type, dysplasia, bowel preparation quality, family history, and local guidelines
+- Many people with low-risk polyps return to routine screening rather than accelerated follow-up
+- Know the warning signs after colonoscopy that require urgent attention
+
+---
+
+## What Are Colorectal Polyps?
+
+Colorectal polyps are small growths that develop on the lining of the colon (large bowel) or rectum. They are common — found in roughly one in four to one in three adults over 50, and increasingly common with age.
+
+Polyps vary in size, shape, and type. Most cause no symptoms and are found incidentally — during a colonoscopy performed for screening, after a positive FIT (faecal immunochemical test), or as part of a surveillance programme.
+
+The reason polyps matter is that certain types can, over years, undergo changes that lead to bowel cancer. Identifying and removing these types while they are still benign is one of the most effective forms of cancer prevention available.
+
+---
+
+## Why Polyps Matter
+
+### Most polyps are benign
+
+The majority of colorectal polyps are not cancer and will never become cancer. Finding a polyp is not a diagnosis of cancer.
+
+### Some can develop into bowel cancer over time
+
+Certain polyp types — primarily adenomas and some serrated polyps — are considered pre-cancerous. This does not mean they are cancer now; it means they carry a risk of transforming into cancer over a period of years if not managed. Removal interrupts that process.
+
+### Removal significantly reduces bowel cancer risk
+
+Large studies have shown that identifying and removing adenomas through colonoscopy reduces the incidence of bowel cancer by 70–90% compared with no removal. This is one of the strongest preventive effects available in cancer medicine.
+
+For more on bowel cancer screening and how polyps fit into that process, see [Bowel Cancer Screening — Early Detection Matters](/guides/bowel-cancer-screening) and [Bowel Cancer — Guide Hub](/guides/bowel-cancer).
+
+---
+
+## Types of Colorectal Polyps
+
+### Adenomas (adenomatous polyps)
+
+Adenomas are the most clinically important type of colorectal polyp from a cancer-prevention standpoint. They arise from glandular cells in the bowel lining and carry genuine potential to develop into bowel cancer if left in place over years.
+
+Adenomas are classified further by their architecture:
+
+- **Tubular adenomas** — the most common type; generally lower risk, particularly when small
+- **Villous adenomas** — a less common type with finger-like projections; associated with higher risk of malignant change
+- **Tubulovillous adenomas** — a mixed type
+
+The key risk features of adenomas include:
+
+- **Size** — polyps 10 mm or larger (and especially those 20 mm or larger) carry greater risk
+- **Number** — finding three or more adenomas at a single colonoscopy increases the overall risk burden
+- **Dysplasia** — the degree of abnormal cell change within the polyp; high-grade dysplasia indicates more advanced pre-cancerous change
+- **Villous architecture** — villous or tubulovillous patterns are associated with higher risk than purely tubular ones
+- **Completeness of removal** — whether the polyp was fully excised affects the surveillance interval
+
+### Serrated polyps
+
+Serrated polyps are a broader category that includes several distinct subtypes. Their inner lining has a saw-tooth (serrated) appearance under the microscope.
+
+- **Hyperplastic polyps** — the most common serrated type; small, usually in the lower bowel (sigmoid colon, rectum); generally considered low risk
+- **Sessile serrated lesions (SSLs), also called sessile serrated polyps (SSPs)** — flat or slightly raised; may be harder to detect at colonoscopy; can be in the right colon; some carry meaningful pre-cancerous potential, particularly if they develop a dysplastic component
+- **Traditional serrated adenomas (TSAs)** — less common; generally considered higher risk and managed similarly to adenomas
+
+The risk associated with serrated polyps depends on their subtype, size, location, and whether dysplasia is present. Your pathology report and specialist will clarify what was found in your case.
+
+### Hyperplastic polyps
+
+Small hyperplastic polyps, especially those in the lower bowel (left colon, sigmoid, rectum), are generally considered to have low cancer risk and do not usually change surveillance planning significantly. However, hyperplastic polyps in the right colon (proximal/proximal to the splenic flexure) or larger ones may be re-classified on closer examination — this is why pathology review matters even for seemingly low-risk polyps.
+
+### Inflammatory polyps
+
+Inflammatory polyps (also called pseudopolyps) are not pre-cancerous themselves — they develop as part of the healing response in conditions such as inflammatory bowel disease (Crohn's disease or ulcerative colitis). People with long-standing inflammatory bowel disease have an elevated bowel cancer risk from chronic inflammation, but this is managed separately from adenoma surveillance.
+
+---
+
+## How Polyps Are Found
+
+Most colorectal polyps are found during:
+
+- **Bowel cancer screening** — a positive [FIT (faecal immunochemical test)](/guides/bowel-cancer-screening) triggers a colonoscopy, during which polyps may be found
+- **Surveillance colonoscopy** — follow-up colonoscopy for a known history of polyps or increased risk
+- **Diagnostic colonoscopy** — investigation of symptoms such as rectal bleeding, change in bowel habit, unexplained anaemia, or abdominal pain
+- **Family history assessment** — colonoscopy performed because of a significant family history of bowel cancer or polyps
+- **Incidental finding** — identified during a procedure performed for another reason
+
+Many people with polyps have no symptoms at all. Symptoms — when they do occur — are more likely with larger polyps or if cancer has already developed. Do not assume that the absence of symptoms means there is nothing to find.
+
+---
+
+## What Happens During Colonoscopy
+
+A colonoscopy involves passing a thin, flexible tube with a camera (colonoscope) through the rectum to inspect the entire lining of the large bowel. The procedure requires bowel preparation beforehand — taking laxatives to clear the colon — and is usually performed under sedation.
+
+During colonoscopy, the endoscopist can:
+
+- **Inspect** the bowel lining visually, using white light and sometimes special dye or filter techniques to improve detection
+- **Remove polyps** (polypectomy) — small polyps can be removed using a wire snare (snare polypectomy), a biopsy forceps, or endoscopic mucosal resection (EMR) for larger flat lesions
+- **Biopsy** — take a small tissue sample if a polyp cannot be safely removed immediately, or if there is concern about possible cancer
+- **Mark** — in some cases, a tattooing dye is injected near a polyp or lesion to help surgeons locate it later if surgery is needed
+
+Not all polyps can be removed at the first colonoscopy. Large or complex polyps may require a second procedure or surgical referral.
+
+Bowel preparation quality matters: a poorly prepared bowel makes it harder to see small polyps, and a poor prep may be documented in your report as a reason to repeat the colonoscopy sooner than usual.
+
+---
+
+## Understanding Your Pathology Report
+
+When polyps are removed and sent to pathology, the laboratory provides a written report. Understanding the key terms helps you ask better questions at your follow-up appointment.
+
+### What the report typically describes
+
+- **Polyp type** — adenoma, sessile serrated lesion, hyperplastic polyp, tubulovillous adenoma, etc.
+- **Size** — measured in millimetres; size affects risk and surveillance
+- **Number** — total number of polyps found and removed
+- **Dysplasia** — the degree of abnormal cell change; may be low-grade (LGD) or high-grade (HGD); high-grade dysplasia means the cells look more abnormal and is a higher-risk finding
+- **Architecture** — tubular, villous, or tubulovillous (for adenomas)
+- **Margins** — whether the polyp appeared to be fully removed (complete) or whether the margin of removal is involved or unclear
+- **Cancerous change** — in some cases, a polyp may contain an area of early cancer (carcinoma in situ or invasive carcinoma); this changes management significantly
+
+If your pathology report mentions **invasive carcinoma** or **cancer within a polyp**, further assessment will be needed to determine whether additional surgery or treatment is required. This decision depends on the depth of invasion, the margins, and other features the pathologist describes.
+
+### Bowel preparation quality
+
+Your endoscopy report will also document the quality of your bowel preparation (e.g., Boston Bowel Preparation Scale score). If preparation was inadequate, a repeat colonoscopy may be recommended sooner to ensure no lesions were missed.
+
+---
+
+## Surveillance After Polyp Removal
+
+One of the most common questions after polyp removal is: "When do I need to come back?"
+
+There is no single universal answer. Surveillance colonoscopy intervals are not one-size-fits-all — they are personalised based on a combination of factors, and your gastroenterologist or specialist should provide you with a specific written recommendation.
+
+### Factors that influence surveillance interval
+
+- **Number of polyps** — finding three or more adenomas at once generally warrants a shorter follow-up interval than finding just one or two
+- **Size** — a polyp of 10 mm or more carries more weight in risk assessment than a small 3–4 mm lesion
+- **Type** — adenomas and sessile serrated lesions with dysplasia require different management than small hyperplastic polyps
+- **Dysplasia** — high-grade dysplasia in an adenoma typically prompts earlier follow-up
+- **Villous architecture** — villous or tubulovillous adenomas are generally higher risk
+- **Completeness of removal** — a polyp with an involved or uncertain margin may require earlier repeat endoscopy to confirm clearance
+- **Bowel preparation quality** — a poor prep at the index colonoscopy may prompt earlier repeat to ensure adequate visualisation
+- **Family history** — a first-degree relative with bowel cancer or advanced adenomas, or a diagnosis at young age, can shift the risk category and surveillance recommendation
+- **Personal history of previous polyps** — prior adenoma history is itself a risk factor
+- **Local guidelines** — recommendations differ between countries (e.g., British Society of Gastroenterology, US Multi-Society Task Force, Gastroenterological Society of Australia) and are updated as evidence accumulates
+
+### Typical categories (illustrative only — not personalised advice)
+
+As a general orientation (not a substitute for your own specialist's recommendation):
+
+- **Low-risk findings** (e.g., one or two small tubular adenomas with low-grade dysplasia, fully removed, good prep) — many guidelines recommend a return to standard population screening intervals rather than early surveillance
+- **Intermediate-risk findings** (e.g., three to four adenomas, or one adenoma 10 mm or larger, or any adenoma with villous features or high-grade dysplasia) — typically 3-year surveillance colonoscopy
+- **High-risk findings** (e.g., five or more adenomas, or a very large polyp 20 mm or more, or piecemeal removal requiring confirming clearance) — typically 1-year surveillance
+
+These categories are illustrative. Your actual recommendation may differ based on the full clinical picture.
+
+### Ask for a written surveillance plan
+
+After polyp removal, ask your specialist for a written recommendation that includes:
+- The polyp type(s) and risk category
+- Your recommended surveillance interval
+- Who is responsible for organising the next colonoscopy
+
+Do not assume a follow-up will be booked automatically. Keep your own record and follow up if you have not received a referral by the expected time.
+
+---
+
+## Family History and Genetic Risk
+
+Family history of bowel cancer or polyps is a significant independent risk factor for both polyp development and bowel cancer.
+
+### When family history matters
+
+- **One first-degree relative** (parent, sibling, or child) with bowel cancer diagnosed before age 55, or two first-degree relatives of any age — typically warrants earlier colonoscopy surveillance than the general population, often from age 40–45 or ten years before the youngest affected relative's diagnosis
+- **Multiple affected relatives** — further increases risk and may warrant more intensive surveillance
+- **Diagnosis at a young age** — polyps or bowel cancer found in someone under 50 raises the possibility of an inherited condition
+
+### Inherited bowel cancer syndromes
+
+Some people have an inherited genetic condition that greatly increases their risk of bowel cancer and polyps. Examples include:
+
+- **Lynch syndrome (hereditary non-polyposis colorectal cancer, HNPCC)** — the most common inherited bowel cancer syndrome; caused by mutations in DNA mismatch repair genes; associated with bowel, uterine, and other cancers; requires intensive surveillance from a young age
+- **Familial adenomatous polyposis (FAP)** — causes hundreds to thousands of adenomas in the large bowel from a young age; without treatment, bowel cancer is almost inevitable
+- **MUTYH-associated polyposis (MAP)** — a recessive condition causing multiple adenomas; associated with increased bowel cancer risk
+
+These conditions are managed through specialist genetics services and gastroenterology with close surveillance programs.
+
+If your gastroenterologist identifies features that raise concern about an inherited syndrome — such as polyps found in someone young, or an unusually large number of polyps — they may recommend genetic counselling or referral to a family cancer clinic. This is not something to fear; it is an opportunity to protect yourself and potentially your family members through earlier, more targeted screening.
+
+---
+
+## Polyps Versus Bowel Cancer
+
+It is important to understand the relationship clearly:
+
+- **Most polyps are not cancer.** Even adenomas — the pre-cancerous type — take years to develop into bowel cancer, and many never do.
+- **A polyp containing cancer is different from advanced bowel cancer.** When pathology reports cancer within a polyp (focal or superficial invasive cancer), this is usually a much earlier and more manageable situation than cancer found later by symptoms.
+- **Pathology determines next steps.** If cancer is found within a removed polyp, a multidisciplinary team will review the case to determine whether endoscopic removal alone was sufficient, or whether further surgery is recommended.
+
+---
+
+## Symptoms of Colorectal Polyps
+
+Most colorectal polyps cause no symptoms at all. This is why screening — not waiting for symptoms — is so important.
+
+When symptoms do occur, they may include:
+
+- **Rectal bleeding** — blood on the toilet paper, in the toilet bowl, or mixed with stool; any rectal bleeding should be assessed by a doctor, even if haemorrhoids seem the most likely explanation
+- **Change in bowel habit** — stools becoming looser, more frequent, or narrower than usual, persisting for more than two to three weeks
+- **Iron deficiency anaemia** — caused by slow, chronic bleeding from a polyp; may present as unexplained fatigue, pallor, or breathlessness
+- **Abdominal pain or cramping** — less common with polyps alone; more likely if a polyp is large or obstruction is developing
+
+**Do not ignore these symptoms even after a recent clear colonoscopy.** Interval cancers — bowel cancers that develop between scheduled surveillance colonoscopies — are uncommon but real. New or changing symptoms warrant prompt medical review regardless of recent test results.
+
+---
+
+## Reducing Bowel Cancer Risk
+
+Attending surveillance appointments is the most direct action you can take after polyp removal. Beyond that, the same lifestyle factors that reduce bowel cancer risk in the general population apply here:
+
+- **Keep your surveillance appointments** — this is the most important action; do not let them lapse
+- **Participate in national bowel cancer screening** — continue FIT testing as directed if eligible
+- **Quit smoking** — smoking is associated with increased adenoma risk and bowel cancer risk; see [Smoking and Tobacco Cessation](/guides/smoking-cessation) for support
+- **Increase physical activity** — regular moderate physical activity is consistently associated with lower bowel cancer incidence
+- **Eat a diet high in fibre** — including vegetables, legumes, fruit, and whole grains
+- **Limit red and processed meat** — particularly processed meat (bacon, sausages, deli meats), which is classified as a group 1 carcinogen by the IARC
+- **Limit alcohol** — alcohol increases bowel cancer risk in a dose-dependent way
+- **Maintain a healthy weight** — obesity and excess abdominal fat increase colorectal cancer risk
+- **Manage metabolic risk** — type 2 diabetes and insulin resistance are associated with higher colorectal cancer risk; for guidance on metabolic health, see [Type 2 Diabetes](/guides/type-2-diabetes)
+
+For the broader context of cancer prevention and screening, see [Cancer — Guide Hub](/guides/cancer) and [Preventive Screening Hub](/guides/preventive-screening-hub).
+
+---
+
+## After Colonoscopy: What to Expect
+
+Most people tolerate colonoscopy well and are able to go home the same day. Knowing what is normal — and what is not — helps you recover confidently and act quickly if something changes.
+
+### Common and expected
+
+- **Bloating and wind** — very common for several hours after the procedure; the bowel is inflated with air or carbon dioxide during colonoscopy
+- **Mild cramping** — can occur as the bowel returns to normal activity
+- **Drowsiness** — from the sedation; do not drive, operate machinery, or make important decisions for at least 12–24 hours after sedation
+- **Some blood in the first bowel motion** — a small amount of blood after polyp removal is not unusual, particularly in the first 24 hours; follow your discharge instructions
+
+### What to watch for
+
+Significant complications after colonoscopy are uncommon, but they do occur. The risk is higher after polyp removal, particularly large or complex polypectomy.
+
+If you are on blood thinners (anticoagulants or antiplatelet medicines) and these were paused before your procedure, your endoscopy team should advise you exactly when to restart them. Do not adjust these medicines independently — see [Medication Safety](/guides/medication-safety) and [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) for guidance on managing medicine transitions after procedures.
+
+---
+
+## When to Seek Urgent Help After Colonoscopy
+
+**Go to your nearest emergency department or call 000 (Australia) / 999 (UK) / 911 (US) immediately if you develop:**
+
+- **Severe or worsening abdominal pain** — particularly if constant, spreading, or not improving
+- **Heavy rectal bleeding** — more than a small amount, or bright red blood filling the toilet bowl
+- **Black, tarry stools (melaena)** — this can indicate bleeding in the upper bowel and is always urgent
+- **Repeated or worsening bleeding** — any rectal bleeding that continues or worsens over hours
+- **Fever, chills, or shivering** — may indicate infection or perforation
+- **Dizziness, faintness, or feeling very lightheaded** — can indicate significant blood loss
+- **Repeated vomiting** or inability to keep fluids down
+- **Severe weakness or collapse**
+- **Chest pain or severe breathlessness** — always an emergency, regardless of cause
+- **Feeling very unwell** — trust your instincts; if something feels seriously wrong after a procedure, seek help
+
+Bowel perforation (a small tear in the bowel wall) and delayed post-polypectomy bleeding are uncommon but serious complications. Both are treatable when caught promptly. Do not manage these symptoms at home or wait until the next business day if they are severe.
+
+If you are unsure, call your local health advice line (healthdirect 1800 022 222 in Australia; 111 in the UK) or contact the endoscopy unit that performed your procedure.
+
+---
+
+## Questions to Ask Your Specialist
+
+After a colonoscopy with polyp findings, consider asking:
+
+1. What type of polyps were found?
+2. How many polyps were removed?
+3. Were they completely removed, or is there concern about the margins?
+4. Were there any high-risk features (size, dysplasia, villous architecture)?
+5. When do I need another colonoscopy, and when will the referral be organised?
+6. Should any of my family members consider earlier or more frequent screening?
+7. Was the bowel preparation adequate, or could this have affected detection?
+8. Are there any symptoms I should watch for between now and my next colonoscopy?
+9. Should I continue with standard FIT testing between surveillance colonoscopies?
+10. Is there anything about the pathology that raises concern about an inherited condition?
+
+---
+
+## FAQ
+
+**Are colorectal polyps cancer?**
+Most colorectal polyps are not cancer. Some types — particularly adenomas and certain serrated polyps — can develop into bowel cancer over time if not removed and monitored, which is why they are taken seriously.
+
+**What happens if polyps are found during colonoscopy?**
+Many polyps can be removed during the same colonoscopy and sent to pathology. The pathology report guides decisions about surveillance timing and any further action needed.
+
+**How soon do I need another colonoscopy after polyps?**
+There is no single answer. Follow-up timing depends on the number, size, type, and features of the polyps, the quality of bowel preparation, your personal and family history, and the guidelines used by your specialist. Always ask for a written recommendation.
+
+**What is the difference between adenomas and hyperplastic polyps?**
+Adenomas are pre-cancerous and require surveillance. Small hyperplastic polyps, especially in the lower bowel, are generally low risk and do not usually change screening intervals significantly — though some serrated polyps need closer follow-up depending on their type and size.
+
+**When should I seek urgent help after colonoscopy?**
+Seek urgent help for severe or worsening abdominal pain, heavy rectal bleeding, black tarry stools, fever, dizziness or faintness, repeated vomiting, or feeling very unwell after the procedure.
+
+---
+
+## Further Reading
+
+The following are neutral, reputable sources for further information on colorectal polyps and bowel cancer screening.
+
+- **NHS — Bowel Polyps**: plain-language information on what bowel polyps are and what happens after they are found — [nhs.uk/conditions/bowel-polyps](https://www.nhs.uk/conditions/bowel-polyps/)
+- **Cancer Research UK — Bowel Polyps**: types of polyp, risk, and follow-up — [cancerresearchuk.org](https://www.cancerresearchuk.org/about-cancer/bowel-cancer/risks-causes/polyps)
+- **American Cancer Society — Colorectal Polyps**: overview of polyp types, detection, and cancer prevention — [cancer.org](https://www.cancer.org/cancer/types/colon-rectal-cancer/detection-diagnosis-staging/what-is-colorectal-cancer.html)
+- **CDC — Colorectal Cancer Screening**: US public health screening information and guidelines — [cdc.gov/cancer/colorectal](https://www.cdc.gov/cancer/colorectal/basic_info/screening/index.htm)
+- **National Cancer Institute — Colorectal Cancer Prevention**: evidence summaries on colorectal polyps and cancer prevention — [cancer.gov](https://www.cancer.gov/types/colorectal/patient/colorectal-prevention-pdq)
+- **Bowel Cancer Australia**: Australian-specific resources on bowel cancer prevention, screening, and polyp management — [bowelcanceraustralia.org](https://www.bowelcanceraustralia.org/)
+
+---
+
+## Related Guides
+
+- [Bowel Cancer — Guide Hub](/guides/bowel-cancer) — colorectal cancer: screening, treatment, genetics, and survivorship
+- [Bowel Cancer Screening — Early Detection Matters](/guides/bowel-cancer-screening) — FIT testing, colonoscopy, and who should be screened
+- [Cancer — Guide Hub](/guides/cancer) — all cancer types, prevention, and survivorship
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — age-based screening programs including bowel, breast, and cervical cancer
+- [Smoking and Tobacco Cessation](/guides/smoking-cessation) — reducing cancer risk through quitting smoking
+- [Type 2 Diabetes](/guides/type-2-diabetes) — metabolic risk and its association with colorectal cancer
+- [Hospital Discharge and Recovery](/guides/hospital-discharge-recovery) — recovery after procedures including colonoscopy; medicines and warning signs
+- [Medication Safety](/guides/medication-safety) — managing anticoagulants and antiplatelets around procedures
+
+---
+
+*This guide is for educational purposes only and is not a substitute for professional medical advice. Surveillance intervals, management decisions, and follow-up requirements vary by individual circumstances and local clinical guidelines. Speak with your gastroenterologist or specialist about the plan that is right for you.*

--- a/src/content/guides/hospital-discharge-recovery.md
+++ b/src/content/guides/hospital-discharge-recovery.md
@@ -393,3 +393,4 @@ The following are neutral, reputable sources of information on hospital discharg
 - [COPD](/guides/copd)
 - [Sepsis](/guides/sepsis)
 - [Preventive Screening Hub](/guides/preventive-screening-hub)
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — recovery and red flags after colonoscopy and polypectomy; when to seek urgent help after a bowel procedure

--- a/src/content/guides/medication-safety.md
+++ b/src/content/guides/medication-safety.md
@@ -452,6 +452,7 @@ Seek urgent help for difficulty breathing, swelling of the face or throat, sever
 - [Common Heart Medications and Their Side Effects](/guides/common-heart-medications) — plain-language guide to statins, ACE inhibitors, beta-blockers, anticoagulants, and more
 - [Atrial Fibrillation](/guides/atrial-fibrillation) — anticoagulation in AF; stroke prevention and bleeding risk
 - [Peripheral Artery Disease: Leg Pain, Circulation, and When to Seek Help](/guides/peripheral-artery-disease) — antiplatelet medicines, blood-thinning treatments, and vascular risk reduction in PAD
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — managing anticoagulants and antiplatelets around colonoscopy and polypectomy; post-procedure bleeding risk
 - [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — blood pressure medicines, monitoring, and side effects
 - [Diabetes Hub](/guides/diabetes-hub) — diabetes medicines, hypoglycaemia, sick days, and CKD
 - [Diabetic Foot Care: Nerve Damage, Circulation, and Wound Warning Signs](/guides/diabetic-foot-care) — antibiotics, blood thinners, and diabetes medicines in the context of foot infections and wound management

--- a/src/content/guides/preventive-screening-hub.md
+++ b/src/content/guides/preventive-screening-hub.md
@@ -5,6 +5,7 @@ description: "Your central guide to preventive health screening — cancer check
 category: "Guide Hubs"
 publishDate: "2026-06-05"
 updatedDate: "2026-06-11"
+
 hubKey: "Preventive Screening"
 draft: false
 tags:
@@ -131,8 +132,9 @@ Bowel cancer is one of the most common cancers in high-income countries and one 
 
 - [Bowel Cancer Screening Explained](/guides/bowel-cancer-screening-explained) — who should be screened, how FIT and colonoscopy work, intervals, and positive result pathways
 - [Bowel Cancer Screening — Early Detection Matters](/guides/bowel-cancer-screening) — overview of the programme and what to expect
+- [Colorectal Polyps: What They Mean and When Follow-Up Is Needed](/guides/colorectal-polyps-surveillance) — polyp types, pathology results, colonoscopy removal, surveillance intervals, and post-procedure warning signs
 
-**Who should screen:** Most guidelines recommend starting at age 45–50 for average-risk adults, with the FIT test (home stool test) every 1–2 years. Earlier screening applies if you have a family history, Lynch syndrome, or long-standing inflammatory bowel disease.
+**Who should screen:** Most guidelines recommend starting at age 45–50 for average-risk adults, with the FIT test (home stool test) every 1–2 years. Earlier screening applies if you have a family history, Lynch syndrome, or long-standing inflammatory bowel disease. A positive FIT test or previous polyps found at colonoscopy triggers personalised surveillance planning.
 
 ---
 


### PR DESCRIPTION
## Summary

* Adds a patient-facing colorectal polyps and surveillance guide covering polyp types (adenomas, serrated lesions, hyperplastic), pathology results, colonoscopy removal, bowel cancer risk, surveillance follow-up, family history/genetic risk, and urgent post-colonoscopy red flags
* Wires colorectal polyps into the preventive screening, cancer, bowel cancer hub, bowel cancer screening, hospital discharge, and medication safety clusters
* Does not give personalised surveillance intervals — explains the factors that determine them and directs readers to their specialist for a written plan

## Checks

* npm run content:check — 0 errors, 13 warnings (baseline unchanged)
* npm run build — passes, 768 pages indexed
* Route /guides/colorectal-polyps-surveillance/ confirmed in dist/