### PR TITLE
feat(x402): paid structured guide brief endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # build output
 dist/
 
-# Generated chatbot index — rebuilt at deploy time via prebuild script.
-# Do not commit; committing balloons git history with 600KB+ diffs on every content update.
+# Generated indices — rebuilt at deploy time via prebuild scripts.
+# Do not commit; committing balloons git history with large diffs on every content update.
 netlify/functions/chatbot-index.json
+netlify/functions/x402-guide-briefs.json
 
 # generated types
 .astro/

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -25,52 +25,114 @@ The whole flow happens in one HTTP round-trip for the caller.
 
 ---
 
-## Architecture for this experiment
+## Current deployed architecture (Part 1)
+
+`patientguide.io` is **not** currently configured as a native Cloudflare zone route
+for this Worker. Instead, traffic reaches the Worker via a Netlify proxy redirect:
 
 ```
 Browser / curl / x402 client
         │
-        │  GET /api/x402/ping
+        │  GET https://patientguide.io/api/x402/ping
         ▼
 ┌─────────────────────────────┐
-│  Cloudflare Worker          │  ← this project
-│  patientguide.io/api/x402/* │
-│                             │
-│  1. No X-PAYMENT → 402      │
-│  2. Verify via facilitator  │
-│  3. Settle via facilitator  │  ← required; failure → 402/502, no proxy
-│  4. Proxy to Netlify fn     │
+│  Netlify proxy redirect      │
+│  /api/x402/*                 │
+│  → patientguide-x402-worker  │
+│    .wavechecker.workers.dev  │
 └─────────┬───────────────────┘
-          │  GET /.netlify/functions/x402-ping
-          │  + X-Worker-Secret header
+          │  (internal — Worker sees workers.dev hostname)
           ▼
 ┌─────────────────────────────┐
-│  Netlify Function           │
-│  netlify/functions/         │
-│  x402-ping.ts               │
+│  Cloudflare Worker          │  ← this project
+│  patientguide-x402-worker   │
+│  .wavechecker.workers.dev   │
 │                             │
-│  Returns { ok, paid, ... }  │
+│  1. No X-PAYMENT → 402      │
+│     resource canonicalized  │
+│     to patientguide.io URL  │
+│  2. Verify via facilitator  │
+│  3. Settle via facilitator  │
+│  4. Return JSON directly    │
+│     (Worker-only, no        │
+│      Netlify function)      │
 └─────────────────────────────┘
 ```
 
-**Settlement is required before origin access.** If the facilitator verifies a
-payment but settlement fails (network error, facilitator rejection, etc.), the
-Worker returns an error and does **not** proxy to the Netlify function. The
-resource is never served until payment is fully finalized.
+### Canonical resource URL
 
-**Facilitator:** `https://x402.org/facilitator` (testnet, free, no API key required)
+Although the Worker is internally reached via `patientguide-x402-worker.wavechecker.workers.dev`,
+it canonicalizes the x402 `resource` field to the **public-facing URL**:
 
-**Network identifiers:**
+```
+https://patientguide.io/api/x402/ping
+```
+
+This is done using the `PATIENTGUIDE_ORIGIN` secret:
+
+```typescript
+const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/\/+$/, "");
+const resource = `${canonicalOrigin}${url.pathname}${url.search}`;
+```
+
+Payment proofs are therefore bound to the client-facing URL, not the internal workers.dev hostname.
+
+### Part 1 does not use Netlify build minutes
+
+The `/api/x402/ping` response is returned directly from the Worker after payment
+settlement. No Netlify function is called. Deploying or updating this Worker uses
+only Wrangler — it does not trigger a Netlify build.
+
+---
+
+## Network identifiers
 
 | Identifier | Chain | Allowed in this experiment |
 |---|---|---|
 | `eip155:84532` | Base Sepolia testnet | ✅ yes |
 | `eip155:8453` | Base mainnet | ❌ NO — do not use |
 
-**Public routes are untouched.** The Cloudflare route binding in `wrangler.toml`
-restricts the Worker exclusively to `patientguide.io/api/x402/*`. All other paths
-(`/`, `/guides/*`, `/posts/*`, `/search/*`, `sitemap.xml`, `robots.txt`,
-`llms.txt`) continue to be served directly from Netlify.
+The Worker enforces `eip155:84532` at runtime. Any other value (including the mainnet
+identifier `eip155:8453`) causes the Worker to return `503 x402_network_not_allowed`
+and refuse all requests — it fails closed rather than accidentally enabling real payments.
+
+---
+
+## Public routes
+
+Public routes are never touched by this Worker. The Netlify proxy redirect only forwards
+`/api/x402/*` to the Worker. All other paths are served directly by Netlify:
+
+| Path | Served by |
+|---|---|
+| `/` | Netlify (Astro) |
+| `/guides/*` | Netlify (Astro) |
+| `/posts/*` | Netlify (Astro) |
+| `/search/*` | Netlify (Astro) |
+| `/sitemap*.xml` | Netlify (Astro) |
+| `/robots.txt` | Netlify (Astro) |
+| `/llms.txt` | Netlify (Astro) |
+| `/api/x402/*` | Cloudflare Worker (this project) |
+
+The Worker also enforces a belt-and-suspenders route guard: any request to a path that
+does not start with `/api/x402/` returns `404 not_found`. Within `/api/x402/*`, only
+`/api/x402/ping` is intentionally supported — all other sub-paths return `404 not_found`.
+
+---
+
+## Future Part 2 options (paused)
+
+Part 2 would extend x402 to a structured content endpoint. Two options under consideration:
+
+**Option A — Worker-only structured endpoint**
+Add a new route (e.g. `/api/x402/content`) entirely within the Worker. No Netlify build
+minutes required. Can proceed independently of Netlify quota.
+
+**Option B — Astro/content collections endpoint via Netlify function**
+Add a Netlify function backed by Astro content collections. Requires Netlify build
+minutes to deploy. Paused until quota resets.
+
+Part 2 remains paused. No mainnet (`eip155:8453`) support is planned.
 
 ---
 
@@ -79,9 +141,7 @@ restricts the Worker exclusively to `patientguide.io/api/x402/*`. All other path
 | Path | Purpose |
 |---|---|
 | `cloudflare/x402-worker/src/index.ts` | Worker entry point — x402 gate logic |
-| `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config and route binding |
-| `cloudflare/x402-worker/.env.example` | Environment variable template |
-| `netlify/functions/x402-ping.ts` | Origin endpoint called after payment clears |
+| `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config |
 
 ---
 
@@ -89,7 +149,6 @@ restricts the Worker exclusively to `patientguide.io/api/x402/*`. All other path
 
 ### Prerequisites
 
-- Cloudflare account with `patientguide.io` zone
 - Node.js ≥ 18
 - Wrangler CLI: `npm install -g wrangler` (or use the local one)
 - A Base Sepolia wallet address to receive testnet USDC
