### PR TITLE
fix(ask): improve PAD retrieval for walking leg pain queries

### DIFF
--- a/netlify/functions/retrieval.mjs
+++ b/netlify/functions/retrieval.mjs
@@ -162,6 +162,19 @@ function preprocessQuery(text) {
     .replace(/\bcva\b/gi, "stroke cerebrovascular accident")
     .replace(/\bcabg\b/gi, "coronary artery bypass grafting surgery")
     .replace(/\bpci\b/gi, "percutaneous coronary intervention angioplasty stent")
+    // Vascular / claudication — intermittent leg pain on walking
+    // Maps plain-English descriptions of claudication to the clinical terms
+    // used in the PAD guide (claudication, PAD, peripheral artery disease).
+    // Order: more-specific multi-word phrases before bare "claudication".
+    .replace(/\bleg\s+pain\s+(?:when|while|during|after|on|with)\s+(?:walking|exercise|exertion|activity)\b/gi,
+      "leg pain walking claudication peripheral artery disease PAD circulation")
+    .replace(/\bcalf\s+pain\s+(?:when|while|during|after|on|with)\s+(?:walking|exercise|exertion|activity)\b/gi,
+      "calf pain walking claudication peripheral artery disease PAD circulation")
+    .replace(/\bpain\s+in\s+(?:my\s+)?(?:calf|calves?|leg|legs)\s+(?:when|while|during|after|with)\s+(?:walking|exercise|exertion|activity)\b/gi,
+      "leg pain walking claudication peripheral artery disease PAD circulation")
+    .replace(/\bleg\s+pain\s+(?:better|goes?\s+away|improves?|relieves?|eases?)\s+(?:with|after|when|at)\s+rest\b/gi,
+      "claudication peripheral artery disease PAD leg pain rest")
+    .replace(/\bclaudication\b/gi, "claudication peripheral artery disease PAD leg pain walking")
     // Blood pressure / hypertension
     .replace(/\bhtn\b/gi, "hypertension high blood pressure")
     .replace(/\b(?<![a-z])bp(?![a-z])\b/gi, "blood pressure")
@@ -218,10 +231,13 @@ const _regexCache = new Map();
 function termRegex(term) {
   if (!_regexCache.has(term)) {
     const esc = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    // Negative lookbehind: the term must not be immediately preceded by [a-z0-9].
-    // No positive lookahead, so plurals and inflected forms still match
-    // (e.g. query term "antidepressant" hits document token "antidepressants").
-    _regexCache.set(term, new RegExp(`(?<![a-z0-9])${esc}`, "i"));
+    // Lookbehind: term must not be immediately preceded by [a-z0-9].
+    // Lookahead (?![a-z]{5,}): allows up to 4 trailing letters so common medical
+    // inflections still match ("treat"→"treatment" +4, "rest"→"resting" +3,
+    // "antidepressant"→"antidepressants" +1) but blocks false prefix matches where
+    // the term is a short stem of an unrelated word ("leg" must not hit
+    // "Legionnaires" +9 chars or "legionella" +7 chars).
+    _regexCache.set(term, new RegExp(`(?<![a-z0-9])${esc}(?![a-z]{5,})`, "i"));
   }
   return _regexCache.get(term);
 }
@@ -270,7 +286,12 @@ export function scoreItem(item, queryTerms) {
 //
 // A result is shown as a link only when:
 //   - 2+ distinct query terms appear in title / tags / headings (high-signal fields), OR
-//   - the item's raw score is very high (≥ 15), indicating a strong overall match
+//   - the item's raw score is very high (≥ 20), indicating a strong multi-term match
+//
+// The ≥ 20 threshold is intentionally above the maximum score a single query term
+// can accumulate across all fields (title 6 + desc 3 + tags 3 + headings 2 + FAQ 2
+// + excerpt 1 = 17), so only items where at least two query terms contributed can
+// bypass the high-signal-hit check.
 //
 // Single-term queries bypass the filter entirely — nothing to cross-check against.
 // ---------------------------------------------------------------------------
@@ -285,7 +306,7 @@ export function filterDisplayLinks(results, queryTerms) {
   const required = queryTerms.length >= 3 ? 2 : 1;
 
   const filtered = results.filter((item) => {
-    if (item.score >= 15) return true; // already strongly grounded
+    if (item.score >= 20) return true; // strong multi-term match
     const title    = item.title.toLowerCase();
     const tags     = (item.tags     || []).map((t) => t.toLowerCase());
     const headings = (item.headings || []).map((h) => h.toLowerCase());

--- a/src/lib/chatbot/eval.mjs
+++ b/src/lib/chatbot/eval.mjs
@@ -407,6 +407,22 @@ const TEST_CASES = [
   { q: "someone is convulsing on the floor",
     expected: "urgent",
     note: "URGENT_PATTERNS /convuls/ still fires; bystander emergency framing" },
+
+  // --- Vascular / PAD / claudication ---
+  // PAD guide title has "Leg Pain" + "Circulation"; tags include claudication, PAD, leg pain.
+  // Claudication expansion boosts PAD above generic coincidence matches.
+  { q: "leg pain when walking",
+    expected: "grounded",
+    note: "PAD guide scores strongly; claudication expansion suppresses false-prefix 'leg'→'Legionnaires' match" },
+  { q: "calf pain when walking",
+    expected: "grounded",
+    note: "PAD FAQ covers calf claudication; expansion adds claudication + PAD terms" },
+  { q: "leg pain better with rest",
+    expected: "grounded",
+    note: "classic claudication pattern — expansion boosts PAD guide strongly" },
+  { q: "diabetes foot sore not healing",
+    expected: "grounded",
+    note: "PAD guide covers slow-healing wounds + diabetes risk; diabetic foot care content also scores" },
 ];
 
 // ---------------------------------------------------------------------------
@@ -503,6 +519,11 @@ const LINK_QUALITY_CASES = [
     mustNotBeOnlyToken: "problems",
     note: "displayed links must not match on 'problems' alone",
   },
+  {
+    q: "leg pain when walking",
+    mustNotBeOnlyToken: "pain",
+    note: "Legionnaires and anxiety/abdominal-pain guides must not appear via generic 'pain' match alone",
+  },
 ];
 
 console.log(`Link Quality Checks`);
@@ -553,7 +574,7 @@ console.log(`Link quality: ${lqPass}/${LINK_QUALITY_CASES.length} passed, ${lqFa
 const M = {
   titleAndTag: { title: "Acid Reflux and Chest Discomfort", tags: ["acid reflux", "chest"], headings: [], score: 12 },
   tagOnly:     { title: "Nutrition During Cancer Treatment", tags: ["nutrition", "eating", "cancer"], headings: [], score: 8 },
-  highScore:   { title: "Blood Pressure Overview", tags: ["blood pressure"], headings: [], score: 16 },
+  highScore:   { title: "Blood Pressure Overview", tags: ["blood pressure"], headings: [], score: 20 },
   noMatch:     { title: "General Wellness Tips", tags: ["wellness"], headings: [], score: 4 },
   headingOnly: { title: "Sleep Overview", tags: ["sleep"], headings: ["chest pain during sleep"], score: 9 },
 };
@@ -622,7 +643,7 @@ console.log(SEP);
   const terms   = ["chest", "discomfort", "eating"];
   const results = [M.highScore]; // score=16, no matching terms
   const out     = filterDisplayLinks(results, terms);
-  uAssert("high-score bypass: score≥15 always passes", out.length, 1);
+  uAssert("high-score bypass: score≥20 always passes", out.length, 1);
 }
 
 // 5. Title-match ordering: item with title hit comes before item without.


### PR DESCRIPTION
## Summary

- Fixes "leg pain when walking" returning irrelevant cards (Legionnaires' Disease, When Anxiety Causes Abdominal Pain in Children) alongside the correct PAD guide
- Three orthogonal, non-breaking changes to `netlify/functions/retrieval.mjs`; four new eval cases + one link quality case in `src/lib/chatbot/eval.mjs`
- Does not touch medical content, safety patterns, urgency routing, or the Claude prompt

## Root cause

The query `"leg pain when walking"` tokenises to `["leg", "pain", "walking"]`.

| Problem | Mechanism |
|---|---|
| **Legionnaires' Disease** appearing | `termRegex` had no trailing word-boundary check, so the 3-letter token `"leg"` matched the prefix of `"Legionnaires"` and `"legionella"`, inflating that guide's score to 17 and triggering the `>=15` display-filter bypass |
| **Anxiety/Abdominal Pain (children)** appearing | The generic token `"pain"` accumulates up to 17 points across title + desc + tags + headings + FAQ + excerpt, also bypassing the `>=15` threshold despite having only 1 high-signal hit |

## Changes

### 1. `termRegex` trailing lookahead (`(?![a-z]{5,})`)

Allows up to 4 trailing letters (so `"treat"→"treatment"`, `"rest"→"resting"`, `"antidepressant"→"antidepressants"` all still work) but blocks 5+ char extensions, eliminating `"leg"→"Legionnaires"` (+9) and `"leg"→"legionella"` (+7).

### 2. Claudication/PAD synonym expansion in `preprocessQuery`

Five patterns map plain-English walking-leg-pain descriptions to the clinical vocabulary in the PAD guide:
- `"leg pain when walking"` → `"leg pain walking claudication peripheral artery disease PAD circulation"`
- `"calf pain when walking"` → same
- `"pain in leg/calf when walking"` → same
- `"leg pain better with rest"` → `"claudication peripheral artery disease PAD leg pain rest"`
- bare `"claudication"` → full PAD synonym set

PAD guide score for this query rises from 40 → **122**.

### 3. `filterDisplayLinks` bypass threshold `>=15` → `>=20`

The maximum a single query term can score across all fields is 17 (title 6 + desc 3 + tags 3 + headings 2 + FAQ 2 + excerpt 1 = 17). Raising the bypass to 20 ensures that at least two query terms must have contributed before a result can skip the high-signal-hit check — eliminating single-generic-word bypasses.

## Before / after (display links for "leg pain when walking")

| # | Before | After |
|---|---|---|
| 1 | Peripheral Artery Disease ✅ | Peripheral Artery Disease ✅ |
| 2 | When Anxiety Causes Abdominal Pain in Children ❌ | Diabetic Foot Care ✅ |
| 3 | Legionnaires' Disease ❌ | Heart & Circulation Overview ✅ |
| 4 | Managing Chronic Back Pain ⚠️ | Restless Legs Syndrome ⚠️ |

## Checks

- `npm run content:check` — 0 errors (13 pre-existing warnings unchanged)
- Chatbot eval: **117/119** main cases pass (2 pre-existing failures unchanged); **4/4** link quality (was 2/3 — pre-existing "chest discomfort after eating" failure also resolved by the bypass change); 13/13 unit tests; 22/22 classification boundary; 10/10 isInformationalAboutEmergency
- 4 new PAD test cases all pass; 1 new link quality case passes
- No safety patterns, urgency routing, or response modes changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
