### PR TITLE
feat(womens-health): add uterine fibroids guide

### DIFF
--- a/src/content/guides/endometriosis.md
+++ b/src/content/guides/endometriosis.md
@@ -326,6 +326,8 @@ Psychological support, access to peer communities, and a healthcare team that ac
 
 ## Related Guides
 
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — fibroids often coexist with endometriosis; another common cause of heavy periods and pelvic pain
+- [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help) — heavy menstrual bleeding is common in endometriosis; investigation and treatment options
 - [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause)
 - [Hormone Therapy for Menopause: Weighing Risks and Benefits](/guides/hormone-therapy-menopause)
 - [Managing Chronic Back Pain — Principles of Pain Management](/guides/managing-chronic-back-pain)

--- a/src/content/guides/heavy-periods-when-to-seek-help.md
+++ b/src/content/guides/heavy-periods-when-to-seek-help.md
@@ -4,7 +4,7 @@ slug: "heavy-periods-when-to-seek-help"
 description: "A guide to heavy menstrual bleeding — causes, when bleeding becomes a medical concern, the link to iron deficiency anaemia, investigations, and treatment options."
 category: "Women's Health"
 publishDate: "2026-06-01"
-updatedDate: "2026-06-01"
+updatedDate: "2026-06-11"
 draft: false
 tags:
   - heavy periods