@@ -110,25 +169,13 @@ Set each secret via Wrangler (they are stored in Cloudflare, never in this repo)
 wrangler secret put X402_RECEIVING_ADDRESS
 
 # Official CDP / x402.org facilitator base URL
-# Check https://x402.org or https://docs.cdp.coinbase.com for the current value
 wrangler secret put X402_FACILITATOR_URL
+# → enter: https://x402.org/facilitator
 
-# Netlify origin base URL
+# Canonical public origin
 wrangler secret put PATIENTGUIDE_ORIGIN
 # → enter: https://patientguide.io
-
-# Random hex secret shared between the Worker and the Netlify function
-# Generate: openssl rand -hex 32
-wrangler secret put X402_WORKER_SECRET
 ```
-
-Set the same `X402_WORKER_SECRET` value as a Netlify environment variable
-(`Site settings → Environment variables → Add variable`).
-
-> **Required before deploying:** `X402_WORKER_SECRET` must be configured in
-> Netlify before the Netlify function goes live. Without it, the function returns
-> `500 x402_origin_not_configured` in all deployed environments (it does not fall
-> back to open access).
 
 ### 3. Local development
 
@@ -158,16 +205,9 @@ curl -i http://localhost:8787/api/x402/ping
 npm run deploy
 ```
 
-Wrangler reads `wrangler.toml` and registers the route binding automatically.
+This uses only Wrangler and does not trigger a Netlify build.
 
-### 5. Configure Cloudflare route (if not auto-registered)
-
-In the Cloudflare dashboard → **Workers & Pages → your worker → Triggers → Routes**:
-
-- Route: `patientguide.io/api/x402/*`
-- Zone: `patientguide.io`
-
-### 6. Verify the live endpoint
+### 5. Verify the live endpoint
 
 ```bash
 # Should return 402 with X-PAYMENT-REQUIRED header
@@ -176,40 +216,15 @@ curl -i https://patientguide.io/api/x402/ping
 # Expected 402 body (formatted):
 # {
 #   "x402Version": 1,
-#   "accepts": [{ "scheme": "exact", "network": "base-sepolia", ... }],
+#   "accepts": [{
+#     "scheme": "exact",
+#     "network": "eip155:84532",
+#     "resource": "https://patientguide.io/api/x402/ping",
+#     ...
+#   }],
 #   "error": "Payment required ..."
 # }
 ```
-
----
-
-## How to disable / remove the route
-
-**Temporary disable (keep the Worker, stop receiving traffic):**
-
-In `wrangler.toml`, comment out the `[[routes]]` block:
-
-```toml
-# [[routes]]
-#   pattern = "patientguide.io/api/x402/*"
-#   zone_name = "patientguide.io"
-```
-
-Then redeploy:
-
-```bash
-npm run deploy
-```
-
-**Full removal:**
-
-```bash
-wrangler delete
-```
-
-This deletes the Worker from Cloudflare entirely. The Netlify function
-(`netlify/functions/x402-ping.ts`) can be removed from the codebase separately.
-No other Astro/Netlify config needs to change.
 
 ---
 
@@ -217,12 +232,11 @@ No other Astro/Netlify config needs to change.
 
 | Variable | Where | Description |
 |---|---|---|
-| `X402_NETWORK` | `wrangler.toml [vars]` | CAIP-2 chain identifier — must be `eip155:84532` (Base Sepolia testnet). `eip155:8453` is Base mainnet and must not be used. |
+| `X402_NETWORK` | `wrangler.toml [vars]` | CAIP-2 chain identifier — must be `eip155:84532` (Base Sepolia). `eip155:8453` is mainnet and must not be used. |
 | `X402_PRICE_USDC` | `wrangler.toml [vars]` | Price per request in USDC decimal string |
-| `X402_RECEIVING_ADDRESS` | Wrangler secret | Your Base Sepolia testnet wallet address |
+| `X402_RECEIVING_ADDRESS` | Wrangler secret | Base Sepolia testnet wallet address |
 | `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` (testnet, free) |
-| `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` |
-| `X402_WORKER_SECRET` | Wrangler secret + Netlify env | Shared secret for Worker→function auth |
+| `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` — used to canonicalize the x402 resource URL |
 
 ---
 
@@ -233,8 +247,7 @@ To move to mainnet, all of the following changes would be required:
 - Update `REQUIRED_NETWORK` in `src/index.ts` to `"eip155:8453"`
 - Update `USDC_BASE_SEPOLIA` in `src/index.ts` to the mainnet USDC contract address
 - Update `X402_RECEIVING_ADDRESS` to a mainnet wallet
-- Update the Cloudflare route in `wrangler.toml`
 - A separate PR review with explicit sign-off
 
-> ⚠️ `eip155:8453` = Base mainnet. Using this value would enable **real** USDC
+> `eip155:8453` = Base mainnet. Using this value would enable **real** USDC
 > payments with real monetary value. This experiment is `eip155:84532` (testnet) only.

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -7,6 +7,16 @@
 
 ---
 
