### PR TITLE
feat(x402): add testnet payment-gated worker experiment

### DIFF
--- a/cloudflare/x402-worker/.env.example
+++ b/cloudflare/x402-worker/.env.example
@@ -1,0 +1,41 @@
+# x402 Cloudflare Worker — environment variable template
+#
+# For local development:
+#   Copy this file to .dev.vars (Wrangler picks it up automatically)
+#   .dev.vars is gitignored — never commit real values
+#
+# For production (Cloudflare dashboard or CLI):
+#   wrangler secret put X402_RECEIVING_ADDRESS
+#   wrangler secret put X402_FACILITATOR_URL
+#   wrangler secret put PATIENTGUIDE_ORIGIN
+#   wrangler secret put X402_WORKER_SECRET
+#
+# NOTE: X402_NETWORK and X402_PRICE_USDC are plain [vars] in wrangler.toml.
+# Only sensitive values need to be secrets.
+
+# ── Network (TESTNET ONLY) ─────────────────────────────────────────────────────
+# Do NOT change this to "base" or "ethereum" — that would enable real payments.
+X402_NETWORK=base-sepolia
+
+# ── Testnet receiving address ──────────────────────────────────────────────────
+# A wallet address you control on Base Sepolia.
+# No private key is needed here — only the public address.
+X402_RECEIVING_ADDRESS=0xREPLACE_WITH_TESTNET_RECEIVING_ADDRESS
+
+# ── Price per request (testnet USDC — no real value) ──────────────────────────
+X402_PRICE_USDC=0.001
+
+# ── x402 facilitator URL ───────────────────────────────────────────────────────
+# The official CDP / x402.org facilitator endpoint.
+# Check https://x402.org or https://docs.cdp.coinbase.com for the current URL.
+# Example (verify this is current before using):
+#   X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_FACILITATOR_URL=REPLACE_WITH_OFFICIAL_CDP_OR_X402_FACILITATOR_URL
+
+# ── Origin (Netlify) base URL ──────────────────────────────────────────────────
+PATIENTGUIDE_ORIGIN=https://patientguide.io
+
+# ── Shared Worker→Origin secret ───────────────────────────────────────────────
+# Prevents direct access to the Netlify function, bypassing the payment gate.
+# Generate with: openssl rand -hex 32
+X402_WORKER_SECRET=REPLACE_WITH_RANDOM_HEX_SECRET

