### PR TITLE
fix(hero): highlight mental health toolkit card in blue

### DIFF
--- a/src/components/HeroPage.astro
+++ b/src/components/HeroPage.astro
@@ -90,7 +90,7 @@ const frontmatter = {
         <h2 class="hero-page__section-title">Featured Guides</h2>
         <div class="hero-page__clusters">
           {config.featuredClusters.map((cluster: FeaturedCluster) => (
-            <a href={cluster.href} class="hero-page__cluster-card">
+            <a href={cluster.href} class:list={["hero-page__cluster-card", { "hero-page__cluster-card--primary": cluster.primary }]}>
               <h3 class="hero-page__cluster-title">{cluster.title}</h3>
               <p class="hero-page__cluster-desc">{cluster.description}</p>
             </a>
@@ -253,6 +253,54 @@ const frontmatter = {
     border-color: var(--pg-link, #2563eb);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
     text-decoration: none;
+  }
+
+  /* Mental Health Toolkit CTA — blue accent */
+  .hero-page__cluster-card--primary {
+    background: var(--pg-link, #2563eb);
+    border-color: var(--pg-link, #2563eb);
+  }
+
+  .hero-page__cluster-card--primary .hero-page__cluster-title {
+    color: #ffffff;
+  }
+
+  .hero-page__cluster-card--primary .hero-page__cluster-desc {
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .hero-page__cluster-card--primary:hover {
+    background: var(--pg-link-hover, #1d4ed8);
+    border-color: var(--pg-link-hover, #1d4ed8);
+    box-shadow: 0 2px 8px rgba(37, 99, 235, 0.25);
+  }
+
+  .hero-page__cluster-card--primary:hover .hero-page__cluster-title {
+    color: #ffffff;
+  }
+
+  /* Dark mode: use a deep blue (#1e40af) so white text clears WCAG AA.
+     The dark-mode --pg-link (#60a5fa) is too pale for a filled bg. */
+  html[data-theme="dark"] .hero-page__cluster-card--primary {
+    background: #1e40af;
+    border-color: #1e40af;
+  }
+
+  html[data-theme="dark"] .hero-page__cluster-card--primary:hover {
+    background: #2563eb;
+    border-color: #2563eb;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .hero-page__cluster-card--primary {
+      background: #1e40af;
+      border-color: #1e40af;
+    }
+
+    :root:not([data-theme="light"]) .hero-page__cluster-card--primary:hover {
+      background: #2563eb;
+      border-color: #2563eb;
+    }
   }
 
   .hero-page__cluster-title {

--- a/src/lib/hero-pages.ts
+++ b/src/lib/hero-pages.ts
@@ -1,10 +1,10 @@
 // src/lib/hero-pages.ts
 // Centralised configuration for all hero pages (category landing pages)
-
 export interface FeaturedCluster {
   title: string;
   description: string;
   href: string;
+  primary?: boolean;
 }
 
 export interface GuideGroup {
@@ -195,6 +195,7 @@ export const HERO_PAGES: Record<string, HeroPageConfig> = {
         title: "Mental Health Toolkit",
         description: "Evidence-based habits that support mood and resilience.",
         href: "/guides/mental-health-toolkit",
+        primary: true,
       },
       {
         title: "Crisis Support",


### PR DESCRIPTION
## Summary
- Add a visual-only `primary` flag for featured hero clusters
- Mark the Mental Health Toolkit cluster as primary
- Style the primary cluster card in PatientGuide blue instead of the dark surface background
- Use accessible dark-mode blue that passes contrast for white text

## Accessibility
- Light mode blue: `#2563eb` (`var(--pg-link)`) with white text — 5.2:1 (WCAG AA ✓)
- Dark mode resting blue: `#1e40af` with white text — 8.7:1 (WCAG AAA ✓)
- Dark mode hover: `#2563eb` with white text — 5.2:1 (WCAG AA ✓)
- (Previous dark-mode token `#60a5fa` failed at 2.5:1 — now fixed)

## Safety
- `primary?: boolean` is visual-only — no routing, schema, search indexing, API, or page generation impact
- Only the Mental Health Toolkit cluster card is affected; all other featured cluster cards on all hub pages are unchanged
- No guide/post typography changed

## Checks
- `npm run content:check` — ✅ 0 errors
- `npm run build` — ✅ 770 pages, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)