+## Core principle
+
+**Humans read public guides for free.**
+**Machines and agents pay for structured API access.**
+
+`/guides/*` remains completely free and public. The x402 gate only applies to
+structured JSON endpoints under `/api/x402/*`, intended for programmatic access.
+
+---
+
 ## What is x402?
 
 [x402](https://x402.org) is an open HTTP payment protocol built on top of the
@@ -25,7 +35,7 @@ The whole flow happens in one HTTP round-trip for the caller.
 
 ---
 
-## Current deployed architecture (Part 1)
+## Current deployed architecture
 
 `patientguide.io` is **not** currently configured as a native Cloudflare zone route
 for this Worker. Instead, traffic reaches the Worker via a Netlify proxy redirect:
@@ -33,29 +43,27 @@ for this Worker. Instead, traffic reaches the Worker via a Netlify proxy redirec
 ```
 Browser / curl / x402 client
         │
-        │  GET https://patientguide.io/api/x402/ping
+        │  GET https://patientguide.io/api/x402/<path>
         ▼
 ┌─────────────────────────────┐
-│  Netlify proxy redirect      │
-│  /api/x402/*                 │
-│  → patientguide-x402-worker  │
-│    .wavechecker.workers.dev  │
+│  Netlify proxy redirect     │
+│  /api/x402/*                │
+│  → patientguide-x402-worker │
+│    .wavechecker.workers.dev │
 └─────────┬───────────────────┘
           │  (internal — Worker sees workers.dev hostname)
           ▼
 ┌─────────────────────────────┐
 │  Cloudflare Worker          │  ← this project
-│  patientguide-x402-worker   │
-│  .wavechecker.workers.dev   │
 │                             │
-│  1. No X-PAYMENT → 402      │
-│     resource canonicalized  │
-│     to patientguide.io URL  │
-│  2. Verify via facilitator  │
-│  3. Settle via facilitator  │
-│  4. Return JSON directly    │
-│     (Worker-only, no        │
-│      Netlify function)      │
+│  1. Route guard             │
+│  2. Env validation          │
+│  3. No X-PAYMENT → 402      │
+│     (canonical resource)    │
+│  4. Verify payment          │
+│  5. Settle payment          │
+│  6. Return response         │
+│     (Worker-only or origin) │
 └─────────────────────────────┘
 ```
 
@@ -66,22 +74,111 @@ it canonicalizes the x402 `resource` field to the **public-facing URL**:
 
 ```
 https://patientguide.io/api/x402/ping
+https://patientguide.io/api/x402/guide-brief?slug=hypertension
 ```
 
 This is done using the `PATIENTGUIDE_ORIGIN` secret:
 
 ```typescript
-const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/\/+$/, "");
-const resource = `${canonicalOrigin}${url.pathname}${url.search}`;
+const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\/+$/, "");
+const resource = `${canonicalOrigin}${url.pathname}?slug=${slug}`;
 ```
 
 Payment proofs are therefore bound to the client-facing URL, not the internal workers.dev hostname.
 
-### Part 1 does not use Netlify build minutes
+### Future clean architecture
 
-The `/api/x402/ping` response is returned directly from the Worker after payment
-settlement. No Netlify function is called. Deploying or updating this Worker uses
-only Wrangler — it does not trigger a Netlify build.
+When `patientguide.io` moves fully behind Cloudflare as a zone, the Netlify proxy
+redirect would be replaced by a native `[[routes]]` binding in `wrangler.toml`:
+
+```toml
+[[routes]]
+  pattern = "patientguide.io/api/x402/*"
+  zone_name = "patientguide.io"
+```
+
+No code changes are required — only the routing topology changes.
+
+---
+
+## Endpoints
+
+### `/api/x402/ping` — Worker-only test
+
+A minimal test endpoint to verify the x402 payment gate works end-to-end.
+The response is built directly in the Worker — no Netlify function is called.
+
+**No payment:**
+```
+HTTP 402 Payment Required
+X-PAYMENT-REQUIRED: { x402Version, accepts: [{ network, resource, ... }], error }
+```
+
+**After valid payment:**
+```json
+{
+  "ok": true,
+  "service": "PatientGuide x402 test",
+  "paid": true,
+  "network": "eip155:84532",
+  "networkName": "Base Sepolia",
+  "origin": "cloudflare-worker"
+}
+```
+
+---
+
+### `/api/x402/guide-brief?slug=<slug>` — Paid structured guide metadata
+
+Returns structured metadata from the actual Astro guide content collection.
+Intended for machine / agent access to guide data.
+
+**No payment:**
+```
+HTTP 402 Payment Required
+X-PAYMENT-REQUIRED: { x402Version, accepts: [{ network, resource: "https://patientguide.io/api/x402/guide-brief?slug=hypertension", ... }] }
+```
+
+**After valid payment:**
+```json
+{
+  "slug": "hypertension",
+  "title": "Hypertension: Symptoms, Causes, Diagnosis, Treatment, and Home Blood Pressure Monitoring",
+  "description": "An evidence-based guide to high blood pressure...",
+  "category": "Heart & Circulation",
+  "publishDate": "2026-06-17",
+  "updatedDate": "2026-06-17",
+  "tags": ["hypertension", "high blood pressure", "..."],
+  "keyPoints": ["Hypertension is defined as...", "..."],
+  "relatedGuides": [
+    { "title": "Cardiovascular Risk Assessment...", "slug": "cardiovascular-risk-assessment", "url": "https://patientguide.io/guides/cardiovascular-risk-assessment" }
+  ],
+  "canonicalUrl": "https://patientguide.io/guides/hypertension"
+}
+```
+
+Data source: `netlify/functions/x402-guide-briefs.json` — built at deploy time by
+`scripts/build-x402-guide-briefs.mjs` from `src/content/guides/`. Draft guides excluded.
+
+**Flow:**
+```
+Worker gates payment → settles → proxies to Netlify function
+                                 └── reads pre-built guide briefs JSON
+                                 └── returns structured metadata
+```
+
+---
+
+## Origin bypass protection
+
+The `guide-brief` endpoint has an origin Netlify function. To prevent callers from
+hitting it directly and bypassing the payment gate:
+
+- The Worker sets `X-Worker-Secret: <secret>` on all calls to the origin.
+- The Netlify function requires this header — returns `403 forbidden` if missing or wrong.
+- The secret is stored in both Cloudflare Worker secrets and Netlify environment variables.
+
+Direct access to `/.netlify/functions/x402-guide-brief` without the correct secret returns `403`.
 
 ---
 
@@ -92,47 +189,39 @@ only Wrangler — it does not trigger a Netlify build.
 | `eip155:84532` | Base Sepolia testnet | ✅ yes |
 | `eip155:8453` | Base mainnet | ❌ NO — do not use |
 
-The Worker enforces `eip155:84532` at runtime. Any other value (including the mainnet
-identifier `eip155:8453`) causes the Worker to return `503 x402_network_not_allowed`
-and refuse all requests — it fails closed rather than accidentally enabling real payments.
+The Worker enforces `eip155:84532` at runtime. Any other value (including `eip155:8453`)
+causes the Worker to return `503 x402_network_not_allowed` — fails closed.
 
 ---
 
-## Public routes
+## Public routes (untouched)
 
-Public routes are never touched by this Worker. The Netlify proxy redirect only forwards
-`/api/x402/*` to the Worker. All other paths are served directly by Netlify:
-
-| Path | Served by |
-|---|---|
-| `/` | Netlify (Astro) |
-| `/guides/*` | Netlify (Astro) |
-| `/posts/*` | Netlify (Astro) |
-| `/search/*` | Netlify (Astro) |
-| `/sitemap*.xml` | Netlify (Astro) |
-| `/robots.txt` | Netlify (Astro) |
-| `/llms.txt` | Netlify (Astro) |
-| `/api/x402/*` | Cloudflare Worker (this project) |
-
-The Worker also enforces a belt-and-suspenders route guard: any request to a path that
-does not start with `/api/x402/` returns `404 not_found`. Within `/api/x402/*`, only
-`/api/x402/ping` is intentionally supported — all other sub-paths return `404 not_found`.
+| Path | Served by | Free? |
+|---|---|---|
+| `/` | Netlify (Astro) | ✅ yes |
+| `/guides/*` | Netlify (Astro) | ✅ yes |
+| `/posts/*` | Netlify (Astro) | ✅ yes |
+| `/search/*` | Netlify (Astro) | ✅ yes |
+| `/sitemap*.xml` | Netlify (Astro) | ✅ yes |
+| `/robots.txt` | Netlify (Astro) | ✅ yes |
+| `/api/x402/ping` | Cloudflare Worker | x402 gated (testnet) |
+| `/api/x402/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated (testnet) |
 
 ---
 
-## Future Part 2 options (paused)
+## Part 3 — Mainnet (disabled, not planned)
 
-Part 2 would extend x402 to a structured content endpoint. Two options under consideration:
+Part 3 would be moving to mainnet (`eip155:8453`). This is intentionally disabled.
+All of the following changes would be required before mainnet:
 
-**Option A — Worker-only structured endpoint**
-Add a new route (e.g. `/api/x402/content`) entirely within the Worker. No Netlify build
-minutes required. Can proceed independently of Netlify quota.
+- Set `X402_NETWORK` to `eip155:8453` in `wrangler.toml`
+- Update `REQUIRED_NETWORK` in `src/index.ts` to `"eip155:8453"`
+- Update `USDC_BASE_SEPOLIA` to the mainnet USDC contract address
+- Update `X402_RECEIVING_ADDRESS` to a mainnet wallet
+- A separate PR review with explicit sign-off
 
-**Option B — Astro/content collections endpoint via Netlify function**
-Add a Netlify function backed by Astro content collections. Requires Netlify build
-minutes to deploy. Paused until quota resets.
-
-Part 2 remains paused. No mainnet (`eip155:8453`) support is planned.
+> `eip155:8453` = Base mainnet. Using this value would enable **real** USDC
+> payments with real monetary value. This experiment is `eip155:84532` (testnet) only.
 
 ---
 
@@ -142,16 +231,13 @@ Part 2 remains paused. No mainnet (`eip155:8453`) support is planned.
 |---|---|
 | `cloudflare/x402-worker/src/index.ts` | Worker entry point — x402 gate logic |
 | `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config |
+| `netlify/functions/x402-guide-brief.ts` | Paid guide brief origin endpoint |
+| `netlify/functions/x402-guide-briefs.json` | Pre-built guide brief data (gitignored — built at deploy time) |
+| `scripts/build-x402-guide-briefs.mjs` | Build script that generates x402-guide-briefs.json |
 
 ---
 
 ## Setup and deployment
-
-### Prerequisites
-
-- Node.js ≥ 18
-- Wrangler CLI: `npm install -g wrangler` (or use the local one)
-- A Base Sepolia wallet address to receive testnet USDC
 
 ### 1. Install dependencies
 
@@ -160,70 +246,46 @@ cd cloudflare/x402-worker
 npm install
 ```
 
-### 2. Configure secrets
-
-Set each secret via Wrangler (they are stored in Cloudflare, never in this repo):
+### 2. Configure Worker secrets
 
 ```bash
-# Your Base Sepolia receiving address (public, no private key)
-wrangler secret put X402_RECEIVING_ADDRESS
-
-# Official CDP / x402.org facilitator base URL
-wrangler secret put X402_FACILITATOR_URL
-# → enter: https://x402.org/facilitator
-
-# Canonical public origin
-wrangler secret put PATIENTGUIDE_ORIGIN
-# → enter: https://patientguide.io
+wrangler secret put X402_RECEIVING_ADDRESS    # Base Sepolia wallet address
+wrangler secret put X402_FACILITATOR_URL      # https://x402.org/facilitator
+wrangler secret put PATIENTGUIDE_ORIGIN       # https://patientguide.io
+wrangler secret put X402_WORKER_SECRET        # openssl rand -hex 32
 ```
 
-### 3. Local development
+### 3. Configure Netlify environment variable
 
-Copy `.env.example` to `.dev.vars` (Wrangler loads this automatically):
+In Netlify: Site settings → Environment variables:
 
-```bash
-cp .env.example .dev.vars
-# Edit .dev.vars with real testnet values
+```
+X402_WORKER_SECRET = <same value as the Worker secret>
 ```
 
-Run the Worker locally:
+### 4. Deploy Netlify site
 
 ```bash
-npm run dev
-# Worker starts at http://localhost:8787
+# From repo root — triggers prebuild which generates x402-guide-briefs.json
+git push origin main
 ```
 
-Test without payment (should return 402):
+### 5. Deploy Worker
 
 ```bash
-curl -i http://localhost:8787/api/x402/ping
-```
-
-### 4. Deploy to Cloudflare
-
-```bash
+cd cloudflare/x402-worker
 npm run deploy
 ```
 
-This uses only Wrangler and does not trigger a Netlify build.
-
-### 5. Verify the live endpoint
+### 6. Verify
 
 ```bash
-# Should return 402 with X-PAYMENT-REQUIRED header
-curl -i https://patientguide.io/api/x402/ping
+# Should return 402 with canonical resource URL
+curl -i "https://patientguide.io/api/x402/ping"
+curl -i "https://patientguide.io/api/x402/guide-brief?slug=hypertension"
 
-# Expected 402 body (formatted):
-# {
-#   "x402Version": 1,
-#   "accepts": [{
-#     "scheme": "exact",
-#     "network": "eip155:84532",
-#     "resource": "https://patientguide.io/api/x402/ping",
-#     ...
-#   }],
-#   "error": "Payment required ..."
-# }
+# Origin bypass check — should return 403
+curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypertension"
 ```
 
 ---
@@ -232,22 +294,9 @@ curl -i https://patientguide.io/api/x402/ping
 
 | Variable | Where | Description |
 |---|---|---|
-| `X402_NETWORK` | `wrangler.toml [vars]` | CAIP-2 chain identifier — must be `eip155:84532` (Base Sepolia). `eip155:8453` is mainnet and must not be used. |
+| `X402_NETWORK` | `wrangler.toml [vars]` | CAIP-2 chain — must be `eip155:84532`. `eip155:8453` is mainnet and must not be used. |
 | `X402_PRICE_USDC` | `wrangler.toml [vars]` | Price per request in USDC decimal string |
 | `X402_RECEIVING_ADDRESS` | Wrangler secret | Base Sepolia testnet wallet address |
-| `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` (testnet, free) |
-| `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` — used to canonicalize the x402 resource URL |
-
----
-
-## Enabling mainnet (NOT for this experiment)
-
-To move to mainnet, all of the following changes would be required:
-- Set `X402_NETWORK` to `eip155:8453` (Base mainnet CAIP-2 identifier)
-- Update `REQUIRED_NETWORK` in `src/index.ts` to `"eip155:8453"`
-- Update `USDC_BASE_SEPOLIA` in `src/index.ts` to the mainnet USDC contract address
-- Update `X402_RECEIVING_ADDRESS` to a mainnet wallet
-- A separate PR review with explicit sign-off
-
-> `eip155:8453` = Base mainnet. Using this value would enable **real** USDC
-> payments with real monetary value. This experiment is `eip155:84532` (testnet) only.
+| `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` |
+| `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` — used to canonicalize x402 resource URLs |
+| `X402_WORKER_SECRET` | Wrangler secret + Netlify env | Shared secret for Worker→origin auth; prevents direct origin bypass |

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -211,7 +211,8 @@ export default {
     // The Worker is reached via a Netlify proxy redirect from patientguide.io,
     // so request.url reflects the workers.dev hostname internally. We canonicalize
     // to the public origin so x402 payment binding matches the client-facing URL.
-    const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/\/+$/, "");
+    // Strip BOM (﻿) that PowerShell may prepend when secrets are set on Windows.
+    const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\/+$/, "");
     const resource = `${canonicalOrigin}${url.pathname}${url.search}`;
 
     const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -26,7 +26,7 @@ const X402_VERSION = 1;
 const REQUIRED_NETWORK = "eip155:84532";
 
 export interface Env {
-  /** Chain identifier — must equal REQUIRED_NETWORK ("base-sepolia"). Set in wrangler.toml [vars]. */
+  /** Chain identifier — must equal REQUIRED_NETWORK ("eip155:84532"). Set in wrangler.toml [vars]. */
   X402_NETWORK: string;
   /** Price per request as a decimal USDC string, e.g. "0.001". Set in wrangler.toml [vars]. */
   X402_PRICE_USDC: string;
@@ -34,10 +34,8 @@ export interface Env {
   X402_RECEIVING_ADDRESS: string;
   /** CDP / x402.org facilitator base URL (no trailing slash). Set via `wrangler secret put`. */
   X402_FACILITATOR_URL: string;
-  /** Netlify origin base URL, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
+  /** Canonical public origin, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
   PATIENTGUIDE_ORIGIN: string;
-  /** Shared secret sent to the Netlify function to block direct origin access. Set via `wrangler secret put`. */
-  X402_WORKER_SECRET: string;
 }
 
 // ── Env validation ─────────────────────────────────────────────────────────────
@@ -54,7 +52,6 @@ function validateEnv(env: Env): Response | null {
     "X402_RECEIVING_ADDRESS",
     "X402_FACILITATOR_URL",
     "PATIENTGUIDE_ORIGIN",
-    "X402_WORKER_SECRET",
   ];
 
   for (const key of required) {
@@ -204,10 +201,20 @@ export default {
     const envError = validateEnv(env);
     if (envError) return envError;
 
-    // Strip trailing slashes to prevent double-slash URLs (e.g. .../verify → ...//verify).
-    const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
+    // Only /api/x402/ping is intentionally supported in Part 1.
+    // Any other /api/x402/* path gets 404 rather than silently falling through.
+    if (url.pathname !== "/api/x402/ping") {
+      return jsonError(404, "not_found");
+    }
 
-    const resource = url.toString();
+    // Build canonical resource URL using the public-facing origin.
+    // The Worker is reached via a Netlify proxy redirect from patientguide.io,
+    // so request.url reflects the workers.dev hostname internally. We canonicalize
+    // to the public origin so x402 payment binding matches the client-facing URL.
+    const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/\/+$/, "");
+    const resource = `${canonicalOrigin}${url.pathname}${url.search}`;
+
+    const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
     const paymentRequirements = buildPaymentRequirements(env, resource);
     const paymentHeader = request.headers.get("X-PAYMENT");
 
@@ -229,9 +236,10 @@ export default {
     }
 
     // ── Step 3: Settle the payment ───────────────────────────────────────────
-    // Settlement is required before origin access.
-    // If the facilitator verifies but settlement fails, the Worker does NOT proxy
-    // to the origin — the resource is not served until payment is finalized.
+    // Settlement is required before the resource is served.
+    // If the facilitator verifies but settlement fails, the Worker returns an
+    // error and does NOT serve the resource — it is never returned until payment
+    // is fully finalized.
     let settleResult: SettleResult;
     try {
       settleResult = await settlePayment(facilitatorBase, paymentHeader, paymentRequirements);
@@ -243,38 +251,29 @@ export default {
       return jsonError(402, "payment_settlement_failed");
     }
 
-    // ── Step 4: Proxy to origin ──────────────────────────────────────────────
-    // The Worker forwards to the Netlify function via its /.netlify/functions/ URL.
-    // The X-Worker-Secret header prevents callers from hitting the function directly
-    // and bypassing the payment gate.
-    const originUrl = `${env.PATIENTGUIDE_ORIGIN}/.netlify/functions/x402-ping`;
-    let originResponse: Response;
-    try {
-      originResponse = await fetch(originUrl, {
-        method: "GET",
-        headers: {
-          "X-Worker-Secret": env.X402_WORKER_SECRET,
-          "Accept": "application/json",
-        },
-      });
-    } catch {
-      return jsonError(502, "origin_unreachable");
-    }
-
-    // Return origin body + payment receipt header.
-    const responseHeaders = new Headers(originResponse.headers);
-    responseHeaders.set(
-      "X-PAYMENT-RESPONSE",
+    // ── Step 4: Return paid response directly from Worker ────────────────────
+    // /api/x402/ping is handled entirely within the Worker — no Netlify function
+    // is required or called. The JSON response is built here after settlement.
+    return new Response(
       JSON.stringify({
-        success: true,
-        txHash: settleResult.txHash ?? null,
-        networkId: settleResult.networkId ?? env.X402_NETWORK,
-      })
+        ok: true,
+        service: "PatientGuide x402 test",
+        paid: true,
+        network: "eip155:84532",
+        networkName: "Base Sepolia",
+        origin: "cloudflare-worker",
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT-RESPONSE": JSON.stringify({
+            success: true,
+            txHash: settleResult.txHash ?? null,
+            networkId: settleResult.networkId ?? env.X402_NETWORK,
+          }),
+        },
+      }
     );
