### PR TITLE
chore(x402): add guarded Base mainnet micro-test config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
 .env.production
+*.local
 
 # macOS-specific files
 .DS_Store

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -204,24 +204,103 @@ causes the Worker to return `503 x402_network_not_allowed` — fails closed.
 | `/search/*` | Netlify (Astro) | ✅ yes |
 | `/sitemap*.xml` | Netlify (Astro) | ✅ yes |
 | `/robots.txt` | Netlify (Astro) | ✅ yes |
-| `/api/x402/ping` | Cloudflare Worker | x402 gated (testnet) |
-| `/api/x402/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated (testnet) |
+| `/api/x402/ping` | Cloudflare Worker | x402 gated |
+| `/api/x402/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated |
 
 ---
 
-## Part 3 — Mainnet (disabled, not planned)
+## Part 3 — Guarded Base mainnet micro-test
 
-Part 3 would be moving to mainnet (`eip155:8453`). This is intentionally disabled.
-All of the following changes would be required before mainnet:
+> **Status: code-ready, not yet deployed.**
+> The Worker now supports an explicit mode switch. Mainnet requires setting
+> secrets via `wrangler secret put` and deploying — see below.
 
-- Set `X402_NETWORK` to `eip155:8453` in `wrangler.toml`
-- Update `REQUIRED_NETWORK` in `src/index.ts` to `"eip155:8453"`
-- Update `USDC_BASE_SEPOLIA` to the mainnet USDC contract address
-- Update `X402_RECEIVING_ADDRESS` to a mainnet wallet
-- A separate PR review with explicit sign-off
+### Mode switch overview
 