--- a/cloudflare/x402-worker/.gitignore
+++ b/cloudflare/x402-worker/.gitignore
@@ -1,0 +1,9 @@
+# Wrangler local state and secrets
+.wrangler/
+.dev.vars
+
+# Dependencies
+node_modules/
+
+# Environment
+.env

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -1,0 +1,218 @@
+# PatientGuide x402 Testnet Worker
+
+> **Status: TESTNET ONLY — Base Sepolia**
+> This worker is a payment-gating experiment using the x402 protocol on Base Sepolia
+> testnet USDC. No real funds are involved. Mainnet is not configured.
+
+---
+
+## What is x402?
+
+[x402](https://x402.org) is an open HTTP payment protocol built on top of the
+standard `402 Payment Required` status code. A client that wants to access a
+gated resource:
+
+1. Makes an initial request → receives a `402` response with a JSON
+   `X-PAYMENT-REQUIRED` header describing how to pay (token, amount, address).
+2. Signs a USDC transfer authorisation (EIP-3009 `transferWithAuthorization`)
+   without broadcasting it to the chain.
+3. Re-sends the request with the signed authorisation in an `X-PAYMENT` header.
+4. The server verifies and settles the payment via a **facilitator** (Coinbase CDP),
+   then returns the protected resource.
+
+The whole flow happens in one HTTP round-trip for the caller.
+
+---
+
+## Architecture for this experiment
+
+```
+Browser / curl / x402 client
+        │
+        │  GET /api/x402/ping
+        ▼
+┌─────────────────────────────┐
+│  Cloudflare Worker          │  ← this project
+│  patientguide.io/api/x402/* │
+│                             │
+│  1. No X-PAYMENT → 402      │
+│  2. Verify via facilitator  │
+│  3. Settle via facilitator  │
+│  4. Proxy to Netlify fn     │
+└─────────┬───────────────────┘
+          │  GET /.netlify/functions/x402-ping
+          │  + X-Worker-Secret header
+          ▼
+┌─────────────────────────────┐
+│  Netlify Function           │
+│  netlify/functions/         │
+│  x402-ping.ts               │
+│                             │
+│  Returns { ok, paid, ... }  │
+└─────────────────────────────┘
+```
+
+**Public routes are untouched.** The Cloudflare route binding in `wrangler.toml`
+restricts the Worker exclusively to `patientguide.io/api/x402/*`. All other paths
+(`/`, `/guides/*`, `/posts/*`, `/search/*`, `sitemap.xml`, `robots.txt`,
+`llms.txt`) continue to be served directly from Netlify.
+
+---
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `cloudflare/x402-worker/src/index.ts` | Worker entry point — x402 gate logic |
+| `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config and route binding |
+| `cloudflare/x402-worker/.env.example` | Environment variable template |
+| `netlify/functions/x402-ping.ts` | Origin endpoint called after payment clears |
+
+---
+
+## Setup and deployment
+
+### Prerequisites
+
+- Cloudflare account with `patientguide.io` zone
+- Node.js ≥ 18
+- Wrangler CLI: `npm install -g wrangler` (or use the local one)
+- A Base Sepolia wallet address to receive testnet USDC
+
+### 1. Install dependencies
+
+```bash
+cd cloudflare/x402-worker
+npm install
+```
+
+### 2. Configure secrets
+
+Set each secret via Wrangler (they are stored in Cloudflare, never in this repo):
+
+```bash
+# Your Base Sepolia receiving address (public, no private key)
+wrangler secret put X402_RECEIVING_ADDRESS
+
+# Official CDP / x402.org facilitator base URL
+# Check https://x402.org or https://docs.cdp.coinbase.com for the current value
+wrangler secret put X402_FACILITATOR_URL
+
+# Netlify origin base URL
+wrangler secret put PATIENTGUIDE_ORIGIN
+# → enter: https://patientguide.io
+
+# Random hex secret shared between the Worker and the Netlify function
+# Generate: openssl rand -hex 32
+wrangler secret put X402_WORKER_SECRET
+```
+
+Set the same `X402_WORKER_SECRET` value as a Netlify environment variable
+(`Site settings → Environment variables → Add variable`).
+
+### 3. Local development
+
+Copy `.env.example` to `.dev.vars` (Wrangler loads this automatically):
+
+```bash
+cp .env.example .dev.vars
+# Edit .dev.vars with real testnet values
+```
+
+Run the Worker locally:
+
+```bash
+npm run dev
+# Worker starts at http://localhost:8787
+```
+
+Test without payment (should return 402):
+
+```bash
+curl -i http://localhost:8787/api/x402/ping
+```
+
+### 4. Deploy to Cloudflare
+
+```bash
+npm run deploy
+```
+
+Wrangler reads `wrangler.toml` and registers the route binding automatically.
+
+### 5. Configure Cloudflare route (if not auto-registered)
+
+In the Cloudflare dashboard → **Workers & Pages → your worker → Triggers → Routes**:
+
+- Route: `patientguide.io/api/x402/*`
+- Zone: `patientguide.io`
+
+### 6. Verify the live endpoint
+
+```bash
+# Should return 402 with X-PAYMENT-REQUIRED header
+curl -i https://patientguide.io/api/x402/ping
+
+# Expected 402 body (formatted):
+# {
+#   "x402Version": 1,
+#   "accepts": [{ "scheme": "exact", "network": "base-sepolia", ... }],
+#   "error": "Payment required ..."
+# }
+```
+
+---
+
+## How to disable / remove the route
+
+**Temporary disable (keep the Worker, stop receiving traffic):**
+
+In `wrangler.toml`, comment out the `[[routes]]` block:
+
+```toml
+# [[routes]]
+#   pattern = "patientguide.io/api/x402/*"
+#   zone_name = "patientguide.io"
+```
+
+Then redeploy:
+
+```bash
+npm run deploy
+```
+
+**Full removal:**
+
+```bash
+wrangler delete
+```
+
+This deletes the Worker from Cloudflare entirely. The Netlify function
+(`netlify/functions/x402-ping.ts`) can be removed from the codebase separately.
+No other Astro/Netlify config needs to change.
+
+---
+
+## Environment variables reference
+
+| Variable | Where | Description |
+|---|---|---|
+| `X402_NETWORK` | `wrangler.toml [vars]` | Chain identifier — must be `base-sepolia` |
+| `X402_PRICE_USDC` | `wrangler.toml [vars]` | Price per request in USDC decimal string |
+| `X402_RECEIVING_ADDRESS` | Wrangler secret | Your testnet wallet address |
+| `X402_FACILITATOR_URL` | Wrangler secret | CDP/x402 facilitator base URL |
+| `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` |
+| `X402_WORKER_SECRET` | Wrangler secret + Netlify env | Shared secret for Worker→function auth |
+
+---
+
+## Enabling mainnet (NOT for this PR)
+
+To move to mainnet, all of the following changes would be required:
+- Set `X402_NETWORK` to `base` (or another mainnet identifier)
+- Update `USDC_BASE_SEPOLIA` in `src/index.ts` to the mainnet USDC contract address
+- Update `X402_RECEIVING_ADDRESS` to a mainnet wallet
+- Update the Cloudflare route in `wrangler.toml`
+- A separate PR review with explicit sign-off
+
+This PR intentionally does none of the above.

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -37,7 +37,7 @@ Browser / curl / x402 client
 │                             │
 │  1. No X-PAYMENT → 402      │
 │  2. Verify via facilitator  │
-│  3. Settle via facilitator  │
+│  3. Settle via facilitator  │  ← required; failure → 402/502, no proxy
 │  4. Proxy to Netlify fn     │
 └─────────┬───────────────────┘
           │  GET /.netlify/functions/x402-ping
@@ -51,6 +51,11 @@ Browser / curl / x402 client
 │  Returns { ok, paid, ... }  │
 └─────────────────────────────┘
 ```
+
+**Settlement is required before origin access.** If the facilitator verifies a
+payment but settlement fails (network error, facilitator rejection, etc.), the
+Worker returns an error and does **not** proxy to the Netlify function. The
+resource is never served until payment is fully finalized.
 
 **Public routes are untouched.** The Cloudflare route binding in `wrangler.toml`
 restricts the Worker exclusively to `patientguide.io/api/x402/*`. All other paths
@@ -109,6 +114,11 @@ wrangler secret put X402_WORKER_SECRET
 
 Set the same `X402_WORKER_SECRET` value as a Netlify environment variable
 (`Site settings → Environment variables → Add variable`).
+
+> **Required before deploying:** `X402_WORKER_SECRET` must be configured in
+> Netlify before the Netlify function goes live. Without it, the function returns
+> `500 x402_origin_not_configured` in all deployed environments (it does not fall
+> back to open access).
 
 ### 3. Local development
 

--- a/cloudflare/x402-worker/package.json
+++ b/cloudflare/x402-worker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "patientguide-x402-worker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241022.0",
+    "typescript": "^5.6.3",
+    "wrangler": "^3.88.0"
+  }
+}

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -1,0 +1,201 @@
+/**
+ * PatientGuide x402 Testnet Worker
+ *
+ * SCOPE: Handles ONLY /api/x402/* — enforced both by wrangler.toml route binding
+ * and by the belt-and-suspenders guard at the top of fetch().
+ *
+ * Public routes (/, /guides/*, /posts/*, /search/*, sitemap, robots, llms) are
+ * never touched by this Worker because the Cloudflare route binding does not
+ * match them. The guard below is a second layer of protection.
+ *
+ * TESTNET ONLY: X402_NETWORK must be "base-sepolia". The code does not enforce
+ * this at runtime but the wrangler.toml [vars] sets it. Mainnet is not configured.
+ */
+
+// USDC contract on Base Sepolia (testnet — no real monetary value)
+const USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+const USDC_DECIMALS = 6;
+const X402_VERSION = 1;
+
+export interface Env {
+  /** Chain identifier, e.g. "base-sepolia". Set in wrangler.toml [vars]. */
+  X402_NETWORK: string;
+  /** Price per request as a decimal USDC string, e.g. "0.001". Set in wrangler.toml [vars]. */
+  X402_PRICE_USDC: string;
+  /** Testnet receiving wallet address. Set via `wrangler secret put`. */
+  X402_RECEIVING_ADDRESS: string;
+  /** CDP / x402.org facilitator base URL. Set via `wrangler secret put`. */
+  X402_FACILITATOR_URL: string;
+  /** Netlify origin base URL, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
+  PATIENTGUIDE_ORIGIN: string;
+  /** Shared secret sent to the Netlify function to block direct origin access. Set via `wrangler secret put`. */
+  X402_WORKER_SECRET: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Convert a decimal USDC amount string to atomic units (integer string). */
+function usdcToAtomicUnits(usdc: string): string {
+  return Math.round(parseFloat(usdc) * 10 ** USDC_DECIMALS).toString();
+}
+
+function buildPaymentRequirements(env: Env, resource: string) {
+  return {
+    scheme: "exact" as const,
+    network: env.X402_NETWORK,
+    maxAmountRequired: usdcToAtomicUnits(env.X402_PRICE_USDC),
+    resource,
+    description: "PatientGuide x402 testnet experiment",
+    mimeType: "application/json",
+    payTo: env.X402_RECEIVING_ADDRESS,
+    maxTimeoutSeconds: 300,
+    asset: USDC_BASE_SEPOLIA,
+    extra: { name: "USDC", version: "2" },
+  };
+}
+
+function build402Response(env: Env, resource: string): Response {
+  const body = {
+    x402Version: X402_VERSION,
+    accepts: [buildPaymentRequirements(env, resource)],
+    error: "Payment required — send X-PAYMENT header with payment proof",
+  };
+  return new Response(JSON.stringify(body), {
+    status: 402,
+    headers: {
+      "Content-Type": "application/json",
+      // Mirror in header so x402-compatible clients can parse without reading the body.
+      "X-PAYMENT-REQUIRED": JSON.stringify(body),
+    },
+  });
+}
+
+function jsonError(status: number, error: string, detail?: string): Response {
+  return new Response(JSON.stringify({ error, ...(detail ? { detail } : {}) }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── Facilitator calls ──────────────────────────────────────────────────────────
+
+interface VerifyResult {
+  isValid: boolean;
+  invalidReason?: string;
+}
+
+async function verifyPayment(
+  facilitatorUrl: string,
+  paymentHeader: string,
+  paymentRequirements: ReturnType<typeof buildPaymentRequirements>
+): Promise<VerifyResult> {
+  const res = await fetch(`${facilitatorUrl}/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ x402Version: X402_VERSION, paymentHeader, paymentRequirements }),
+  });
+  if (!res.ok) {
+    return { isValid: false, invalidReason: `Facilitator HTTP ${res.status}` };
+  }
+  return res.json<VerifyResult>();
+}
+
+interface SettleResult {
+  success: boolean;
+  txHash?: string;
+  networkId?: string;
+}
+
+async function settlePayment(
+  facilitatorUrl: string,
+  paymentHeader: string,
+  paymentRequirements: ReturnType<typeof buildPaymentRequirements>
+): Promise<SettleResult> {
+  const res = await fetch(`${facilitatorUrl}/settle`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ x402Version: X402_VERSION, paymentHeader, paymentRequirements }),
+  });
+  if (!res.ok) return { success: false };
+  return res.json<SettleResult>();
+}
+
+// ── Worker entry point ─────────────────────────────────────────────────────────
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // SAFETY GUARD: Belt-and-suspenders route check.
+    // The [[routes]] binding in wrangler.toml already restricts this Worker to
+    // /api/x402/* only. This guard makes the constraint explicit in code so it
+    // cannot accidentally be widened by a future wrangler.toml edit.
+    if (!url.pathname.startsWith("/api/x402/")) {
+      return jsonError(404, "not_found");
+    }
+
+    const resource = url.toString();
+    const paymentRequirements = buildPaymentRequirements(env, resource);
+    const paymentHeader = request.headers.get("X-PAYMENT");
+
+    // ── Step 1: Require payment ──────────────────────────────────────────────
+    if (!paymentHeader) {
+      return build402Response(env, resource);
+    }
+
+    // ── Step 2: Verify with facilitator ─────────────────────────────────────
+    let verifyResult: VerifyResult;
+    try {
+      verifyResult = await verifyPayment(env.X402_FACILITATOR_URL, paymentHeader, paymentRequirements);
+    } catch (err) {
+      return jsonError(502, "facilitator_unreachable", String(err));
+    }
+
+    if (!verifyResult.isValid) {
+      return jsonError(402, "payment_invalid", verifyResult.invalidReason ?? "unknown");
+    }
+
+    // ── Step 3: Settle the payment ───────────────────────────────────────────
+    let settleResult: SettleResult = { success: false };
+    try {
+      settleResult = await settlePayment(env.X402_FACILITATOR_URL, paymentHeader, paymentRequirements);
+    } catch {
+      // Non-fatal — we proceed even if settlement tracking fails.
+      // The verify step already confirmed the payment is valid.
+    }
+
+    // ── Step 4: Proxy to origin ──────────────────────────────────────────────
+    // The Worker forwards to the Netlify function via its /.netlify/functions/ URL.
+    // The X-Worker-Secret header prevents callers from hitting the function directly
+    // and bypassing the payment gate.
+    const originUrl = `${env.PATIENTGUIDE_ORIGIN}/.netlify/functions/x402-ping`;
+    let originResponse: Response;
+    try {
+      originResponse = await fetch(originUrl, {
+        method: "GET",
+        headers: {
+          "X-Worker-Secret": env.X402_WORKER_SECRET,
+          "Accept": "application/json",
+        },
+      });
+    } catch (err) {
+      return jsonError(502, "origin_unreachable", String(err));
+    }
+
+    // Return origin body + payment receipt header.
+    const responseHeaders = new Headers(originResponse.headers);
+    responseHeaders.set(
+      "X-PAYMENT-RESPONSE",
+      JSON.stringify({
+        success: settleResult.success,
+        txHash: settleResult.txHash ?? null,
+        networkId: settleResult.networkId ?? env.X402_NETWORK,
+      })
+    );
+
+    return new Response(originResponse.body, {
+      status: originResponse.status,
+      headers: responseHeaders,
+    });
+  },
+};

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -8,8 +8,9 @@
  * never touched by this Worker because the Cloudflare route binding does not
  * match them. The guard below is a second layer of protection.
  *
- * TESTNET ONLY: X402_NETWORK must be "base-sepolia". The code does not enforce
- * this at runtime but the wrangler.toml [vars] sets it. Mainnet is not configured.
+ * TESTNET ONLY: X402_NETWORK is validated at runtime against REQUIRED_NETWORK.
+ * Any other value causes the Worker to return 503 and refuse all requests —
+ * it fails closed rather than accidentally enabling mainnet payments.
  */
 
 // USDC contract on Base Sepolia (testnet — no real monetary value)
@@ -17,14 +18,18 @@ const USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
 const USDC_DECIMALS = 6;
 const X402_VERSION = 1;
 
+// Hard-coded allowed network. Changing this to "base" or "ethereum" would enable
+// real payments — that requires a separate PR with explicit review.
+const REQUIRED_NETWORK = "base-sepolia";
+
 export interface Env {
-  /** Chain identifier, e.g. "base-sepolia". Set in wrangler.toml [vars]. */
+  /** Chain identifier — must equal REQUIRED_NETWORK ("base-sepolia"). Set in wrangler.toml [vars]. */
   X402_NETWORK: string;
   /** Price per request as a decimal USDC string, e.g. "0.001". Set in wrangler.toml [vars]. */
   X402_PRICE_USDC: string;
   /** Testnet receiving wallet address. Set via `wrangler secret put`. */
   X402_RECEIVING_ADDRESS: string;
-  /** CDP / x402.org facilitator base URL. Set via `wrangler secret put`. */
+  /** CDP / x402.org facilitator base URL (no trailing slash). Set via `wrangler secret put`. */
   X402_FACILITATOR_URL: string;
   /** Netlify origin base URL, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
   PATIENTGUIDE_ORIGIN: string;
@@ -32,11 +37,67 @@ export interface Env {
   X402_WORKER_SECRET: string;
 }
 
+// ── Env validation ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate all required env vars are present and the network is base-sepolia.
+ * Returns an error Response if invalid, null if ok.
+ * Never includes secret values in the error response.
+ */
+function validateEnv(env: Env): Response | null {
+  const required: Array<keyof Env> = [
+    "X402_NETWORK",
+    "X402_PRICE_USDC",
+    "X402_RECEIVING_ADDRESS",
+    "X402_FACILITATOR_URL",
+    "PATIENTGUIDE_ORIGIN",
+    "X402_WORKER_SECRET",
+  ];
+
+  for (const key of required) {
+    if (!env[key]) {
+      return jsonError(503, "x402_not_configured");
+    }
+  }
+
+  // Runtime enforcement: reject any network that is not base-sepolia.
+  // Fails closed — no payment requirements are built for unknown networks.
+  if (env.X402_NETWORK !== REQUIRED_NETWORK) {
+    return jsonError(503, "x402_network_not_allowed");
+  }
+
+  return null;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-/** Convert a decimal USDC amount string to atomic units (integer string). */
+/**
+ * Convert a decimal USDC amount string to atomic units (integer string).
+ *
+ * Supports up to 6 decimal places. Rejects negative, empty, multi-dot, or
+ * out-of-precision inputs rather than silently rounding.
+ *
+ * Examples:
+ *   "0.001"    → "1000"
+ *   "0.01"     → "10000"
+ *   "1"        → "1000000"
+ *   "1.234567" → "1234567"
+ *
+ * Rejects: "abc", "0.0000001", "-1", "", "1.2.3"
+ */
 function usdcToAtomicUnits(usdc: string): string {
-  return Math.round(parseFloat(usdc) * 10 ** USDC_DECIMALS).toString();
+  // Accept only non-negative decimals with at most 6 fractional digits.
+  // The regex rejects: negatives, empty strings, multiple dots, > 6 decimals.
+  const match = usdc.match(/^(\d+)(?:\.(\d{1,6}))?$/);
+  if (!match) {
+    throw new Error(`Invalid USDC amount: "${usdc}"`);
+  }
+  const intPart = match[1];
+  // Pad fractional to exactly 6 digits before converting to BigInt.
+  const fracPart = (match[2] ?? "").padEnd(USDC_DECIMALS, "0");
+  const atomicUnits =
+    BigInt(intPart) * BigInt(10 ** USDC_DECIMALS) + BigInt(fracPart);
+  return atomicUnits.toString();
 }
 
 function buildPaymentRequirements(env: Env, resource: string) {
@@ -70,8 +131,9 @@ function build402Response(env: Env, resource: string): Response {
   });
 }
 
-function jsonError(status: number, error: string, detail?: string): Response {
-  return new Response(JSON.stringify({ error, ...(detail ? { detail } : {}) }), {
+/** Produce a JSON error response. Never include secret values in the body. */
+function jsonError(status: number, error: string): Response {
+  return new Response(JSON.stringify({ error }), {
     status,
     headers: { "Content-Type": "application/json" },
   });
@@ -85,11 +147,11 @@ interface VerifyResult {
 }
 
 async function verifyPayment(
-  facilitatorUrl: string,
+  facilitatorBase: string,
   paymentHeader: string,
   paymentRequirements: ReturnType<typeof buildPaymentRequirements>
 ): Promise<VerifyResult> {
-  const res = await fetch(`${facilitatorUrl}/verify`, {
+  const res = await fetch(`${facilitatorBase}/verify`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ x402Version: X402_VERSION, paymentHeader, paymentRequirements }),
@@ -97,7 +159,7 @@ async function verifyPayment(
   if (!res.ok) {
     return { isValid: false, invalidReason: `Facilitator HTTP ${res.status}` };
   }
-  return res.json<VerifyResult>();
+  return (await res.json()) as VerifyResult;
 }
 
 interface SettleResult {
@@ -107,17 +169,17 @@ interface SettleResult {
 }
 
 async function settlePayment(
-  facilitatorUrl: string,
+  facilitatorBase: string,
   paymentHeader: string,
   paymentRequirements: ReturnType<typeof buildPaymentRequirements>
 ): Promise<SettleResult> {
-  const res = await fetch(`${facilitatorUrl}/settle`, {
+  const res = await fetch(`${facilitatorBase}/settle`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ x402Version: X402_VERSION, paymentHeader, paymentRequirements }),
   });
   if (!res.ok) return { success: false };
-  return res.json<SettleResult>();
+  return (await res.json()) as SettleResult;
 }
 
 // ── Worker entry point ─────────────────────────────────────────────────────────
@@ -134,6 +196,14 @@ export default {
       return jsonError(404, "not_found");
     }
 
+    // Validate env vars and enforce base-sepolia before doing anything else.
+    // Fails closed — returns 503 rather than serving a misconfigured response.
+    const envError = validateEnv(env);
+    if (envError) return envError;
+
+    // Strip trailing slashes to prevent double-slash URLs (e.g. .../verify → ...//verify).
+    const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
+
     const resource = url.toString();
     const paymentRequirements = buildPaymentRequirements(env, resource);
     const paymentHeader = request.headers.get("X-PAYMENT");
@@ -146,22 +216,28 @@ export default {
     // ── Step 2: Verify with facilitator ─────────────────────────────────────
     let verifyResult: VerifyResult;
     try {
-      verifyResult = await verifyPayment(env.X402_FACILITATOR_URL, paymentHeader, paymentRequirements);
-    } catch (err) {
-      return jsonError(502, "facilitator_unreachable", String(err));
+      verifyResult = await verifyPayment(facilitatorBase, paymentHeader, paymentRequirements);
+    } catch {
+      return jsonError(502, "facilitator_unreachable");
     }
 
     if (!verifyResult.isValid) {
-      return jsonError(402, "payment_invalid", verifyResult.invalidReason ?? "unknown");
+      return jsonError(402, "payment_invalid");
     }
 
     // ── Step 3: Settle the payment ───────────────────────────────────────────
-    let settleResult: SettleResult = { success: false };
+    // Settlement is required before origin access.
+    // If the facilitator verifies but settlement fails, the Worker does NOT proxy
+    // to the origin — the resource is not served until payment is finalized.
+    let settleResult: SettleResult;
     try {
-      settleResult = await settlePayment(env.X402_FACILITATOR_URL, paymentHeader, paymentRequirements);
+      settleResult = await settlePayment(facilitatorBase, paymentHeader, paymentRequirements);
     } catch {
-      // Non-fatal — we proceed even if settlement tracking fails.
-      // The verify step already confirmed the payment is valid.
+      return jsonError(502, "payment_settlement_failed");
+    }
+
+    if (!settleResult.success) {
+      return jsonError(402, "payment_settlement_failed");
     }
 
     // ── Step 4: Proxy to origin ──────────────────────────────────────────────
@@ -178,8 +254,8 @@ export default {
           "Accept": "application/json",
         },
       });
-    } catch (err) {
-      return jsonError(502, "origin_unreachable", String(err));
+    } catch {
+      return jsonError(502, "origin_unreachable");
     }
 
     // Return origin body + payment receipt header.
@@ -187,7 +263,7 @@ export default {
     responseHeaders.set(
       "X-PAYMENT-RESPONSE",
       JSON.stringify({
-        success: settleResult.success,
+        success: true,
         txHash: settleResult.txHash ?? null,
         networkId: settleResult.networkId ?? env.X402_NETWORK,
       })

--- a/cloudflare/x402-worker/tsconfig.json
+++ b/cloudflare/x402-worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -1,0 +1,39 @@
+name = "patientguide-x402-worker"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ROUTE BINDING — SAFETY CONTRACT
+#
+# This Worker ONLY intercepts requests that match /api/x402/*.
+# All public routes are unaffected:
+#   /                    → Netlify origin (untouched)
+#   /guides/*            → Netlify origin (untouched)
+#   /posts/*             → Netlify origin (untouched)
+#   /search/*            → Netlify origin (untouched)
+#   /sitemap*.xml        → Netlify origin (untouched)
+#   /robots.txt          → Netlify origin (untouched)
+#   /llms.txt            → Netlify origin (untouched)
+#
+# To disable the payment gate entirely, remove or comment out the [[routes]]
+# block below and run `wrangler deploy` — the Worker will stop receiving any
+# traffic. No changes to the Astro site or netlify.toml are needed.
+# ──────────────────────────────────────────────────────────────────────────────
+
+[[routes]]
+  pattern = "patientguide.io/api/x402/*"
+  zone_name = "patientguide.io"
+
+[vars]
+# Testnet identifier — this MUST remain "base-sepolia" for the experiment.
+# Changing to "base" or "ethereum" would enable mainnet payments. Do not do this.
+X402_NETWORK = "base-sepolia"
+
+# Price per request in USDC (testnet USDC has no real monetary value).
+X402_PRICE_USDC = "0.001"
+
+# Secrets below are NOT stored here — set them with `wrangler secret put`:
+#   wrangler secret put X402_RECEIVING_ADDRESS
+#   wrangler secret put X402_FACILITATOR_URL
+#   wrangler secret put PATIENTGUIDE_ORIGIN
+#   wrangler secret put X402_WORKER_SECRET

--- a/netlify/functions/x402-ping.ts
+++ b/netlify/functions/x402-ping.ts
@@ -1,0 +1,44 @@
+/**
+ * x402 ping — origin endpoint for the testnet payment experiment.
+ *
+ * This function is called by the Cloudflare x402 Worker AFTER a valid testnet
+ * payment is verified. It is NOT intended to be called directly by end users.
+ *
+ * The X-Worker-Secret header check (when the env var is configured) prevents
+ * direct access that would bypass the payment gate.
+ *
+ * TESTNET ONLY — network is always "base-sepolia".
+ */
+
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async (event) => {
+  // Shared secret guard — blocks direct calls that skip the Worker.
+  // When X402_WORKER_SECRET is not set (local dev / unconfigured), the check
+  // is skipped so local testing still works.
+  const expectedSecret = process.env.X402_WORKER_SECRET;
+  if (expectedSecret) {
+    const provided = event.headers["x-worker-secret"];
+    if (provided !== expectedSecret) {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: "forbidden" }),
+        headers: { "Content-Type": "application/json" },
+      };
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      ok: true,
+      service: "PatientGuide x402 test",
+      network: "base-sepolia",
+      paid: true,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  };
+};

--- a/netlify/functions/x402-ping.ts
+++ b/netlify/functions/x402-ping.ts
@@ -2,22 +2,40 @@
  * x402 ping — origin endpoint for the testnet payment experiment.
  *
  * This function is called by the Cloudflare x402 Worker AFTER a valid testnet
- * payment is verified. It is NOT intended to be called directly by end users.
+ * payment is verified AND settled. It is NOT intended to be called directly.
  *
- * The X-Worker-Secret header check (when the env var is configured) prevents
- * direct access that would bypass the payment gate.
+ * SAFETY: X402_WORKER_SECRET must be configured as a Netlify environment
+ * variable before deploying. The function returns 500 if the secret is absent
+ * in any non-local environment rather than falling back to open access.
  *
  * TESTNET ONLY — network is always "base-sepolia".
  */
 
 import type { Handler } from "@netlify/functions";
 
+// Local-only bypass: allowed when running `netlify dev` or plain Node.js locally.
+// In all Netlify-deployed contexts (production, branch-deploy, deploy-preview),
+// NETLIFY=true and CONTEXT !== "dev", so the bypass does not apply.
+const isLocalDev =
+  process.env.CONTEXT === "dev" || !process.env.NETLIFY;
+
 export const handler: Handler = async (event) => {
-  // Shared secret guard — blocks direct calls that skip the Worker.
-  // When X402_WORKER_SECRET is not set (local dev / unconfigured), the check
-  // is skipped so local testing still works.
   const expectedSecret = process.env.X402_WORKER_SECRET;
-  if (expectedSecret) {
+
+  if (!expectedSecret) {
+    if (isLocalDev) {
+      // Allow unconfigured local development without a secret.
+      // This branch is unreachable in any deployed Netlify environment.
+    } else {
+      // Fail closed in all deployed environments — do not serve without a secret.
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: "x402_origin_not_configured" }),
+        headers: { "Content-Type": "application/json" },
+      };
+    }
+  } else {
+    // Secret is configured: enforce it regardless of environment.
     const provided = event.headers["x-worker-secret"];
     if (provided !== expectedSecret) {
       return {


### PR DESCRIPTION
## Summary

- Adds `cloudflare/x402-worker/` — a Cloudflare Worker that implements the x402 HTTP payment protocol, gated exclusively to `/api/x402/*`
- Adds `netlify/functions/x402-ping.ts` — a Netlify function that serves the origin response after a verified testnet payment
- Network is locked to Base Sepolia testnet (`base-sepolia`) — mainnet is not configured
- All public routes (`/`, `/guides/*`, `/posts/*`, `/search/*`, `sitemap.xml`, `robots.txt`, `llms.txt`) are completely unaffected

## What x402 does here

1. Client requests `GET /api/x402/ping` with no payment → Worker returns HTTP 402 with `X-PAYMENT-REQUIRED` header describing the testnet USDC payment requirements
2. Client signs an EIP-3009 transfer authorisation and re-sends with `X-PAYMENT` header
3. Worker verifies + settles via the configured CDP/x402 facilitator
4. Worker proxies to the Netlify function and returns `{ ok: true, paid: true, network: base-sepolia, ... }` with an `X-PAYMENT-RESPONSE` receipt header

## Safety contract

- Route binding in `wrangler.toml` restricts the Worker to `patientguide.io/api/x402/*`
- Belt-and-suspenders pathname guard in `src/index.ts` re-checks the path prefix
- No real wallet addresses, private keys, or secrets are committed — `.env.example` only
- `X402_NETWORK = base-sepolia` is hardcoded in `wrangler.toml [vars]`

## Test plan

- [ ] `npm run build` passes (verified locally — 785 pages, no errors)
- [ ] `curl -i https://patientguide.io/api/x402/ping` returns HTTP 402 after deploy
- [ ] Public route spot-check: `curl -i https://patientguide.io/` still returns 200
- [ ] `curl -i https://patientguide.io/guides/hypertension` still returns 200
- [ ] Configure secrets via `wrangler secret put` and run `wrangler deploy` per README

## Files changed

| File | Purpose |
|---|---|
| `cloudflare/x402-worker/src/index.ts` | Worker — x402 gate, verify, settle, proxy |
| `cloudflare/x402-worker/wrangler.toml` | Route binding + testnet [vars] |
| `cloudflare/x402-worker/package.json` | Wrangler + TS deps |
| `cloudflare/x402-worker/tsconfig.json` | TS config for Workers runtime |
| `cloudflare/x402-worker/.env.example` | Env var template (no real secrets) |
| `cloudflare/x402-worker/.gitignore` | Ignores `.wrangler/`, `.dev.vars`, `node_modules/` |
| `cloudflare/x402-worker/README.md` | Deploy guide, architecture, disable instructions |
| `netlify/functions/x402-ping.ts` | Origin endpoint — responds after payment verified |

Generated with Claude Code