-
-    return new Response(originResponse.body, {
-      status: originResponse.status,
-      headers: responseHeaders,
-    });
   },
 };

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -12,6 +12,10 @@
  * ("eip155:84532" = Base Sepolia testnet). Any other value — including the Base
  * mainnet identifier "eip155:8453" — causes the Worker to return 503 and refuse
  * all requests. It fails closed rather than accidentally enabling mainnet payments.
+ *
+ * ROUTES:
+ *   /api/x402/ping         — Worker-only test endpoint (no origin call)
+ *   /api/x402/guide-brief  — Paid structured guide metadata (proxies to Netlify origin)
  */
 
 // USDC contract on Base Sepolia (testnet — no real monetary value)
@@ -25,6 +29,9 @@ const X402_VERSION = 1;
 // Changing this requires a separate PR with explicit review.
 const REQUIRED_NETWORK = "eip155:84532";
 
+// Allowed slug pattern — must match the same pattern in the Netlify function.
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,99}$/;
+
 export interface Env {
   /** Chain identifier — must equal REQUIRED_NETWORK ("eip155:84532"). Set in wrangler.toml [vars]. */
   X402_NETWORK: string;
@@ -36,15 +43,12 @@ export interface Env {
   X402_FACILITATOR_URL: string;
   /** Canonical public origin, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
   PATIENTGUIDE_ORIGIN: string;
+  /** Shared secret sent to the Netlify function to block direct origin access. Set via `wrangler secret put`. */
+  X402_WORKER_SECRET: string;
 }
 
 // ── Env validation ─────────────────────────────────────────────────────────────
 
-/**
- * Validate all required env vars are present and the network is base-sepolia.
- * Returns an error Response if invalid, null if ok.
- * Never includes secret values in the error response.
- */
 function validateEnv(env: Env): Response | null {
   const required: Array<keyof Env> = [
     "X402_NETWORK",
@@ -52,6 +56,7 @@ function validateEnv(env: Env): Response | null {
     "X402_RECEIVING_ADDRESS",
     "X402_FACILITATOR_URL",
     "PATIENTGUIDE_ORIGIN",
+    "X402_WORKER_SECRET",
   ];
 
   for (const key of required) {
@@ -71,29 +76,12 @@ function validateEnv(env: Env): Response | null {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-/**
- * Convert a decimal USDC amount string to atomic units (integer string).
- *
- * Supports up to 6 decimal places. Rejects negative, empty, multi-dot, or
- * out-of-precision inputs rather than silently rounding.
- *
- * Examples:
- *   "0.001"    → "1000"
- *   "0.01"     → "10000"
- *   "1"        → "1000000"
- *   "1.234567" → "1234567"
- *
- * Rejects: "abc", "0.0000001", "-1", "", "1.2.3"
- */
 function usdcToAtomicUnits(usdc: string): string {
-  // Accept only non-negative decimals with at most 6 fractional digits.
-  // The regex rejects: negatives, empty strings, multiple dots, > 6 decimals.
   const match = usdc.match(/^(\d+)(?:\.(\d{1,6}))?$/);
   if (!match) {
     throw new Error(`Invalid USDC amount: "${usdc}"`);
   }
   const intPart = match[1];
-  // Pad fractional to exactly 6 digits before converting to BigInt.
   const fracPart = (match[2] ?? "").padEnd(USDC_DECIMALS, "0");
   const atomicUnits =
     BigInt(intPart) * BigInt(10 ** USDC_DECIMALS) + BigInt(fracPart);
@@ -125,13 +113,11 @@ function build402Response(env: Env, resource: string): Response {
     status: 402,
     headers: {
       "Content-Type": "application/json",
-      // Mirror in header so x402-compatible clients can parse without reading the body.
       "X-PAYMENT-REQUIRED": JSON.stringify(body),
     },
   });
 }
 
-/** Produce a JSON error response. Never include secret values in the body. */
 function jsonError(status: number, error: string): Response {
   return new Response(JSON.stringify({ error }), {
     status,
@@ -182,6 +168,55 @@ async function settlePayment(
   return (await res.json()) as SettleResult;
 }
 
+// ── Shared payment gate ────────────────────────────────────────────────────────
+
+// Runs the full 402 → verify → settle flow for a given resource URL.
+// Returns { settled: SettleResult } on success, or a Response to return directly on failure.
+async function runPaymentGate(
+  env: Env,
+  resource: string,
+  paymentHeader: string | null
+): Promise<{ settled: SettleResult } | Response> {
+  const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
+  const paymentRequirements = buildPaymentRequirements(env, resource);
+
+  if (!paymentHeader) {
+    return build402Response(env, resource);
+  }
+
+  let verifyResult: VerifyResult;
+  try {
+    verifyResult = await verifyPayment(facilitatorBase, paymentHeader, paymentRequirements);
+  } catch {
+    return jsonError(502, "facilitator_unreachable");
+  }
+
+  if (!verifyResult.isValid) {
+    return jsonError(402, "payment_invalid");
+  }
+
+  let settleResult: SettleResult;
+  try {
+    settleResult = await settlePayment(facilitatorBase, paymentHeader, paymentRequirements);
+  } catch {
+    return jsonError(502, "payment_settlement_failed");
+  }
+
+  if (!settleResult.success) {
+    return jsonError(402, "payment_settlement_failed");
+  }
+
+  return { settled: settleResult };
+}
+
+function paymentReceiptHeader(settled: SettleResult, network: string): string {
+  return JSON.stringify({
+    success: true,
+    txHash: settled.txHash ?? null,
+    networkId: settled.networkId ?? network,
+  });
+}
+
 // ── Worker entry point ─────────────────────────────────────────────────────────
 
 export default {
@@ -201,80 +236,90 @@ export default {
     const envError = validateEnv(env);
     if (envError) return envError;
 
-    // Only /api/x402/ping is intentionally supported in Part 1.
-    // Any other /api/x402/* path gets 404 rather than silently falling through.
-    if (url.pathname !== "/api/x402/ping") {
-      return jsonError(404, "not_found");
-    }
-
-    // Build canonical resource URL using the public-facing origin.
-    // The Worker is reached via a Netlify proxy redirect from patientguide.io,
-    // so request.url reflects the workers.dev hostname internally. We canonicalize
-    // to the public origin so x402 payment binding matches the client-facing URL.
-    // Strip BOM (﻿) that PowerShell may prepend when secrets are set on Windows.
+    // Build canonical origin once — strip BOM that Windows PowerShell may
+    // prepend when secrets are set via piped input, and strip trailing slashes.
     const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\/+$/, "");
-    const resource = `${canonicalOrigin}${url.pathname}${url.search}`;
 
-    const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
-    const paymentRequirements = buildPaymentRequirements(env, resource);
     const paymentHeader = request.headers.get("X-PAYMENT");
 
-    // ── Step 1: Require payment ──────────────────────────────────────────────
-    if (!paymentHeader) {
-      return build402Response(env, resource);
+    // ── /api/x402/ping ───────────────────────────────────────────────────────
+    if (url.pathname === "/api/x402/ping") {
+      const resource = `${canonicalOrigin}${url.pathname}`;
+
+      const gateResult = await runPaymentGate(env, resource, paymentHeader);
+      if (gateResult instanceof Response) return gateResult;
+
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          service: "PatientGuide x402 test",
+          paid: true,
+          network: "eip155:84532",
+          networkName: "Base Sepolia",
+          origin: "cloudflare-worker",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "X-PAYMENT-RESPONSE": paymentReceiptHeader(gateResult.settled, env.X402_NETWORK),
+          },
+        }
+      );
     }
 
-    // ── Step 2: Verify with facilitator ─────────────────────────────────────
-    let verifyResult: VerifyResult;
-    try {
-      verifyResult = await verifyPayment(facilitatorBase, paymentHeader, paymentRequirements);
-    } catch {
-      return jsonError(502, "facilitator_unreachable");
-    }
+    // ── /api/x402/guide-brief ────────────────────────────────────────────────
+    if (url.pathname === "/api/x402/guide-brief") {
+      const slug = url.searchParams.get("slug");
 
-    if (!verifyResult.isValid) {
-      return jsonError(402, "payment_invalid");
-    }
-
-    // ── Step 3: Settle the payment ───────────────────────────────────────────
-    // Settlement is required before the resource is served.
-    // If the facilitator verifies but settlement fails, the Worker returns an
-    // error and does NOT serve the resource — it is never returned until payment
-    // is fully finalized.
-    let settleResult: SettleResult;
-    try {
-      settleResult = await settlePayment(facilitatorBase, paymentHeader, paymentRequirements);
-    } catch {
-      return jsonError(502, "payment_settlement_failed");
-    }
-
-    if (!settleResult.success) {
-      return jsonError(402, "payment_settlement_failed");
-    }
-
-    // ── Step 4: Return paid response directly from Worker ────────────────────
-    // /api/x402/ping is handled entirely within the Worker — no Netlify function
-    // is required or called. The JSON response is built here after settlement.
-    return new Response(
-      JSON.stringify({
-        ok: true,
-        service: "PatientGuide x402 test",
-        paid: true,
-        network: "eip155:84532",
-        networkName: "Base Sepolia",
-        origin: "cloudflare-worker",
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "X-PAYMENT-RESPONSE": JSON.stringify({
-            success: true,
-            txHash: settleResult.txHash ?? null,
-            networkId: settleResult.networkId ?? env.X402_NETWORK,
-          }),
-        },
+      // Validate slug before building payment requirements — clients should not
+      // be charged for a request that is structurally invalid.
+      if (!slug) {
+        return jsonError(400, "missing_slug");
       }
-    );
+      if (!SLUG_RE.test(slug)) {
+        return jsonError(400, "invalid_slug");
+      }
+
+      // Resource includes query string so payment proof binds to the specific guide.
+      const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
+
+      const gateResult = await runPaymentGate(env, resource, paymentHeader);
+      if (gateResult instanceof Response) return gateResult;
+
+      // ── Proxy to Netlify origin function ──────────────────────────────────
+      // Settlement is required before origin access. If settlement fails above,
+      // runPaymentGate returns an error Response and we never reach this point.
+      const originUrl =
+        `${canonicalOrigin}/.netlify/functions/x402-guide-brief` +
+        `?slug=${encodeURIComponent(slug)}`;
+
+      let originResponse: Response;
+      try {
+        originResponse = await fetch(originUrl, {
+          method: "GET",
+          headers: {
+            "X-Worker-Secret": env.X402_WORKER_SECRET,
+            "Accept": "application/json",
+          },
+        });
+      } catch {
+        return jsonError(502, "origin_unreachable");
+      }
+
+      const responseHeaders = new Headers(originResponse.headers);
+      responseHeaders.set(
+        "X-PAYMENT-RESPONSE",
+        paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
+      );
+
+      return new Response(originResponse.body, {
+        status: originResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ── Unknown /api/x402/* path ─────────────────────────────────────────────
+    return jsonError(404, "not_found");
   },
 };

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -40,4 +40,3 @@ X402_PRICE_USDC = "0.001"
 #   wrangler secret put X402_RECEIVING_ADDRESS
 #   wrangler secret put X402_FACILITATOR_URL
 #   wrangler secret put PATIENTGUIDE_ORIGIN
-#   wrangler secret put X402_WORKER_SECRET

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -40,3 +40,6 @@ X402_PRICE_USDC = "0.001"
 #   wrangler secret put X402_RECEIVING_ADDRESS
 #   wrangler secret put X402_FACILITATOR_URL
 #   wrangler secret put PATIENTGUIDE_ORIGIN
+#   wrangler secret put X402_WORKER_SECRET
+# Set the same X402_WORKER_SECRET value in Netlify:
+#   Site settings → Environment variables → X402_WORKER_SECRET

--- a/netlify/functions/x402-guide-brief.ts
+++ b/netlify/functions/x402-guide-brief.ts
@@ -1,0 +1,98 @@
+/**
+ * x402 guide-brief — paid structured guide metadata endpoint.
+ *
+ * Called by the Cloudflare x402 Worker AFTER a valid testnet payment is
+ * verified AND settled. Not intended for direct browser or curl access.
+ *
+ * SAFETY: X402_WORKER_SECRET must match the Worker secret. Absent or
+ * mismatched secret returns 403. Missing secret in production returns 500.
+ *
+ * Data source: x402-guide-briefs.json — built at deploy time from
+ * src/content/guides/ via scripts/build-x402-guide-briefs.mjs.
+ *
+ * TESTNET ONLY — Base Sepolia (eip155:84532).
+ */
+
+import type { Handler, HandlerEvent } from "@netlify/functions";
+import { createRequire } from "node:module";
+
+// esbuild inlines the JSON at bundle time — the file does not need to exist
+// alongside the deployed function at runtime.
+const _require = createRequire(import.meta.url);
+const GUIDE_BRIEFS: Record<string, GuideBrief> = _require("./x402-guide-briefs.json");
+
+interface RelatedGuide {
+  title: string;
+  slug: string;
+  url: string;
+}
+
+interface GuideBrief {
+  slug: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  publishDate: string | null;
+  updatedDate: string | null;
+  tags: string[];
+  keyPoints: string[];
+  relatedGuides: RelatedGuide[];
+  canonicalUrl: string;
+}
+
+// Same allowed-slug pattern used by the Worker.
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,99}$/;
+
+// Local-only bypass: allowed when running `netlify dev` or plain Node locally.
+// In all Netlify-deployed contexts (production, branch-deploy, deploy-preview),
+// NETLIFY=true and CONTEXT !== "dev", so the bypass does not apply.
+const isLocalDev = process.env.CONTEXT === "dev" || !process.env.NETLIFY;
+
+function json(status: number, body: unknown, extra?: Record<string, string>): ReturnType<Handler> {
+  return {
+    statusCode: status,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store", ...extra },
+  };
+}
+
+function getSlug(event: HandlerEvent): string | null {
+  return event.queryStringParameters?.slug ?? null;
+}
+
+export const handler: Handler = async (event) => {
+  // ── Secret enforcement ──────────────────────────────────────────────────
+  const expectedSecret = process.env.X402_WORKER_SECRET;
+
+  if (!expectedSecret) {
+    if (!isLocalDev) {
+      return json(500, { error: "x402_origin_not_configured" });
+    }
+    // Local dev without a configured secret: skip enforcement.
+  } else {
+    const provided = event.headers["x-worker-secret"];
+    if (provided !== expectedSecret) {
+      return json(403, { error: "forbidden" });
+    }
+  }
+
+  // ── Slug validation ─────────────────────────────────────────────────────
+  const slug = getSlug(event);
+
+  if (!slug) {
+    return json(400, { error: "missing_slug" });
+  }
+
+  if (!SLUG_RE.test(slug)) {
+    return json(400, { error: "invalid_slug" });
+  }
+
+  // ── Guide lookup ────────────────────────────────────────────────────────
+  const brief = GUIDE_BRIEFS[slug];
+
+  if (!brief) {
+    return json(404, { error: "guide_not_found" });
+  }
+
+  return json(200, brief);
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "chatbot:index": "node scripts/build-chatbot-index.mjs",
-    "prebuild": "rm -rf .astro node_modules/.astro/data-store.json && node scripts/build-chatbot-index.mjs",
+    "prebuild": "rm -rf .astro node_modules/.astro/data-store.json && node scripts/build-chatbot-index.mjs && node scripts/build-x402-guide-briefs.mjs",
     "build": "astro build",
     "postbuild": "pagefind --site dist",
     "preview": "astro preview",

--- a/scripts/build-x402-guide-briefs.mjs
+++ b/scripts/build-x402-guide-briefs.mjs
@@ -1,0 +1,111 @@
+// scripts/build-x402-guide-briefs.mjs
+// Builds the guide brief index used by the x402 Netlify function.
+// Run: node scripts/build-x402-guide-briefs.mjs
+// Output: netlify/functions/x402-guide-briefs.json
+//
+// Included in the prebuild step so every Netlify deploy has current data.
+// Only non-draft guides are included.
+
+import { readdir, readFile, writeFile } from "fs/promises";
+import { join, resolve } from "path";
+import matter from "gray-matter";
+
+const ROOT = resolve(".");
+const GUIDES_DIR = join(ROOT, "src/content/guides");
+const OUTPUT = join(ROOT, "netlify/functions/x402-guide-briefs.json");
+const CANONICAL_BASE = "https://patientguide.io";
+
+// Split content into sections on ## headings.
+// Returns the body of the first section whose title matches headingName (case-insensitive).
+function extractSection(content, headingName) {
+  const lines = content.split("\n");
+  let inSection = false;
+  const result = [];
+
+  for (const line of lines) {
+    if (/^##\s+/.test(line)) {
+      if (inSection) break;
+      const title = line.replace(/^##\s+/, "").trim();
+      if (title.toLowerCase() === headingName.toLowerCase()) {
+        inSection = true;
+      }
+    } else if (inSection) {
+      result.push(line);
+    }
+  }
+
+  return result.join("\n").trim();
+}
+
+function extractKeyPoints(content, fmKeyPoints) {
+  if (Array.isArray(fmKeyPoints) && fmKeyPoints.length > 0) {
+    return fmKeyPoints;
+  }
+  const section = extractSection(content, "Key Points");
+  if (!section) return [];
+  return section
+    .split("\n")
+    .map((line) => line.replace(/^[-*+]\s+/, "").trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#") && line !== "---");
+}
+
+function extractRelatedGuides(content) {
+  const section = extractSection(content, "Related Guides");
+  if (!section) return [];
+  const guides = [];
+  const re = /\[([^\]]+)\]\(\/guides\/([a-z0-9][a-z0-9-]*)\)/g;
+  let m;
+  while ((m = re.exec(section)) !== null) {
+    guides.push({
+      title: m[1].trim(),
+      slug: m[2],
+      url: `${CANONICAL_BASE}/guides/${m[2]}`,
+    });
+  }
+  return guides;
+}
+
+const files = (await readdir(GUIDES_DIR)).filter((f) => /\.(md|mdx)$/.test(f));
+const briefs = {};
+let skipped = 0;
+
+for (const file of files) {
+  const filePath = join(GUIDES_DIR, file);
+  // Strip BOM that Windows editors may prepend
+  const raw = (await readFile(filePath, "utf-8")).replace(/^﻿/, "");
+
+  let fm, content;
+  try {
+    const parsed = matter(raw);
+    fm = parsed.data;
+    content = parsed.content;
+  } catch {
+    skipped++;
+    continue;
+  }
+
+  if (fm.draft === true) {
+    skipped++;
+    continue;
+  }
+
+  const slug = (typeof fm.slug === "string" && fm.slug) || file.replace(/\.(md|mdx)$/, "");
+
+  briefs[slug] = {
+    slug,
+    title: fm.title ?? slug,
+    description: fm.description ?? null,
+    category: fm.category ?? null,
+    publishDate: fm.publishDate ?? null,
+    updatedDate: fm.updatedDate ?? null,
+    tags: Array.isArray(fm.tags) ? fm.tags : [],
+    keyPoints: extractKeyPoints(content, fm.keyPoints),
+    relatedGuides: extractRelatedGuides(content),
+    canonicalUrl: `${CANONICAL_BASE}/guides/${slug}`,
+  };
+}
+
+await writeFile(OUTPUT, JSON.stringify(briefs, null, 2), "utf-8");
+console.log(
+  `x402-guide-briefs.json: ${Object.keys(briefs).length} guides (${skipped} skipped)`
+);


### PR DESCRIPTION
## Summary

- Adds `/api/x402/guide-brief?slug=<slug>` — a paid API endpoint for structured guide metadata
- Humans still access `/guides/*` for free; machines/agents pay for structured JSON via x402
- Worker gates payment on Base Sepolia testnet (`eip155:84532`); after settlement, proxies to new Netlify function
- Origin is protected by `X-Worker-Secret` header (stored as Wrangler secret and Netlify env var — secrets already set)
- Build script (`scripts/build-x402-guide-briefs.mjs`) generates `netlify/functions/x402-guide-briefs.json` at deploy time; added to `prebuild` so every Netlify deploy has current data
- Generated JSON gitignored (like `chatbot-index.json`)

## Architecture

```
Client → patientguide.io/api/x402/guide-brief?slug=hypertension
       → Netlify proxy redirect
       → Cloudflare Worker (pays gate: 402 → verify → settle)
       → Netlify function x402-guide-brief (reads pre-built guide briefs JSON)
       → Returns structured metadata JSON
```

## Pre-deploy verification (Worker live, Netlify function deploys on merge)

| Endpoint | Status | Notes |
|---|---|---|
| `/api/x402/ping` | ✅ 402 | resource: `https://patientguide.io/api/x402/ping` |
| `/api/x402/guide-brief?slug=hypertension` | ✅ 402 | resource: `https://patientguide.io/api/x402/guide-brief?slug=hypertension` |
| `/api/x402/guide-brief` (no slug) | ✅ 400 | missing_slug before payment |
| `/api/x402/guide-brief?slug=../etc` | ✅ 400 | invalid_slug guard |
| `/` | ✅ 200 | |
| `/guides/hypertension` | ✅ 301 | |
| `/robots.txt` | ✅ 200 | |
| `/sitemap.xml` | ✅ 301 | |

**After merging:** Netlify deploys `x402-guide-brief.ts` and `x402-guide-briefs.json` (built from content collection). The paid proxy path and origin bypass (`403` without `X-Worker-Secret`) become fully verifiable.

## Part 3

Mainnet (`eip155:8453`) remains disabled. Not planned.

## Test plan

- [ ] Merge PR → confirm Netlify build completes with `x402-guide-briefs.json: N guides` in build log
- [ ] `curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypertension"` → `403 forbidden` (no secret)
- [ ] After testnet payment: `curl -i ... -H "X-PAYMENT: <proof>"` → 200 with guide brief JSON
- [ ] Confirm public routes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)