-> `eip155:8453` = Base mainnet. Using this value would enable **real** USDC
-> payments with real monetary value. This experiment is `eip155:84532` (testnet) only.
+| Var | Testnet | Mainnet micro-test |
+|---|---|---|
+| `X402_MODE` | `testnet` (default) | `mainnet` |
+| `X402_NETWORK` | `eip155:84532` | `eip155:8453` |
+| `X402_PRICE_USDC` | `0.001` | `0.001` |
+| `X402_RECEIVING_ADDRESS` | testnet wallet | `0x21Eacb622931926616C9a458648E7BA02A198561` |
+| USDC asset | Base Sepolia USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+**Native Base mainnet USDC verified via:** Uniswap default token list, CoinGecko Base
+token list, and EIP-55 checksum — `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
+
+Do NOT use:
+- USDT or any non-USDC token
+- L2 Standard Bridged USDC (different contract)
+- Ethereum mainnet USDC
+- Base Sepolia USDC contract in mainnet mode
+
+### Guard behaviour
+
+The Worker enforces all of the following at runtime, returning `503` if any fails:
+
+| Check | Error code |
+|---|---|
+| `X402_MODE` is missing or unknown | `x402_invalid_mode` |
+| `X402_NETWORK` does not match `X402_MODE` | `x402_mode_network_mismatch` |
+| Any required env var is absent | `x402_not_configured` |
+| Mainnet price > 0.01 USDC without override | `x402_mainnet_price_cap_exceeded` |
+
+Mainnet is **never** inferred from the network value alone. Both `X402_MODE=mainnet`
+AND `X402_NETWORK=eip155:8453` must be set together. Mismatch fails closed.
+
+### Mainnet price cap
+
+In mainnet mode, `X402_PRICE_USDC` above `0.01` causes `503 x402_mainnet_price_cap_exceeded`
+unless `X402_ALLOW_HIGHER_MAINNET_PRICE=true` is also set.
+
+For the micro-test, set `X402_PRICE_USDC=0.001` and do **not** set
+`X402_ALLOW_HIGHER_MAINNET_PRICE`.
+
+### Wallet rules
+
+| Wallet | Role | Needs funding | Private key used? |
+|---|---|---|---|
+| Buyer `0x4B0116EEb712b02a93dB8F5d3FFBa9e1C71407dD` | Signs EIP-3009 auth | Yes — small Base ETH + small Base USDC | Yes — locally only |
+| Receiver `0x21Eacb622931926616C9a458648E7BA02A198561` | Receives USDC after settlement | No — starts blank | **Never** |
+
+The receiver wallet only needs to exist as an address. Do not fund it. Do not use its
+private key anywhere. It receives the USDC payment from the facilitator after settlement.
+
+### To deploy mainnet micro-test
+
+> **Wait for explicit instruction before deploying.**
+
+When ready, set mainnet secrets (do NOT commit these values):
+
+```bash
+cd cloudflare/x402-worker
+
+# These override wrangler.toml [vars] at runtime
+wrangler secret put X402_MODE              # mainnet
+wrangler secret put X402_NETWORK           # eip155:8453
+wrangler secret put X402_RECEIVING_ADDRESS # 0x21Eacb622931926616C9a458648E7BA02A198561
+wrangler secret put X402_PRICE_USDC        # 0.001
+wrangler secret put X402_FACILITATOR_URL   # https://x402.org/facilitator
+wrangler secret put PATIENTGUIDE_ORIGIN    # https://patientguide.io
+wrangler secret put X402_WORKER_SECRET     # (same value as Netlify)
+
+# Then deploy
+npm run deploy
+```
+
+To revert to testnet: set `X402_MODE=testnet` and `X402_NETWORK=eip155:84532` via
+`wrangler secret put`, then redeploy. No code changes needed.
+
+### Public routes remain free
+
+Enabling mainnet mode does **not** affect public routes. `/guides/*`, `/posts/*`, and
+all other public Astro pages remain completely free and unaffected. Only `/api/x402/*`
+is gated, and only after payment is verified and settled.
+
+### Direct origin protection remains intact
+
+The Netlify function `/.netlify/functions/x402-guide-brief` continues to require
+`X-Worker-Secret` and returns `403` for direct access regardless of mode.
 
 ---
 
@@ -229,11 +308,12 @@ All of the following changes would be required before mainnet:
 
 | Path | Purpose |
 |---|---|
-| `cloudflare/x402-worker/src/index.ts` | Worker entry point — x402 gate logic |
-| `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config |
+| `cloudflare/x402-worker/src/index.ts` | Worker entry point — x402 gate + mode switch |
+| `cloudflare/x402-worker/wrangler.toml` | Cloudflare Worker config (testnet defaults) |
 | `netlify/functions/x402-guide-brief.ts` | Paid guide brief origin endpoint |
 | `netlify/functions/x402-guide-briefs.json` | Pre-built guide brief data (gitignored — built at deploy time) |
 | `scripts/build-x402-guide-briefs.mjs` | Build script that generates x402-guide-briefs.json |
+| `scripts/test-x402-paid-request.mjs` | Local buyer test client (testnet + mainnet) |
 
 ---
 
@@ -246,7 +326,7 @@ cd cloudflare/x402-worker
 npm install
 ```
 
-### 2. Configure Worker secrets
+### 2. Configure Worker secrets (testnet)
 
 ```bash
 wrangler secret put X402_RECEIVING_ADDRESS    # Base Sepolia wallet address
@@ -294,9 +374,82 @@ curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypert
 
 | Variable | Where | Description |
 |---|---|---|
-| `X402_NETWORK` | `wrangler.toml [vars]` | CAIP-2 chain — must be `eip155:84532`. `eip155:8453` is mainnet and must not be used. |
-| `X402_PRICE_USDC` | `wrangler.toml [vars]` | Price per request in USDC decimal string |
-| `X402_RECEIVING_ADDRESS` | Wrangler secret | Base Sepolia testnet wallet address |
+| `X402_MODE` | `wrangler.toml [vars]` or secret | `"testnet"` (default) or `"mainnet"`. Unknown values fail closed. |
+| `X402_NETWORK` | `wrangler.toml [vars]` or secret | CAIP-2 chain. Must match `X402_MODE`: testnet→`eip155:84532`, mainnet→`eip155:8453`. |
+| `X402_PRICE_USDC` | `wrangler.toml [vars]` or secret | Price per request in decimal USDC. Mainnet capped at 0.01 without override. |
+| `X402_RECEIVING_ADDRESS` | Wrangler secret | Receiving wallet. Testnet: any Sepolia address. Mainnet micro-test: `0x21Eacb…8561`. |
 | `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` |
 | `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` — used to canonicalize x402 resource URLs |
 | `X402_WORKER_SECRET` | Wrangler secret + Netlify env | Shared secret for Worker→origin auth; prevents direct origin bypass |
+| `X402_ALLOW_HIGHER_MAINNET_PRICE` | Wrangler secret (optional) | Set `"true"` to allow mainnet price above 0.01 USDC. Do not set for the micro-test. |
+
+---
+
+## Local buyer test client
+
+`scripts/test-x402-paid-request.mjs` works for both testnet and mainnet.
+
+### Required
+
+```bash
+export BUYER_PRIVATE_KEY=0x<disposable-wallet-private-key>
+```
+
+Use a **disposable** wallet. Never use a wallet that holds real funds you care about.
+The script never prints the private key.
+
+### Optional validation guards (strongly recommended for mainnet)
+
+```bash
+export X402_EXPECTED_NETWORK=eip155:8453   # abort before signing if network differs
+export X402_EXPECTED_PAYTO=0x21Eacb...     # abort before signing if payTo differs
+export X402_EXPECTED_ASSET=0x833589...     # abort before signing if asset differs
+export X402_MAX_USDC=0.001                 # abort before signing if price exceeds this
+```
+
+### Testnet run
+
+```bash
+export BUYER_PRIVATE_KEY=0x<disposable-sepolia-key>
+export X402_EXPECTED_NETWORK=eip155:84532
+export X402_MAX_USDC=0.01
+
+node scripts/test-x402-paid-request.mjs
+```
+
+Fund buyer with Base Sepolia test USDC: [faucet.circle.com](https://faucet.circle.com/) → Base Sepolia.
+
+### Mainnet micro-test run
+
+```bash
+export BUYER_PRIVATE_KEY=0x<disposable-base-mainnet-key>
+export X402_EXPECTED_NETWORK=eip155:8453
+export X402_EXPECTED_PAYTO=0x21Eacb622931926616C9a458648E7BA02A198561
+export X402_EXPECTED_ASSET=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+export X402_MAX_USDC=0.001
+
+node scripts/test-x402-paid-request.mjs
+```
+
+**Real USDC is spent.** Fund buyer with small Base mainnet ETH + small Base mainnet USDC.
+The receiver wallet (`0x21Eacb…8561`) does not need prior funding — it receives the
+USDC payment after the facilitator settles on-chain.
+
+### Security rules
+
+- Use a **disposable** wallet. Never use a wallet with real funds you care about.
+- Set `BUYER_PRIVATE_KEY` **only in your local shell**. Never in `.env` files.
+- The receiver private key is **never used** — it is only an address.
+- The script never prints the private key.
+- `.env.local` and `*.local` are gitignored.
+- Do not use Base Sepolia USDC settings on mainnet.
+- Do not use Ethereum mainnet USDC for Base payments.
+- Do not use USDT.
+
+### Protocol notes
+
+The Worker uses x402 version 1 with CAIP-2 network IDs. The `X-PAYMENT` header value
+is `base64(JSON.stringify(paymentPayload))`. Payment signing is EIP-712
+`TransferWithAuthorization` (EIP-3009) — the buyer signs an off-chain authorisation;
+no on-chain transaction is sent from the buyer. The facilitator at `x402.org` handles
+chain settlement after verifying the signature.

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -1,5 +1,21 @@
 /**
- * PatientGuide x402 Testnet Worker
+ * PatientGuide x402 Worker
+ *
+ * MODE SWITCH (X402_MODE):
+ *   "testnet"  — Base Sepolia (eip155:84532), testnet USDC, no real monetary value.
+ *   "mainnet"  — Base mainnet (eip155:8453), native USDC, REAL money.
+ *   Absent     — defaults to "testnet". Unknown values fail closed with 503.
+ *
+ * MODE / NETWORK CROSS-CHECK (fails closed):
+ *   testnet mode only allows eip155:84532.
+ *   mainnet mode only allows eip155:8453.
+ *   Any mismatch → 503 x402_mode_network_mismatch.
+ *   Mainnet is NEVER inferred from the network value alone.
+ *
+ * MAINNET PRICE GUARD:
+ *   In mainnet mode, X402_PRICE_USDC above 0.01 USDC causes 503 unless
+ *   X402_ALLOW_HIGHER_MAINNET_PRICE=true is also set. Do not set this for
+ *   the micro-test.
  *
  * SCOPE: Handles ONLY /api/x402/* — enforced both by wrangler.toml route binding
  * and by the belt-and-suspenders guard at the top of fetch().
@@ -8,70 +24,95 @@
  * never touched by this Worker because the Cloudflare route binding does not
  * match them. The guard below is a second layer of protection.
  *
- * TESTNET ONLY: X402_NETWORK is validated at runtime against REQUIRED_NETWORK
- * ("eip155:84532" = Base Sepolia testnet). Any other value — including the Base
- * mainnet identifier "eip155:8453" — causes the Worker to return 503 and refuse
- * all requests. It fails closed rather than accidentally enabling mainnet payments.
- *
  * ROUTES:
  *   /api/x402/ping         — Worker-only test endpoint (no origin call)
  *   /api/x402/guide-brief  — Paid structured guide metadata (proxies to Netlify origin)
  */
 