@@ -217,6 +217,7 @@ Definitive treatment — removes the uterus, ending periods permanently. Reserve
 ## Related Guides
 
 - [Women's Health Hub](/guides/womens-health-hub)
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — fibroids are one of the most common structural causes of heavy periods; symptoms, diagnosis, and treatment
 - [Perimenopause: What to Expect](/guides/perimenopause-what-to-expect)
 - [PCOS: Understanding Polycystic Ovary Syndrome](/guides/pcos)
 - [Endometriosis: Symptoms, Diagnosis, and Treatment Options](/guides/endometriosis)

--- a/src/content/guides/medication-safety.md
+++ b/src/content/guides/medication-safety.md
@@ -458,6 +458,7 @@ Seek urgent help for difficulty breathing, swelling of the face or throat, sever
 - [Diabetic Foot Care: Nerve Damage, Circulation, and Wound Warning Signs](/guides/diabetic-foot-care) — antibiotics, blood thinners, and diabetes medicines in the context of foot infections and wound management
 - [Palliative Care: Support, Symptoms, and Planning](/guides/palliative-care) — medication review in advanced illness; symptom medicines and simplifying regimens
 - [Preventive Screening Hub](/guides/preventive-screening-hub) — medicines review as part of preventive health
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — safe use of hormonal medicines, tranexamic acid, NSAIDs, and iron replacement for fibroid-related symptoms
 - [Caregiver Burnout: Signs, Support, and When to Ask for Help](/guides/caregiver-burnout) — medication management as a source of carer stress; respite and support planning
 
 ---

--- a/src/content/guides/menopause.md
+++ b/src/content/guides/menopause.md
@@ -291,6 +291,7 @@ Moderately. Avoiding known triggers (alcohol, hot drinks, spicy food), dressing 
 ## Related Guides
 
 - [Women's Health Hub](/guides/womens-health-hub)
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — fibroids typically shrink after menopause; any postmenopausal bleeding requires assessment regardless of fibroid history
 - [Perimenopause: What to Expect](/guides/perimenopause-what-to-expect)
 - [Menopause and Sleep: Why Rest Becomes Harder and What Helps](/guides/menopause-and-sleep)
 - [Hormone Therapy for Menopause: Benefits, Risks, and Who It Suits](/guides/hormone-therapy-menopause)

--- a/src/content/guides/pcos.md
+++ b/src/content/guides/pcos.md
@@ -277,6 +277,7 @@ Given the metabolic risk profile of PCOS, regular monitoring is recommended even
 ## Related Guides
 
 - [Women's Health Hub](/guides/womens-health-hub)
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — fibroids are another common cause of heavy periods; relevant when assessing abnormal bleeding
 - [PCOS Management: Lifestyle, Medications, and Long-Term Care](/guides/pcos-management)
 - [Insulin Resistance: What It Is and Why It Matters](/guides/insulin-resistance)
 - [Type 2 Diabetes — Overview and Management](/guides/type-2-diabetes)

--- a/src/content/guides/thyroid-disease-overview.md
+++ b/src/content/guides/thyroid-disease-overview.md
@@ -366,6 +366,7 @@ If you are uncertain whether your symptoms need urgent attention, seek medical r
 - [Anxiety Disorders](/guides/anxiety) — anxiety-like symptoms can be driven by an overactive thyroid; testing helps distinguish the cause
 - [Depression: Symptoms, Causes, and Treatment](/guides/depression) — hypothyroidism can contribute to depression-like symptoms; thyroid testing is part of the workup for new-onset depression
 - [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help) — heavy or irregular periods can be caused by hypothyroidism
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — fibroids are another common cause of heavy periods and fatigue; thyroid dysfunction is part of the differential diagnosis
 - [Postpartum Depression: Symptoms, Risks, and Treatment](/guides/postpartum-depression) — postpartum thyroiditis can mimic postnatal depression; thyroid testing is part of the postpartum differential
 - [Gestational Diabetes: Screening, Treatment, and Follow-Up](/guides/gestational-diabetes) — metabolic and hormonal health during pregnancy and the postpartum period
 - [High Blood Pressure (Hypertension)](/guides/high-blood-pressure) — thyroid dysfunction can affect blood pressure and cardiovascular risk

--- a/src/content/guides/uterine-fibroids.md
+++ b/src/content/guides/uterine-fibroids.md
@@ -1,0 +1,338 @@
+---
+title: "Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options"
+description: "A patient-friendly guide to uterine fibroids, including symptoms, heavy bleeding, anaemia, pelvic pressure, fertility and pregnancy considerations, diagnosis, treatment options, and when to seek urgent help."
+category: "Women's Health"
+publishDate: "2026-06-11"
+updatedDate: "2026-06-11"
+draft: false
+tags:
+  - uterine fibroids
+  - heavy periods
+  - pelvic pain
+  - women's health
+  - anaemia
+  - pelvic pressure
+  - menstrual health
+  - fertility
+faq:
+  - q: "What are uterine fibroids?"
+    a: "Uterine fibroids are non-cancerous growths of muscle and fibrous tissue that develop in or around the uterus. They are common and do not always cause symptoms."
+  - q: "Are fibroids cancer?"
+    a: "Fibroids are usually benign and are not cancer. Rare cancers can arise in the uterus, but most fibroids are non-cancerous. New, rapidly changing, or unusual symptoms should always be assessed by a clinician."
+  - q: "What symptoms can fibroids cause?"
+    a: "Fibroids can cause heavy or prolonged periods, pelvic pressure or bloating, pelvic or lower back pain, frequent urination, constipation, pain during sex, and in some cases fertility or pregnancy complications."
+  - q: "Do all fibroids need treatment?"
+    a: "No. Fibroids that are small, stable, and not causing symptoms may only need monitoring. Treatment depends on symptoms, fibroid size and location, age, fertility goals, and overall health."
+  - q: "When should I seek urgent help for fibroid symptoms?"
+    a: "Seek urgent help for very heavy bleeding (soaking pads rapidly or passing large clots), fainting or dizziness, severe pelvic pain, fever, bleeding in pregnancy, postmenopausal bleeding, or symptoms of severe anaemia such as chest pain, breathlessness, or collapse."
+---
+
+## Introduction
+
+Uterine fibroids are among the most common gynaecological conditions — affecting up to 70% of women by the age of 50, though most will never know they have them. When fibroids do cause problems, the effects can be significant: heavy periods leading to anaemia, pelvic pressure and discomfort, and in some cases effects on fertility or pregnancy.
+
+Despite their prevalence, fibroids are poorly understood by many people experiencing them. This guide explains what fibroids are, why they cause the symptoms they do, how they are investigated, and what treatment options are available — including doing nothing when that is the right choice.
+
+---
+
+## Key Points
+
+- Uterine fibroids are non-cancerous growths of muscle and fibrous tissue in or around the uterus; they are very common
+- Many fibroids cause no symptoms and require no treatment
+- Heavy or prolonged periods are the most common symptom and can lead to iron deficiency anaemia
+- Pelvic pressure, frequent urination, constipation, and pelvic pain are other common effects
+- Fibroids do not always affect fertility or pregnancy, but location and size matter
+- Fibroids tend to shrink after menopause; any postmenopausal bleeding should always be assessed
+- Treatment options range from watchful waiting to medical and surgical approaches; the right choice depends on symptoms, size, location, fertility plans, and personal preferences
+- Seek urgent help for very heavy bleeding, fainting, severe pain, fever, postmenopausal bleeding, or signs of severe anaemia
+
+---
+
+## What Are Uterine Fibroids?
+
+Uterine fibroids — also called leiomyomas or myomas — are benign (non-cancerous) growths made up of smooth muscle and fibrous connective tissue. They develop within or around the wall of the uterus (womb). Fibroids vary enormously in size: from a few millimetres to several centimetres, and occasionally larger. A person may have one fibroid or many.
+
+**Are fibroids dangerous?** Fibroids are almost always benign. A rare uterine cancer called leiomyosarcoma can look similar on imaging, but this is uncommon and is not related to the usual progression of fibroids. If new, rapidly growing, or unusual features are present, clinical assessment is warranted — but routine fibroids do not become cancer.
+
+---
+
+## Where Fibroids Grow
+
+The location of a fibroid within or around the uterus affects what symptoms it causes:
+
+- **Intramural** — within the muscular wall of the uterus; the most common type
+- **Submucosal** — projecting into the uterine cavity; most likely to cause heavy bleeding and fertility problems
+- **Subserosal** — projecting outward from the outer surface of the uterus; more likely to cause pressure, bulk symptoms, or urinary problems
+- **Pedunculated** — attached by a stalk, either inside the uterine cavity or on the outer surface
+
+---
+
+## How Common Are Fibroids?
+
+Fibroids are one of the most frequently occurring conditions of the female reproductive system. Studies using imaging suggest that up to **70% of women** will have at least one fibroid by the age of 50, but many will never know because symptoms are absent. Those who seek care typically do so because of heavy periods, pelvic pressure, or problems identified during investigation of another symptom.
+
+---
+
+## Why Do Fibroids Develop?
+
+The exact cause of fibroids is not fully understood, but several factors are associated with their development:
+
+- **Hormones** — oestrogen and progesterone promote fibroid growth; fibroids often grow during the reproductive years and tend to shrink after menopause when hormone levels fall
+- **Genetics** — fibroids run in families; having a first-degree relative with fibroids increases your likelihood of developing them
+- **Age** — fibroids are most common during the reproductive years, particularly from the 30s onward
+- **Pregnancy hormones** — elevated oestrogen and progesterone during pregnancy can cause fibroids to grow, though they often return to a similar or smaller size after delivery
+
+Fibroids are not caused by lifestyle choices. They are not preventable in the usual sense.
+
+---
+
+## Common Symptoms
+
+Many people with fibroids have no symptoms at all. When symptoms do occur, they depend on the fibroid's location, size, and number.
+
+### Menstrual Changes
+
+- **Heavy periods (menorrhagia)** — the most common symptom; periods may be significantly heavier than usual, requiring frequent pad or tampon changes, or passing large clots
+- **Prolonged periods** — periods lasting longer than 7 days
+- **Bleeding between periods** — less common but can occur, particularly with submucosal fibroids
+
+### Pelvic Pressure and Pain
+
+- **Pelvic pressure or fullness** — a sensation of heaviness or pressure in the lower abdomen
+- **Pelvic or lower back pain** — aching or discomfort, sometimes worsening during periods
+- **Pain during sex** — depending on fibroid location
+
+### Bladder and Bowel Effects
+
+- **Frequent urination or urgency** — fibroids pressing on the bladder
+- **Constipation or bloating** — fibroids pressing on the bowel
+
+### Other Symptoms
+
+- **Abdominal bloating or a visibly enlarged lower abdomen** — with larger fibroids
+- **Fatigue** — often related to heavy periods and resulting iron deficiency
+
+---
+
+## Heavy Bleeding and Anaemia
+
+Heavy menstrual bleeding is the most significant symptom for many people with fibroids — and its consequences extend well beyond inconvenience. Recurring blood loss depletes iron stores, leading to **iron deficiency anaemia**.
+
+Symptoms of iron deficiency or anaemia include:
+
+- Persistent fatigue and low energy
+- Dizziness or lightheadedness
+- Breathlessness on exertion
+- Palpitations (awareness of the heartbeat)
+- Difficulty concentrating
+- Feeling cold
+
+Iron deficiency can develop slowly, and many people have lived with it for months or years without realising it is causing their symptoms. **Blood tests — a full blood count and ferritin — are an important part of assessing anyone with heavy periods**, as a normal haemoglobin does not exclude iron depletion.
+
+If iron deficiency or anaemia is confirmed, iron replacement may be recommended. Treating the underlying cause of heavy bleeding is an essential part of restoring iron levels long-term.
+
+For more on fatigue and its causes, see [Why Am I Always Tired?](/guides/why-am-i-always-tired). For more on heavy periods and their investigation, see [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help).
+
+---
+
+## Fibroids and Fertility
+
+Most people with fibroids can become pregnant without difficulty, and many pregnancies occur with fibroids present and cause no problems at all.
+
+However, fibroid location matters:
+
+- **Submucosal fibroids** (projecting into the uterine cavity) are most likely to affect fertility — they can interfere with implantation or increase the risk of early miscarriage
+- **Intramural fibroids** may affect fertility in some circumstances, depending on size and proximity to the uterine cavity
+- **Subserosal fibroids** generally have less impact on fertility
+
+If you are trying to conceive and have known fibroids, specialist review is advisable to assess whether the fibroid location or size is likely to be relevant. Treatment — particularly myomectomy (surgical removal of fibroids) — may be considered in selected cases, but this decision requires careful individual assessment.
+
+Fibroids and fertility is a nuanced area. Decisions should be made collaboratively with a gynaecologist or fertility specialist who can review the specifics of your situation.
+
+---
+
+## Fibroids and Pregnancy
+
+Many pregnancies with fibroids progress entirely normally. However, fibroids may occasionally be associated with:
+
+- Pelvic pain during pregnancy, particularly if a fibroid undergoes degeneration (a process called red or carneous degeneration, often in the second trimester)
+- Increased risk of miscarriage in some circumstances
+- Placental complications depending on fibroid location
+- Preterm birth in some cases
+- Breech presentation or other malpresentation at term
+- Increased likelihood of caesarean birth, particularly with large or poorly positioned fibroids
+
+Most of these complications are uncommon. If you are pregnant and have fibroids, your obstetric team will monitor your pregnancy accordingly. Anxiety about fibroids and pregnancy is understandable, but most outcomes are good.
+
+Do not make decisions about pregnancy management based on fibroid concern alone — this is a conversation for your care team.
+
+---
+
+## Fibroids and Menopause
+
+Fibroids are driven by oestrogen and progesterone. After menopause, as hormone levels fall, **fibroids typically shrink** and symptoms often resolve without treatment. This is why watchful waiting is a reasonable option for people approaching menopause who have manageable symptoms.
+
+**Any vaginal bleeding after menopause requires medical assessment**, regardless of a previous fibroid diagnosis. Postmenopausal bleeding is not normal and must be investigated to exclude endometrial cancer and other causes — it should not be assumed to be fibroid-related without evaluation.
+
+See [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause) for more on the menopausal transition.
+
+---
+
+## Diagnosis
+
+### Clinical Assessment
+
+A thorough symptom history — including menstrual pattern, pain, pressure symptoms, and the impact on daily life — is the starting point. A pelvic examination may detect an enlarged or irregular uterus.
+
+### Blood Tests
+
+- **Full blood count and iron studies (ferritin)** — to assess for anaemia and iron deficiency
+- **Pregnancy test** — where relevant
+- **Thyroid function (TSH)** — thyroid disease can cause heavy or irregular periods and fatigue; testing may be appropriate if these symptoms are prominent (see [Thyroid Disease: Symptoms, Tests, and Treatment](/guides/thyroid-disease-overview))
+
+### Pelvic Ultrasound
+
+Ultrasound is the standard first-line imaging test for fibroids. It can confirm the presence of fibroids, their number, size, and location — and help guide treatment decisions. Transvaginal ultrasound (TVS) provides more detailed images than transabdominal ultrasound in most cases.
+
+### MRI
+
+MRI provides more detailed information about fibroid type and location and is used when surgical planning is needed, or when the ultrasound findings are complex.
+
+### Hysteroscopy or Sonohysterography
+
+These investigations allow direct visualisation or detailed imaging of the uterine cavity. They are particularly useful for identifying submucosal fibroids (those projecting into the cavity) that may not be fully characterised on standard ultrasound.
+
+### Differential Diagnosis
+
+Other conditions can cause similar symptoms and must be considered:
+
+- [Endometriosis](/guides/endometriosis) — pelvic pain and heavy periods; often coexists with fibroids
+- **Adenomyosis** — endometrial tissue within the uterine wall; causes heavy periods and an enlarged, tender uterus; often misidentified as fibroids
+- **Endometrial polyps** — benign growths of the uterine lining causing irregular bleeding
+- [PCOS](/guides/pcos) — irregular or heavy periods from anovulatory cycles
+- [Thyroid disease](/guides/thyroid-disease-overview) — hypothyroidism causes heavier, more frequent periods
+- **Pregnancy-related bleeding** — must be excluded when relevant
+- **Pelvic infection** — can cause pain and bleeding
+- **Endometrial hyperplasia or cancer** — must be considered in women over 40 with new, worsening, or postmenopausal bleeding
+
+---
+
+## Treatment Options
+
+Treatment depends on symptoms, fibroid size and location, fertility goals, proximity to menopause, and personal preferences. **Not all fibroids need treatment.**
+
+### Watchful Waiting
+
+For fibroids that are small, stable, and not causing significant symptoms, monitoring without active treatment is a reasonable and commonly recommended approach. Regular review — including symptoms and sometimes repeat imaging — allows treatment to be considered if things change.
+
+### Treating Associated Anaemia
+
+If heavy bleeding has caused iron deficiency anaemia, iron replacement (if prescribed) is an important part of care. Treating the bleeding itself is also necessary to prevent anaemia from recurring.
+
+### Medicines for Symptom Control
+
+**Tranexamic acid** — reduces heavy menstrual blood loss by reducing clot breakdown. Taken during periods only. Does not affect hormones or fertility.
+
+**NSAIDs (anti-inflammatory medicines)** — reduce blood loss and relieve period pain. Taken during menstruation.
+
+**Hormonal intrauterine system (LNG-IUS / Mirena)** — releases progestogen locally into the uterine cavity. Very effective for heavy bleeding and is often a first-line option for women wanting to preserve fertility or avoid surgery. Most effective for smaller fibroids that do not significantly distort the cavity.
+
+**Combined hormonal contraception (combined pill, patch, ring)** — regulates cycles and reduces blood loss. General contraceptive cautions apply.
+
+**Progestogen therapy** — oral or injectable progestogens can reduce bleeding in some women.
+
+**GnRH analogues and antagonists** — these medicines substantially reduce oestrogen levels, causing fibroids to shrink and periods to stop or become very light. They are effective but are typically used for a limited time (before surgery, or in specific circumstances) because of effects on bone density and menopausal-type side effects. GnRH antagonists (such as relugolix or elagolix) are newer options that may be used with add-back hormone therapy.
+
+Discuss specific medicine suitability, contraindications, and side effects with your clinician. See [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) for general guidance on medicines.
+
+### Minimally Invasive and Surgical Options
+
+**Uterine artery embolisation (UAE)** — a radiological procedure that blocks the blood supply to fibroids, causing them to shrink. It preserves the uterus and is performed through a small incision in the groin. Recovery is typically shorter than open surgery.
+
+**Myomectomy** — surgical removal of fibroids while preserving the uterus. Options include hysteroscopic myomectomy (for submucosal fibroids, performed through the vagina), laparoscopic myomectomy, or open (abdominal) myomectomy. Appropriate for women who want to preserve fertility or avoid hysterectomy.
+
+**Focused ultrasound (MRgFUS)** — uses focused ultrasound waves to destroy fibroid tissue without an incision. Availability is limited; not suitable for all fibroid types or locations.
+
+**Endometrial ablation** — destroys the uterine lining to reduce or stop periods. Effective for heavy bleeding but is not appropriate if fibroids are the primary cause or if there are large fibroids; not suitable for women wanting future pregnancy.
+
+**Hysterectomy** — surgical removal of the uterus; the only treatment that permanently ends fibroid symptoms and prevents recurrence. Used when other treatments have failed or are not appropriate, or when the person has completed childbearing and wishes a definitive solution.
+
+Treatment choice is not one-size-fits-all. Fibroid type, location, and size; severity of symptoms; desire for future pregnancy; proximity to menopause; and personal values all shape the decision.
+
+---
+
+## Questions to Ask Before Starting Treatment
+
+These questions can help guide a meaningful conversation with your clinician:
+
+1. What type and location are my fibroids — and are they likely to be causing my symptoms?
+2. Do I have anaemia? Do I need iron replacement?
+3. What are my fertility goals, and how do they affect the choice of treatment?
+4. What non-surgical options are available for my situation?
+5. If surgery is recommended, what are the risks, recovery time, and recurrence rates?
+6. What follow-up or monitoring will I need?
+7. If I choose watchful waiting, what would prompt a change in approach?
+
+---
+
+## When to Seek Urgent Help
+
+Seek emergency or urgent medical attention if you experience:
+
+- **Very heavy bleeding** — soaking through pads or tampons rapidly, or passing large blood clots
+- **Dizziness, fainting, or collapse** — suggesting significant blood loss or severe anaemia
+- **Severe pelvic or abdominal pain** — particularly if sudden or different from usual
+- **Fever with pelvic pain** — may suggest infection
+- **Bleeding during pregnancy** or sudden worsening pain in a known pregnancy with fibroids
+- **Postmenopausal bleeding** — any vaginal bleeding after menopause requires urgent assessment to exclude endometrial cancer
+- **Chest pain, severe breathlessness at rest, or collapse** — may indicate severe anaemia or another emergency
+
+If you are uncertain whether your symptoms need urgent attention, seek medical assessment promptly rather than waiting.
+
+---
+
+## FAQ
+
+**What are uterine fibroids?**
+Uterine fibroids are non-cancerous growths of muscle and fibrous tissue that develop in or around the uterus. They are common and do not always cause symptoms.
+
+**Are fibroids cancer?**
+Fibroids are usually benign and are not cancer. Rare cancers can arise in the uterus, but most fibroids are non-cancerous. New, rapidly changing, or unusual symptoms should always be assessed by a clinician.
+
+**What symptoms can fibroids cause?**
+Fibroids can cause heavy or prolonged periods, pelvic pressure or bloating, pelvic or lower back pain, frequent urination, constipation, pain during sex, and in some cases fertility or pregnancy complications.
+
+**Do all fibroids need treatment?**
+No. Fibroids that are small, stable, and not causing symptoms may only need monitoring. Treatment depends on symptoms, fibroid size and location, age, fertility goals, and overall health.
+
+**When should I seek urgent help for fibroid symptoms?**
+Seek urgent help for very heavy bleeding, fainting or dizziness, severe pelvic pain, fever, bleeding in pregnancy, postmenopausal bleeding, or symptoms of severe anaemia such as chest pain, breathlessness, or collapse.
+
+---
+
+## Further Reading
+
+- [NHS — Fibroids](https://www.nhs.uk/conditions/fibroids/) — UK national health guidance on fibroids, causes, symptoms, and treatment
+- [Mayo Clinic — Uterine Fibroids](https://www.mayoclinic.org/diseases-conditions/uterine-fibroids/symptoms-causes/syc-20354288) — overview of causes, diagnosis, and treatment options
+- [ACOG — Uterine Fibroids Patient FAQ](https://www.acog.org/womens-health/faqs/uterine-fibroids) — American College of Obstetricians and Gynecologists patient resource
+- [Office on Women's Health — Uterine Fibroids](https://www.womenshealth.gov/a-z-topics/uterine-fibroids) — US government women's health resource
+- [Healthdirect — Uterine Fibroids (Australia)](https://www.healthdirect.gov.au/uterine-fibroids) — Australian health information service
+
+---
+
+## Related Guides
+
+- [Women's Health Hub](/guides/womens-health-hub) — central hub for women's health content on PatientGuide
+- [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help) — the most common fibroid symptom; causes, investigation, and treatment
+- [Endometriosis: Symptoms, Diagnosis, and Treatment Options](/guides/endometriosis) — often coexists with fibroids; shares pelvic pain and heavy bleeding as symptoms
+- [PCOS: Understanding Polycystic Ovary Syndrome](/guides/pcos) — another common cause of irregular or heavy periods and fertility concerns
+- [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause) — fibroids typically shrink after menopause; postmenopausal bleeding always needs assessment
+- [Perimenopause: What to Expect](/guides/perimenopause-what-to-expect) — new or worsening heavy bleeding in the 40s warrants assessment
+- [Thyroid Disease: Symptoms, Tests, and Treatment](/guides/thyroid-disease-overview) — hypothyroidism can cause heavy or irregular periods and should be included in the differential
+- [Why Am I Always Tired?](/guides/why-am-i-always-tired) — fatigue from anaemia secondary to heavy periods is common; practical guide to investigating persistent tiredness
+- [Medication Safety: How to Avoid Common Medicine Problems](/guides/medication-safety) — safe use of hormonal medicines, iron replacement, NSAIDs, and tranexamic acid
+- [Preventive Screening Hub](/guides/preventive-screening-hub) — diagnostic evaluation when symptoms of abnormal bleeding or pelvic symptoms arise
+
+---
+
+*Educational only; not a substitute for professional medical advice. Decisions about fibroid treatment should be made with your clinical care team based on your individual circumstances.*

--- a/src/content/guides/why-am-i-always-tired.md
+++ b/src/content/guides/why-am-i-always-tired.md
@@ -255,6 +255,8 @@ A: No. CFS/ME is a specific diagnosed condition with distinct clinical criteria 
 - [Chronic Fatigue Syndrome](/guides/chronic-fatigue)
 - [Post-Viral Syndromes](/guides/post-viral-syndromes)
 - [Thyroid Disease: Symptoms, Tests, and Treatment](/guides/thyroid-disease-overview)
+- [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids) — heavy periods from fibroids are a common cause of iron deficiency anaemia and fatigue in women
+- [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help) — heavy menstrual bleeding is the leading cause of iron deficiency anaemia in women of reproductive age
 
 ---
 

--- a/src/content/guides/womens-health-hub.md
+++ b/src/content/guides/womens-health-hub.md
@@ -121,7 +121,10 @@ Irregular periods can indicate PCOS, [thyroid dysfunction](/guides/thyroid-disea
 Vasomotor symptoms affect around 75% of women during the menopausal transition, on average for 7 years. They can begin during perimenopause — sometimes years before periods stop. See [Menopause: Symptoms, Stages, and What to Expect](/guides/menopause) and [Perimenopause: What to Expect](/guides/perimenopause-what-to-expect).
 
 ### Heavy or Prolonged Periods
-Heavy menstrual bleeding is one of the most common gynaecological complaints and a leading cause of iron deficiency anaemia in women. See [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help).
+Heavy menstrual bleeding is one of the most common gynaecological complaints and a leading cause of iron deficiency anaemia in women. Uterine fibroids are among the most frequent causes — see [Heavy Periods: When to Seek Help](/guides/heavy-periods-when-to-seek-help) and [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids).
+
+### Pelvic Pain and Pressure
+Pelvic pain and pressure have multiple causes — endometriosis, adenomyosis, fibroids, and PCOS among them. See [Endometriosis: Symptoms, Diagnosis, and Treatment Options](/guides/endometriosis) and [Uterine Fibroids: Heavy Periods, Pelvic Pressure, and Treatment Options](/guides/uterine-fibroids).
 
 ---
 


### PR DESCRIPTION
## Summary

* Adds a comprehensive patient-facing uterine fibroids guide (`src/content/guides/uterine-fibroids.md`) — symptoms, heavy bleeding, anaemia, pelvic pressure, fibroid types, fertility and pregnancy considerations, menopause effects, diagnosis (including differential), treatment options, and urgent red flags
* Wires fibroids into the Women's Health hub (new Pelvic Pain and Pressure section), heavy-periods, endometriosis, PCOS, menopause, fatigue, thyroid, and medication-safety clusters
* Category: Women's Health; 5 FAQ items; full Further Reading from NHS, Mayo Clinic, ACOG, OWH, and Healthdirect

## Checks

* `npm run content:check` — 0 errors, 13 warnings (baseline unchanged)
* `npm run build` — 769 pages, 0 errors
* Route `/guides/uterine-fibroids/` confirmed generated