### PR TITLE
content(author): add context engineer role

### DIFF
--- a/src/content/guides/ai-in-healthcare.mdx
+++ b/src/content/guides/ai-in-healthcare.mdx
@@ -9,7 +9,7 @@ draft: false
 author:
   name: "Michael J Whitley"
   href: "/authors/michael-j-whitley"
-  role: "Editor, PatientGuide"
+  role: "Editor & Context Engineer, PatientGuide"
 faq:
   - q: "What is artificial intelligence in healthcare?"
     a: "AI in healthcare refers to computer systems that analyse medical data to support diagnosis, treatment planning, and administrative tasks — including tools that read medical images, flag abnormal test results, and assist with clinical decisions."

--- a/src/content/guides/how-to-use-ai-for-health-questions.mdx
+++ b/src/content/guides/how-to-use-ai-for-health-questions.mdx
@@ -9,7 +9,7 @@ draft: false
 author:
   name: "Michael J Whitley"
   href: "/authors/michael-j-whitley"
-  role: "Editor, PatientGuide"
+  role: "Editor & Context Engineer, PatientGuide"
 faq:
   - q: "Is it safe to use AI for health information?"
     a: "AI tools can provide useful general health information but are not a substitute for clinical assessment. For specific symptoms, diagnoses, or treatment decisions, consult a clinician."

--- a/src/content/guides/longevity-interventions-evidence.mdx
+++ b/src/content/guides/longevity-interventions-evidence.mdx
@@ -20,7 +20,7 @@ faq:
 author:
   name: "Michael J Whitley"
   href: "/authors/michael-j-whitley"
-  role: "Editor, PatientGuide"
+  role: "Editor & Context Engineer, PatientGuide"
 ---
 
 ## Intro

--- a/src/content/guides/vaccination-overview.mdx
+++ b/src/content/guides/vaccination-overview.mdx
@@ -9,7 +9,7 @@ draft: false
 author:
   name: "Michael J Whitley"
   href: "/authors/michael-j-whitley"
-  role: "Editor, PatientGuide"
+  role: "Editor & Context Engineer, PatientGuide"
 faq:
   - q: "Do vaccines wear off?"
     a: "Some vaccines provide lifelong immunity, while others require boosters. Immunity can decline over time, and pathogens can evolve. Booster doses restore protection when needed — for example, tetanus and pertussis boosters in adolescence and adulthood, and updated influenza vaccines each year."

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -48,6 +48,11 @@ const frontmatter = {
       industry funding that could influence what we publish or how we frame it.
       If that ever changes, we will disclose it clearly on every affected page.
     </p>
+    <p>
+      PatientGuide.io is developed and maintained by Michael J Whitley, an
+      editor and Context Engineer focused on building clearer, safer,
+      AI-assisted health information systems for patients and families.
+    </p>
 
     <h2>Learn more</h2>
     <ul>

--- a/src/pages/authors/michael-j-whitley.astro
+++ b/src/pages/authors/michael-j-whitley.astro
@@ -3,30 +3,33 @@ import Layout from "@/layouts/Layout.astro";
 import SchemaPerson from "@/components/SchemaPerson.astro";
 
 const frontmatter = {
-  title: "Michael J Whitley — Editor, PatientGuide",
+  title: "Michael J Whitley — Editor & Context Engineer, PatientGuide",
   description:
-    "Michael J Whitley is the editor of PatientGuide.io, focusing on AI in healthcare, evidence literacy, and preventive health.",
+    "Michael J Whitley is the editor and Context Engineer behind PatientGuide.io, working across health information architecture, guide taxonomy, AI-assisted editorial systems, and patient-facing guidance.",
 };
 ---
 
 <Layout frontmatter={frontmatter}>
   <SchemaPerson
     name="Michael J Whitley"
-    jobTitle="Editor"
-    description="Editor of PatientGuide.io, focusing on AI in healthcare, evidence literacy, and preventive health."
+    jobTitle="Editor & Context Engineer"
+    description="Editor and Context Engineer at PatientGuide.io, working across health information architecture, guide taxonomy, AI-assisted editorial systems, and patient-facing guidance."
     url="https://patientguide.io/authors/michael-j-whitley"
     sameAs={[]}
   />
 
   <article class="prose">
     <h1>Michael J Whitley</h1>
-    <p class="text-lg text-gray-600">Editor, PatientGuide</p>
+    <p class="text-lg text-gray-600">Editor &amp; Context Engineer, PatientGuide</p>
 
     <h2>About</h2>
     <p>
-      Michael J Whitley is the editor of PatientGuide.io. He oversees the
-      site's editorial direction and works to ensure that every guide is clear,
-      evidence-based, and useful for patients navigating real health decisions.
+      Michael J Whitley is the editor and Context Engineer behind PatientGuide.io,
+      shaping the site's health information architecture, guide taxonomy,
+      AI-assisted editorial workflows, and patient-facing content systems. His
+      work focuses on helping people find clear, reliable, and context-aware
+      health guidance across symptoms, conditions, treatments, prevention, and
+      care pathways.
     </p>
 
     <h2>Focus areas</h2>


### PR DESCRIPTION
## Summary

- Update Michael J Whitley's author page: title, meta description, SchemaPerson jobTitle/description, visible subtitle, and bio copy to reflect the Context Engineer role
- Add a single restrained attribution sentence to the About page under Editorial independence
- Update \`role\` frontmatter in 4 selected guides for consistency

## Checks

- \`npm run content:check\` — PASSED (0 errors, 13 pre-existing FAQ warnings unrelated to this change)
- \`npm run build\` — Complete (0 errors)

## Files changed

| File | Change |
|------|--------|
| \`src/pages/authors/michael-j-whitley.astro\` | Title, meta, schema, subtitle, body copy |
| \`src/pages/about.astro\` | One sentence added under Editorial independence |
| \`src/content/guides/ai-in-healthcare.mdx\` | \`role\` field updated |
| \`src/content/guides/how-to-use-ai-for-health-questions.mdx\` | \`role\` field updated |
| \`src/content/guides/longevity-interventions-evidence.mdx\` | \`role\` field updated |
| \`src/content/guides/vaccination-overview.mdx\` | \`role\` field updated |

## Not changed

Footer, homepage, advertise/Work With Us, Editorial Standards, How We Review Evidence, sponsored-content-policy, post template default author.