-// USDC contract on Base Sepolia (testnet — no real monetary value)
+// ── Asset constants ────────────────────────────────────────────────────────────
+
+// Testnet USDC — Base Sepolia. No real monetary value.
 const USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
+// Native USDC — Base mainnet. REAL money.
+// Verified: Uniswap default token list, CoinGecko Base token list,
+//           EIP-55 checksum via viem getAddress().
+// Do NOT substitute with bridged USDC, USDT, or Ethereum mainnet USDC.
+const USDC_BASE_MAINNET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
 const USDC_DECIMALS = 6;
 const X402_VERSION = 1;
 
-// CAIP-2 identifier for Base Sepolia testnet.
-//   eip155:84532 = Base Sepolia testnet  ← required value
-//   eip155:8453  = Base mainnet          ← DO NOT USE — enables real payments
-// Changing this requires a separate PR with explicit review.
-const REQUIRED_NETWORK = "eip155:84532";
+// ── Network constants ──────────────────────────────────────────────────────────
 
-// Allowed slug pattern — must match the same pattern in the Netlify function.
+const NETWORK_TESTNET = "eip155:84532"; // Base Sepolia — testnet
+const NETWORK_MAINNET = "eip155:8453";  // Base mainnet  — REAL money, use with care
+
+// ── Mainnet price cap ──────────────────────────────────────────────────────────
+
+// Maximum price allowed on mainnet without an explicit override env var.
+// Protects against accidental large charges during the micro-test.
+const MAINNET_PRICE_CAP_USDC = 0.01;
+
+// ── Slug validation ────────────────────────────────────────────────────────────
+
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,99}$/;
 
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type X402Mode = "testnet" | "mainnet";
+
 export interface Env {
-  /** Chain identifier — must equal REQUIRED_NETWORK ("eip155:84532"). Set in wrangler.toml [vars]. */
+  /**
+   * Mode switch.
+   *   "testnet" — Base Sepolia, testnet USDC, no real money. (default when absent)
+   *   "mainnet" — Base mainnet, native USDC, REAL money.
+   * Unknown values fail closed. Set in wrangler.toml [vars] for testnet;
+   * set via `wrangler secret put X402_MODE` for mainnet.
+   */
+  X402_MODE?: string;
+  /**
+   * CAIP-2 network identifier. Must exactly match X402_MODE:
+   *   testnet → eip155:84532 (Base Sepolia)
+   *   mainnet → eip155:8453  (Base mainnet)
+   * Mismatch fails closed. Set in wrangler.toml [vars].
+   */
   X402_NETWORK: string;
-  /** Price per request as a decimal USDC string, e.g. "0.001". Set in wrangler.toml [vars]. */
+  /** Price per request as decimal USDC, e.g. "0.001". Set in wrangler.toml [vars]. */
   X402_PRICE_USDC: string;
-  /** Testnet receiving wallet address. Set via `wrangler secret put`. */
+  /** Receiving wallet address. Set via `wrangler secret put X402_RECEIVING_ADDRESS`. */
   X402_RECEIVING_ADDRESS: string;
-  /** CDP / x402.org facilitator base URL (no trailing slash). Set via `wrangler secret put`. */
+  /** Facilitator base URL (no trailing slash). Set via `wrangler secret put X402_FACILITATOR_URL`. */
   X402_FACILITATOR_URL: string;
-  /** Canonical public origin, e.g. "https://patientguide.io". Set via `wrangler secret put`. */
+  /** Canonical public origin, e.g. "https://patientguide.io". Set via `wrangler secret put PATIENTGUIDE_ORIGIN`. */
   PATIENTGUIDE_ORIGIN: string;
-  /** Shared secret sent to the Netlify function to block direct origin access. Set via `wrangler secret put`. */
+  /** Shared secret for Worker→Netlify origin auth. Set via `wrangler secret put X402_WORKER_SECRET`. */
   X402_WORKER_SECRET: string;
+  /**
+   * Set to "true" to allow mainnet price above 0.01 USDC.
+   * Do NOT set this for the micro-test. Leave unset.
+   */
+  X402_ALLOW_HIGHER_MAINNET_PRICE?: string;
 }
 
-// ── Env validation ─────────────────────────────────────────────────────────────
+// ── Mode helpers ───────────────────────────────────────────────────────────────
 
-function validateEnv(env: Env): Response | null {
-  const required: Array<keyof Env> = [
-    "X402_NETWORK",
-    "X402_PRICE_USDC",
-    "X402_RECEIVING_ADDRESS",
-    "X402_FACILITATOR_URL",
-    "PATIENTGUIDE_ORIGIN",
-    "X402_WORKER_SECRET",
-  ];
-
-  for (const key of required) {
-    if (!env[key]) {
-      return jsonError(503, "x402_not_configured");
-    }
-  }
-
-  // Runtime enforcement: reject any network that is not base-sepolia.
-  // Fails closed — no payment requirements are built for unknown networks.
-  if (env.X402_NETWORK !== REQUIRED_NETWORK) {
-    return jsonError(503, "x402_network_not_allowed");
-  }
-
+function resolveMode(env: Env): X402Mode | null {
+  const raw = (env.X402_MODE ?? "testnet").trim();
+  if (raw === "testnet" || raw === "mainnet") return raw;
   return null;
+}
+
+function expectedNetwork(mode: X402Mode): string {
+  return mode === "mainnet" ? NETWORK_MAINNET : NETWORK_TESTNET;
+}
+
+function assetForMode(mode: X402Mode): string {
+  return mode === "mainnet" ? USDC_BASE_MAINNET : USDC_BASE_SEPOLIA;
+}
+
+function networkNameForMode(mode: X402Mode): string {
+  return mode === "mainnet" ? "Base" : "Base Sepolia";
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -88,25 +129,84 @@ function usdcToAtomicUnits(usdc: string): string {
   return atomicUnits.toString();
 }
 
-function buildPaymentRequirements(env: Env, resource: string) {
+function jsonError(status: number, error: string): Response {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── Env validation ─────────────────────────────────────────────────────────────
+
+function validateEnv(env: Env): Response | null {
+  // 1. Required fields (mode-independent)
+  const required: Array<keyof Env> = [
+    "X402_NETWORK",
+    "X402_PRICE_USDC",
+    "X402_RECEIVING_ADDRESS",
+    "X402_FACILITATOR_URL",
+    "PATIENTGUIDE_ORIGIN",
+    "X402_WORKER_SECRET",
+  ];
+  for (const key of required) {
+    if (!env[key]) {
+      return jsonError(503, "x402_not_configured");
+    }
+  }
+
+  // 2. Resolve mode — unknown value fails closed.
+  const mode = resolveMode(env);
+  if (!mode) {
+    return jsonError(503, "x402_invalid_mode");
+  }
+
+  // 3. Network must exactly match the mode.
+  //    Never infer mainnet from network alone. Never allow cross-mode values.
+  if (env.X402_NETWORK !== expectedNetwork(mode)) {
+    return jsonError(503, "x402_mode_network_mismatch");
+  }
+
+  // 4. Mainnet price guard — prevents accidental large charges.
+  if (mode === "mainnet") {
+    const price = parseFloat(env.X402_PRICE_USDC);
+    if (isNaN(price) || price <= 0) {
+      return jsonError(503, "x402_invalid_price");
+    }
+    if (price > MAINNET_PRICE_CAP_USDC) {
+      const override = (env.X402_ALLOW_HIGHER_MAINNET_PRICE ?? "").trim().toLowerCase();
+      if (override !== "true") {
+        return jsonError(503, "x402_mainnet_price_cap_exceeded");
+      }
+    }
+  }
+
+  return null;
+}
+
+// ── Payment requirements ───────────────────────────────────────────────────────
+
+function buildPaymentRequirements(env: Env, mode: X402Mode, resource: string) {
   return {
     scheme: "exact" as const,
     network: env.X402_NETWORK,
     maxAmountRequired: usdcToAtomicUnits(env.X402_PRICE_USDC),
     resource,
-    description: "PatientGuide x402 testnet experiment",
+    description:
+      mode === "mainnet"
+        ? "PatientGuide x402 mainnet micro-test"
+        : "PatientGuide x402 testnet experiment",
     mimeType: "application/json",
     payTo: env.X402_RECEIVING_ADDRESS,
     maxTimeoutSeconds: 300,
-    asset: USDC_BASE_SEPOLIA,
+    asset: assetForMode(mode),
     extra: { name: "USDC", version: "2" },
   };
 }
 
-function build402Response(env: Env, resource: string): Response {
+function build402Response(env: Env, mode: X402Mode, resource: string): Response {
   const body = {
     x402Version: X402_VERSION,
-    accepts: [buildPaymentRequirements(env, resource)],
+    accepts: [buildPaymentRequirements(env, mode, resource)],
     error: "Payment required — send X-PAYMENT header with payment proof",
   };
   return new Response(JSON.stringify(body), {
@@ -115,13 +215,6 @@ function build402Response(env: Env, resource: string): Response {
       "Content-Type": "application/json",
       "X-PAYMENT-REQUIRED": JSON.stringify(body),
     },
-  });
-}
-
-function jsonError(status: number, error: string): Response {
-  return new Response(JSON.stringify({ error }), {
-    status,
-    headers: { "Content-Type": "application/json" },
   });
 }
 
@@ -170,18 +263,17 @@ async function settlePayment(
 
 // ── Shared payment gate ────────────────────────────────────────────────────────
 
-// Runs the full 402 → verify → settle flow for a given resource URL.
-// Returns { settled: SettleResult } on success, or a Response to return directly on failure.
 async function runPaymentGate(
   env: Env,
+  mode: X402Mode,
   resource: string,
   paymentHeader: string | null
 ): Promise<{ settled: SettleResult } | Response> {
   const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
-  const paymentRequirements = buildPaymentRequirements(env, resource);
+  const paymentRequirements = buildPaymentRequirements(env, mode, resource);
 
   if (!paymentHeader) {
-    return build402Response(env, resource);
+    return build402Response(env, mode, resource);
   }
 
   let verifyResult: VerifyResult;
@@ -224,20 +316,23 @@ export default {
     const url = new URL(request.url);
 
     // SAFETY GUARD: Belt-and-suspenders route check.
-    // The [[routes]] binding in wrangler.toml already restricts this Worker to
-    // /api/x402/* only. This guard makes the constraint explicit in code so it
-    // cannot accidentally be widened by a future wrangler.toml edit.
+    // The [[routes]] binding in wrangler.toml restricts this Worker to /api/x402/*
+    // only. This guard makes the constraint explicit in code so it cannot
+    // accidentally be widened by a future wrangler.toml edit.
     if (!url.pathname.startsWith("/api/x402/")) {
       return jsonError(404, "not_found");
     }
 
-    // Validate env vars and enforce base-sepolia before doing anything else.
+    // Validate env (mode, network cross-check, price guard).
     // Fails closed — returns 503 rather than serving a misconfigured response.
     const envError = validateEnv(env);
     if (envError) return envError;
 
-    // Build canonical origin once — strip BOM that Windows PowerShell may
-    // prepend when secrets are set via piped input, and strip trailing slashes.
+    // Mode is guaranteed valid after validateEnv passes.
+    const mode = resolveMode(env) as X402Mode;
+
+    // Strip BOM that Windows PowerShell may prepend when secrets are set via
+    // piped input, and strip trailing slashes.
     const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\/+$/, "");
 
     const paymentHeader = request.headers.get("X-PAYMENT");
@@ -246,16 +341,17 @@ export default {
     if (url.pathname === "/api/x402/ping") {
       const resource = `${canonicalOrigin}${url.pathname}`;
 
-      const gateResult = await runPaymentGate(env, resource, paymentHeader);
+      const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
       if (gateResult instanceof Response) return gateResult;
 
       return new Response(
         JSON.stringify({
           ok: true,
-          service: "PatientGuide x402 test",
+          service: "PatientGuide x402",
           paid: true,
-          network: "eip155:84532",
-          networkName: "Base Sepolia",
+          mode,
+          network: env.X402_NETWORK,
+          networkName: networkNameForMode(mode),
           origin: "cloudflare-worker",
         }),
         {
@@ -284,7 +380,7 @@ export default {
       // Resource includes query string so payment proof binds to the specific guide.
       const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
 
-      const gateResult = await runPaymentGate(env, resource, paymentHeader);
+      const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
       if (gateResult instanceof Response) return gateResult;
 
       // ── Proxy to Netlify origin function ──────────────────────────────────

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -27,13 +27,32 @@ compatibility_date = "2025-01-01"
 #   zone_name = "patientguide.io"
 
 [vars]
-# Network identifier (CAIP-2 format) — Base Sepolia testnet.
-#   eip155:84532 = Base Sepolia testnet  ← this value
-#   eip155:8453  = Base mainnet          ← DO NOT USE — enables real payments
-# The Worker runtime also enforces this constant; any other value returns 503.
+# ── Mode switch ────────────────────────────────────────────────────────────────
+# X402_MODE controls which network and asset the Worker uses.
+#
+#   "testnet"  — Base Sepolia (eip155:84532), testnet USDC, NO real money.
+#   "mainnet"  — Base mainnet (eip155:8453),  native USDC, REAL money.
+#
+# Default: "testnet" when X402_MODE is absent.
+# Unknown values → 503. Mode/network mismatch → 503. Fails closed.
+#
+# To switch to mainnet for the micro-test, set X402_MODE and X402_NETWORK
+# via `wrangler secret put` (do NOT commit mainnet values here):
+#   wrangler secret put X402_MODE            # set to: mainnet
+#   wrangler secret put X402_NETWORK         # set to: eip155:8453
+#   wrangler secret put X402_RECEIVING_ADDRESS  # mainnet receiver address
+#   wrangler secret put X402_PRICE_USDC      # set to: 0.001
+# Then deploy: cd cloudflare/x402-worker && npm run deploy
+X402_MODE = "testnet"
+
+# Network identifier (CAIP-2). Must match X402_MODE exactly.
+#   testnet mode → eip155:84532 (Base Sepolia)
+#   mainnet mode → eip155:8453  (Base mainnet) — set as secret, not here
 X402_NETWORK = "eip155:84532"
 
-# Price per request in USDC (testnet USDC has no real monetary value).
+# Price per request in USDC.
+# Testnet USDC has no real monetary value.
+# Mainnet: capped at 0.01 USDC unless X402_ALLOW_HIGHER_MAINNET_PRICE=true.
 X402_PRICE_USDC = "0.001"
 
 # Secrets below are NOT stored here — set them with `wrangler secret put`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,16 @@
         "postcss": "^8.5.6",
         "remark-include": "^2.0.0",
         "tailwindcss": "^4.1.12",
+        "viem": "^2.53.1",
         "vite-tsconfig-paths": "^5.1.4"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -3073,6 +3081,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3846,6 +3896,45 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "3.20.0",
@@ -5033,6 +5122,28 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/abort-controller": {
@@ -9417,6 +9528,22 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -28270,6 +28397,37 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-event": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
@@ -31036,6 +31194,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/viem": {
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
@@ -31661,6 +31850,28 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "postcss": "^8.5.6",
     "remark-include": "^2.0.0",
     "tailwindcss": "^4.1.12",
+    "viem": "^2.53.1",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/scripts/test-x402-paid-request.mjs
+++ b/scripts/test-x402-paid-request.mjs
@@ -1,0 +1,326 @@
+/**
+ * Local-only x402 buyer test client — works for both Base Sepolia testnet and Base mainnet.
+ *
+ * Performs a real x402 payment flow (EIP-3009 off-chain signing) against any x402
+ * endpoint and confirms that the paid JSON body is returned.
+ *
+ * ── REQUIRED ──────────────────────────────────────────────────────────────────
+ *   BUYER_PRIVATE_KEY       0x-prefixed private key of a DISPOSABLE buyer wallet.
+ *                           For mainnet: fund with small Base ETH + Base USDC.
+ *                           For testnet: fund with Base Sepolia ETH + test USDC.
+ *                           NEVER use a wallet that holds real funds you care about.
+ *                           NEVER commit this key. NEVER put it in a .env file.
+ *
+ * ── OPTIONAL ──────────────────────────────────────────────────────────────────
+ *   X402_TEST_URL           Target URL. Default:
+ *                           https://patientguide.io/api/x402/guide-brief?slug=hypertension
+ *
+ *   X402_EXPECTED_NETWORK   Expected CAIP-2 network from the 402 response.
+ *                           If set and the endpoint returns a different network,
+ *                           the script aborts before signing. Example:
+ *                             testnet: eip155:84532
+ *                             mainnet: eip155:8453
+ *
+ *   X402_EXPECTED_PAYTO     Expected payTo address from the 402 response.
+ *                           Aborts before signing if the endpoint returns a
+ *                           different address.
+ *
+ *   X402_EXPECTED_ASSET     Expected asset (USDC contract) address from the 402.
+ *                           Aborts before signing if the endpoint returns a
+ *                           different asset.
+ *
+ *   X402_MAX_USDC           Maximum USDC amount you are willing to pay (decimal).
+ *                           Aborts before signing if the endpoint asks for more.
+ *                           Example: "0.001" or "0.01"
+ *                           Strongly recommended for mainnet runs.
+ *
+ * ── SECURITY RULES ────────────────────────────────────────────────────────────
+ *   • Use a DISPOSABLE wallet. Never reuse a wallet with real funds.
+ *   • Set BUYER_PRIVATE_KEY only in your local shell:
+ *       export BUYER_PRIVATE_KEY=0x...
+ *       node scripts/test-x402-paid-request.mjs
+ *   • The script never prints the private key.
+ *   • For mainnet: real USDC is spent on settlement.
+ *   • For mainnet: set X402_EXPECTED_NETWORK, X402_EXPECTED_PAYTO,
+ *     X402_EXPECTED_ASSET, and X402_MAX_USDC to protect against
+ *     endpoint misconfiguration before any signing happens.
+ *
+ * ── PROTOCOL NOTES ────────────────────────────────────────────────────────────
+ *   The Worker uses x402Version=1 with CAIP-2 network IDs.
+ *   X-PAYMENT = base64(JSON.stringify(paymentPayload))
+ *   Payment signing is EIP-712 TransferWithAuthorization (EIP-3009).
+ *   No on-chain transaction from the buyer — the x402.org facilitator settles.
+ */
+
+import { privateKeyToAccount } from "viem/accounts";
+import { toHex } from "viem";
+import { randomBytes } from "node:crypto";
+
+// ── Config ─────────────────────────────────────────────────────────────────────
+
+const BUYER_PRIVATE_KEY     = process.env.BUYER_PRIVATE_KEY;
+const X402_TEST_URL         = process.env.X402_TEST_URL
+  ?? "https://patientguide.io/api/x402/guide-brief?slug=hypertension";
+const EXPECTED_NETWORK      = process.env.X402_EXPECTED_NETWORK  ?? null;
+const EXPECTED_PAYTO        = process.env.X402_EXPECTED_PAYTO    ?? null;
+const EXPECTED_ASSET        = process.env.X402_EXPECTED_ASSET    ?? null;
+const MAX_USDC_RAW          = process.env.X402_MAX_USDC          ?? null;
+
+// ── Validate BUYER_PRIVATE_KEY ─────────────────────────────────────────────────
+
+if (!BUYER_PRIVATE_KEY) {
+  console.error("ERROR: BUYER_PRIVATE_KEY env var is required.");
+  console.error();
+  console.error("  Use a DISPOSABLE wallet. Never use a real-funds wallet.");
+  console.error("  Set it only in your local shell:");
+  console.error("    export BUYER_PRIVATE_KEY=0x...");
+  console.error("    node scripts/test-x402-paid-request.mjs");
+  console.error();
+  console.error("  Testnet faucets:");
+  console.error("    Base Sepolia ETH  : coinbase.com/faucets/base-ethereum-goerli-faucet");
+  console.error("    Base Sepolia USDC : faucet.circle.com  →  select Base Sepolia");
+  console.error();
+  console.error("  Mainnet (real funds — micro-test only):");
+  console.error("    Fund buyer wallet with small Base ETH + small Base USDC.");
+  console.error("    Receiver needs no funding — it only receives the payment.");
+  process.exit(1);
+}
+
+// ── Derive buyer address (never print the key) ─────────────────────────────────
+
+const account = privateKeyToAccount(/** @type {`0x${string}`} */ (BUYER_PRIVATE_KEY));
+
+// ── Parse X402_MAX_USDC ────────────────────────────────────────────────────────
+
+let maxAtomicUnits = null;
+if (MAX_USDC_RAW !== null) {
+  const parsed = parseFloat(MAX_USDC_RAW);
+  if (isNaN(parsed) || parsed <= 0) {
+    console.error(`ERROR: X402_MAX_USDC "${MAX_USDC_RAW}" is not a valid positive number.`);
+    process.exit(1);
+  }
+  maxAtomicUnits = BigInt(Math.round(parsed * 1_000_000));
+}
+
+// ── Header ─────────────────────────────────────────────────────────────────────
+
+console.log("PatientGuide x402 buyer test");
+console.log("─".repeat(55));
+console.log("Buyer address    :", account.address);
+console.log("Target URL       :", X402_TEST_URL);
+if (EXPECTED_NETWORK) console.log("Expected network :", EXPECTED_NETWORK);
+if (EXPECTED_PAYTO)   console.log("Expected payTo   :", EXPECTED_PAYTO);
+if (EXPECTED_ASSET)   console.log("Expected asset   :", EXPECTED_ASSET);
+if (MAX_USDC_RAW)     console.log("Max USDC         :", MAX_USDC_RAW);
+console.log();
+
+// ── Step 1: Probe — confirm 402 and parse payment requirements ─────────────────
+
+console.log("Step 1: Probing endpoint for 402…");
+let probe;
+try {
+  probe = await fetch(X402_TEST_URL);
+} catch (err) {
+  console.error("ERROR: Could not reach endpoint:", err.message);
+  process.exit(1);
+}
+
+if (probe.status !== 402) {
+  console.error(`ERROR: Expected HTTP 402 but got ${probe.status}.`);
+  const body = await probe.text().catch(() => "(unreadable)");
+  console.error("       Body:", body);
+  process.exit(1);
+}
+
+let paymentBody;
+try {
+  paymentBody = await probe.json();
+} catch {
+  console.error("ERROR: 402 response body is not valid JSON.");
+  process.exit(1);
+}
+
+const req = paymentBody.accepts?.[0];
+if (!req) {
+  console.error("ERROR: 402 body has no accepts array.");
+  console.error("       Body:", JSON.stringify(paymentBody));
+  process.exit(1);
+}
+
+// Human-readable USDC amount (atomic units ÷ 1,000,000)
+const humanUsdc = (Number(req.maxAmountRequired) / 1_000_000).toFixed(6).replace(/\.?0+$/, "");
+
+console.log("  x402Version       :", paymentBody.x402Version);
+console.log("  network           :", req.network);
+console.log("  payTo             :", req.payTo);
+console.log("  asset             :", req.asset);
+console.log("  maxAmountRequired :", req.maxAmountRequired, `(${humanUsdc} USDC)`);
+console.log("  resource          :", req.resource);
+console.log();
+
+// ── Step 2: Pre-signing safety checks (abort before any signing) ───────────────
+
+console.log("Step 2: Pre-signing safety checks…");
+
+// Network check
+if (EXPECTED_NETWORK && req.network !== EXPECTED_NETWORK) {
+  console.error(`ERROR: Network mismatch — aborting before signing.`);
+  console.error(`       Expected : ${EXPECTED_NETWORK}`);
+  console.error(`       Got      : ${req.network}`);
+  process.exit(1);
+}
+
+// payTo check
+if (EXPECTED_PAYTO) {
+  const normalise = (a) => a.toLowerCase();
+  if (normalise(req.payTo) !== normalise(EXPECTED_PAYTO)) {
+    console.error(`ERROR: payTo mismatch — aborting before signing.`);
+    console.error(`       Expected : ${EXPECTED_PAYTO}`);
+    console.error(`       Got      : ${req.payTo}`);
+    process.exit(1);
+  }
+}
+
+// Asset check
+if (EXPECTED_ASSET) {
+  const normalise = (a) => a.toLowerCase();
+  if (normalise(req.asset) !== normalise(EXPECTED_ASSET)) {
+    console.error(`ERROR: Asset mismatch — aborting before signing.`);
+    console.error(`       Expected : ${EXPECTED_ASSET}`);
+    console.error(`       Got      : ${req.asset}`);
+    process.exit(1);
+  }
+}
+
+// Price cap check
+if (maxAtomicUnits !== null) {
+  const required = BigInt(req.maxAmountRequired);
+  if (required > maxAtomicUnits) {
+    console.error(`ERROR: Price exceeds X402_MAX_USDC — aborting before signing.`);
+    console.error(`       Max allowed : ${MAX_USDC_RAW} USDC (${maxAtomicUnits} atomic)`);
+    console.error(`       Endpoint asks: ${humanUsdc} USDC (${req.maxAmountRequired} atomic)`);
+    process.exit(1);
+  }
+}
+
+// Derive chainId from CAIP-2 network identifier ("eip155:84532" → 84532)
+const chainId = parseInt(req.network.split(":")[1] ?? "", 10);
+if (isNaN(chainId)) {
+  console.error(`ERROR: Cannot parse chainId from network "${req.network}".`);
+  process.exit(1);
+}
+
+console.log("  All checks passed.");
+console.log();
+
+// ── Step 3: Sign EIP-712 TransferWithAuthorization ────────────────────────────
+
+console.log("Step 3: Signing EIP-712 TransferWithAuthorization…");
+
+// Random 32-byte nonce as 0x-prefixed hex (bytes32)
+const nonce = toHex(randomBytes(32));
+const now = Math.floor(Date.now() / 1000);
+const validAfter  = (now - 600).toString();  // 10-min grace window
+const validBefore = (now + Number(req.maxTimeoutSeconds)).toString();
+
+const signature = await account.signTypedData({
+  domain: {
+    name:              req.extra.name,       // "USDC"
+    version:           req.extra.version,    // "2"
+    chainId,
+    verifyingContract: /** @type {`0x${string}`} */ (req.asset),
+  },
+  types: {
+    TransferWithAuthorization: [
+      { name: "from",        type: "address" },
+      { name: "to",          type: "address" },
+      { name: "value",       type: "uint256" },
+      { name: "validAfter",  type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce",       type: "bytes32" },
+    ],
+  },
+  primaryType: "TransferWithAuthorization",
+  message: {
+    from:        account.address,
+    to:          /** @type {`0x${string}`} */ (req.payTo),
+    value:       BigInt(req.maxAmountRequired),
+    validAfter:  BigInt(validAfter),
+    validBefore: BigInt(validBefore),
+    nonce,
+  },
+});
+
+console.log("  Signature :", signature.slice(0, 22) + "…");
+console.log();
+
+// ── Step 4: Encode x402 v1 payment payload ────────────────────────────────────
+
+const paymentPayload = {
+  x402Version: 1,
+  scheme:  req.scheme,
+  network: req.network,
+  payload: {
+    authorization: {
+      from:        account.address,
+      to:          req.payTo,
+      value:       req.maxAmountRequired,
+      validAfter,
+      validBefore,
+      nonce,
+    },
+    signature,
+  },
+};
+
+// X-PAYMENT = base64(JSON.stringify(payload))  — x402 v1 spec
+const xPaymentHeader = Buffer.from(JSON.stringify(paymentPayload), "utf8").toString("base64");
+
+// ── Step 5: Paid request ───────────────────────────────────────────────────────
+
+console.log("Step 4: Sending paid request with X-PAYMENT header…");
+let paidResponse;
+try {
+  paidResponse = await fetch(X402_TEST_URL, {
+    headers: {
+      "X-PAYMENT": xPaymentHeader,
+      "Accept":    "application/json",
+    },
+  });
+} catch (err) {
+  console.error("ERROR: Could not reach endpoint for paid request:", err.message);
+  process.exit(1);
+}
+
+// ── Result ─────────────────────────────────────────────────────────────────────
+
+console.log();
+console.log("─".repeat(55));
+console.log("HTTP Status         :", paidResponse.status);
+
+const xPaymentResponse = paidResponse.headers.get("x-payment-response");
+if (xPaymentResponse) {
+  console.log("X-PAYMENT-RESPONSE  :", xPaymentResponse);
+}
+
+if (!paidResponse.ok) {
+  const errBody = await paidResponse.text().catch(() => "(unreadable)");
+  console.error();
+  console.error("ERROR: Did not receive paid JSON response.");
+  console.error("       Body:", errBody);
+  process.exit(1);
+}
+
+let data;
+try {
+  data = await paidResponse.json();
+} catch {
+  console.error("ERROR: Paid response body is not valid JSON.");
+  process.exit(1);
+}
+
+console.log("Paid JSON returned  : YES");
+if (data.title) console.log("title               :", data.title);
+if (data.slug)  console.log("slug                :", data.slug);
+console.log();
+console.log("x402 end-to-end test PASSED.");


### PR DESCRIPTION
## Summary

- Adds `X402_MODE` switch (`testnet` | `mainnet`) to the Cloudflare Worker. Default remains `testnet` — no change to current live behaviour.
- Mode and network must cross-match exactly (`testnet`↔`eip155:84532`, `mainnet`↔`eip155:8453`); any mismatch fails closed with `503`.
- Mainnet price capped at 0.01 USDC without an explicit override var — protects against accidental large charges during the micro-test.
- Native Base mainnet USDC hardcoded and verified: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (Uniswap token list + CoinGecko + EIP-55 checksum).
- `buildPaymentRequirements()` selects asset by mode — no cross-mode pairing is possible in code.
- `scripts/test-x402-paid-request.mjs` rewritten: supports both networks, adds `X402_EXPECTED_NETWORK` / `X402_EXPECTED_PAYTO` / `X402_EXPECTED_ASSET` / `X402_MAX_USDC` guards that abort **before signing** if any expectation fails.
- README replaces the old "Part 3 disabled" stub with full guarded mainnet micro-test documentation.

## What does NOT change

- Live endpoint continues to serve testnet 402 responses — `X402_MODE` defaults to `testnet`.
- Public `/guides/*` and `/posts/*` remain completely free and untouched.
- Direct Netlify origin protection (403 without `X-Worker-Secret`) remains intact.
- No mainnet deployment in this PR — secrets must be set via `wrangler secret put` and `npm run deploy` run explicitly.

## Mainnet micro-test — to activate when ready

```bash
cd cloudflare/x402-worker
wrangler secret put X402_MODE              # mainnet
wrangler secret put X402_NETWORK           # eip155:8453
wrangler secret put X402_RECEIVING_ADDRESS # 0x21Eacb622931926616C9a458648E7BA02A198561
wrangler secret put X402_PRICE_USDC        # 0.001
npm run deploy
```

## Test plan

- [ ] `cd cloudflare/x402-worker && npm run type-check` — passes (verified locally)
- [ ] `npm run build` — passes (running in CI / verified locally)
- [ ] `curl -i https://patientguide.io/api/x402/guide-brief?slug=hypertension` — still returns 402 on `eip155:84532` after deploy
- [ ] Run buyer test script in testnet mode with `X402_EXPECTED_NETWORK=eip155:84532` and `X402_MAX_USDC=0.01`
- [ ] After mainnet deploy: run buyer test script with all four `X402_EXPECTED_*` guards set

🤖 Generated with [Claude Code](https://claude.ai/claude-code)