### PR TITLE
feat(x402): add Solana Devnet as second payment rail

### DIFF
--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -1,9 +1,9 @@
-# PatientGuide x402 Testnet Worker
+# PatientGuide x402 Worker
 
-> **Status: TESTNET ONLY — Base Sepolia (`eip155:84532`)**
-> This worker is a payment-gating experiment using the x402 protocol on Base Sepolia
-> testnet USDC. No real funds are involved. Mainnet (`eip155:8453`) is not configured
-> and must not be used in this experiment.
+> **Status: Base Sepolia testnet active. Base mainnet code-ready (not deployed). Solana Devnet rail added (not deployed).**
+> No real funds are involved in testnet or Solana Devnet operation.
+> Base mainnet (`eip155:8453`) requires explicit secrets + deploy step.
+> Solana mainnet is NOT supported in this build (requires CDP API keys).
 
 ---
 
@@ -25,10 +25,10 @@ gated resource:
 
 1. Makes an initial request → receives a `402` response with a JSON
    `X-PAYMENT-REQUIRED` header describing how to pay (token, amount, address).
-2. Signs a USDC transfer authorisation (EIP-3009 `transferWithAuthorization`)
-   without broadcasting it to the chain.
+2. Signs a USDC transfer authorisation without broadcasting it to the chain.
+   (EVM: EIP-3009 `transferWithAuthorization`. Solana: SVM-native signing via `@x402/svm`.)
 3. Re-sends the request with the signed authorisation in an `X-PAYMENT` header.
-4. The server verifies and settles the payment via a **facilitator** (Coinbase CDP),
+4. The server verifies and settles the payment via a **facilitator** (`x402.org/facilitator`),
    then returns the protected resource.
 
 The whole flow happens in one HTTP round-trip for the caller.
@@ -184,13 +184,15 @@ Direct access to `/.netlify/functions/x402-guide-brief` without the correct secr
 
 ## Network identifiers
 
-| Identifier | Chain | Allowed in this experiment |
+| CAIP-2 identifier | Chain | Status |
 |---|---|---|
-| `eip155:84532` | Base Sepolia testnet | ✅ yes |
-| `eip155:8453` | Base mainnet | ❌ NO — do not use |
+| `eip155:84532` | Base Sepolia testnet | ✅ active (default) |
+| `eip155:8453` | Base mainnet | code-ready — not deployed |
+| `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | Solana Devnet | code-ready — not deployed |
+| `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | Solana mainnet | ❌ NOT supported (requires CDP) |
 
-The Worker enforces `eip155:84532` at runtime. Any other value (including `eip155:8453`)
-causes the Worker to return `503 x402_network_not_allowed` — fails closed.
+The EVM path enforces mode/network consistency at runtime — a mismatch returns `503 x402_mode_network_mismatch`.
+The Solana Devnet endpoint is hard-coded to Devnet; Solana mainnet is blocked at code level.
 
 ---
 
@@ -204,8 +206,9 @@ causes the Worker to return `503 x402_network_not_allowed` — fails closed.
 | `/search/*` | Netlify (Astro) | ✅ yes |
 | `/sitemap*.xml` | Netlify (Astro) | ✅ yes |
 | `/robots.txt` | Netlify (Astro) | ✅ yes |
-| `/api/x402/ping` | Cloudflare Worker | x402 gated |
-| `/api/x402/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated |
+| `/api/x402/ping` | Cloudflare Worker | x402 gated (EVM) |
+| `/api/x402/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated (EVM) |
+| `/api/x402/solana/guide-brief` | Cloudflare Worker → Netlify fn | x402 gated (Solana Devnet) |
 
 ---
 
@@ -372,16 +375,25 @@ curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypert
 
 ## Environment variables reference
 
+### EVM (Base) rail
+
 | Variable | Where | Description |
 |---|---|---|
 | `X402_MODE` | `wrangler.toml [vars]` or secret | `"testnet"` (default) or `"mainnet"`. Unknown values fail closed. |
 | `X402_NETWORK` | `wrangler.toml [vars]` or secret | CAIP-2 chain. Must match `X402_MODE`: testnet→`eip155:84532`, mainnet→`eip155:8453`. |
 | `X402_PRICE_USDC` | `wrangler.toml [vars]` or secret | Price per request in decimal USDC. Mainnet capped at 0.01 without override. |
-| `X402_RECEIVING_ADDRESS` | Wrangler secret | Receiving wallet. Testnet: any Sepolia address. Mainnet micro-test: `0x21Eacb…8561`. |
-| `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` |
+| `X402_RECEIVING_ADDRESS` | Wrangler secret | Receiving wallet (EVM). Testnet: any Sepolia address. Mainnet: `0x21Eacb…8561`. |
+| `X402_FACILITATOR_URL` | Wrangler secret | `https://x402.org/facilitator` (shared by EVM and Solana rails) |
 | `PATIENTGUIDE_ORIGIN` | Wrangler secret | `https://patientguide.io` — used to canonicalize x402 resource URLs |
 | `X402_WORKER_SECRET` | Wrangler secret + Netlify env | Shared secret for Worker→origin auth; prevents direct origin bypass |
 | `X402_ALLOW_HIGHER_MAINNET_PRICE` | Wrangler secret (optional) | Set `"true"` to allow mainnet price above 0.01 USDC. Do not set for the micro-test. |
+
+### Solana Devnet rail
+
+| Variable | Where | Description |
+|---|---|---|
+| `X402_SOLANA_RECEIVING_ADDRESS` | Wrangler secret | **Required** to activate Solana rail. Base58 Solana public key. If absent → `503 x402_solana_not_configured`. |
+| `X402_SOLANA_PRICE_USDC` | `wrangler.toml [vars]` or secret (optional) | Price per request in decimal USDC. Defaults to `"0.001"` when absent. |
 
 ---
 
@@ -453,3 +465,92 @@ is `base64(JSON.stringify(paymentPayload))`. Payment signing is EIP-712
 `TransferWithAuthorization` (EIP-3009) — the buyer signs an off-chain authorisation;
 no on-chain transaction is sent from the buyer. The facilitator at `x402.org` handles
 chain settlement after verifying the signature.
+
+---
+
+## Part 4 — Solana Devnet rail
+
+> **Status: code-ready, not yet deployed.**
+> Adds `/api/x402/solana/guide-brief` as a second payment rail on Solana Devnet.
+> No real monetary value. Solana mainnet requires CDP API keys and is blocked at code level.
+
+### Why a separate endpoint
+
+The Solana endpoint lives at `/api/x402/solana/guide-brief` (not the same path as the
+EVM endpoint) to keep each rail independently testable and deployable. A single endpoint
+with multiple `accepts` entries is a future optimisation once both rails are proven.
+
+### Solana Devnet config values
+
+| Field | Value |
+|---|---|
+| Network (CAIP-2) | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+| USDC mint | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` (Circle devnet) |
+| USDC decimals | 6 (same as EVM USDC) |
+| Price default | `0.001` USDC = `1000` atomic units |
+| Facilitator | `https://x402.org/facilitator` (shared with EVM rail, no API key needed for devnet) |
+| Solana mainnet | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` — NOT enabled |
+
+### What the Worker does
+
+The Worker produces a standard x402 `402` response with Solana Devnet payment requirements.
+The `X-PAYMENT` header from the client is passed to the facilitator unchanged. The Worker
+never parses the Solana payment payload — all network-specific verification and on-chain
+settlement is handled by `x402.org/facilitator`.
+
+The Netlify origin function (`x402-guide-brief`) is network-agnostic; the same function
+serves both EVM and Solana paid responses.
+
+### To deploy Solana Devnet rail
+
+```bash
+cd cloudflare/x402-worker
+
+# Create a Solana devnet receiver wallet (e.g. solana-keygen new)
+# and provide its base58 public key:
+wrangler secret put X402_SOLANA_RECEIVING_ADDRESS
+# → paste base58 Solana public key
+
+# X402_FACILITATOR_URL must already be set (shared with EVM rail)
+# Then deploy:
+npm run deploy
+```
+
+### To verify
+
+```bash
+# Should return 402 with Solana Devnet network and devnet USDC mint
+curl -i "https://patientguide.io/api/x402/solana/guide-brief?slug=hypertension"
+```
+
+Confirm the `accepts[0]` in the response body:
+- `network`: `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`
+- `asset`: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`
+- `payTo`: your Solana devnet receiver public key
+- `maxAmountRequired`: `1000` (0.001 USDC)
+
+### Solana Devnet buyer test client
+
+A Solana test script is a **follow-up task** — it requires Solana-specific signing
+(`@x402/svm` or `@solana/web3.js`) which is fundamentally different from the EVM
+EIP-3009 flow. The existing `scripts/test-x402-paid-request.mjs` is EVM-only and
+cannot be used for Solana.
+
+**What a Solana buyer test would need:**
+- A Solana keypair (ed25519, not secp256k1) — generated with `solana-keygen new`
+- Devnet SOL for fees (Solana Devnet faucet: `solana airdrop 1`)
+- Devnet USDC — mint from [faucet.circle.com](https://faucet.circle.com/) → "Solana Devnet"
+- `@x402/svm` package for Solana payment payload construction
+- Guards equivalent to the EVM script (expected network, mint, receiver, max price)
+
+**Mainnet Solana note:** Solana mainnet requires a Coinbase CDP API key to use the CDP
+facilitator (`https://api.cdp.coinbase.com/platform/v2/x402`). This is a separate PR.
+
+### Facilitator support matrix
+
+| Network | Facilitator | API key required |
+|---|---|---|
+| Base Sepolia (`eip155:84532`) | `x402.org/facilitator` | No |
+| Base mainnet (`eip155:8453`) | `x402.org/facilitator` (verify) or CDP | TBD |
+| Solana Devnet | `x402.org/facilitator` | No |
+| Solana mainnet | `api.cdp.coinbase.com/platform/v2/x402` | Yes (CDP) |

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -25,11 +25,19 @@
  * match them. The guard below is a second layer of protection.
  *
  * ROUTES:
- *   /api/x402/ping         — Worker-only test endpoint (no origin call)
- *   /api/x402/guide-brief  — Paid structured guide metadata (proxies to Netlify origin)
+ *   /api/x402/ping                — Worker-only test endpoint (no origin call, Base/EVM)
+ *   /api/x402/guide-brief         — Paid structured guide metadata (Base/EVM)
+ *   /api/x402/solana/guide-brief  — Paid structured guide metadata (Solana Devnet)
+ *
+ * SOLANA DEVNET RAIL:
+ *   A second payment rail on Solana Devnet. No real monetary value.
+ *   Network: solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1
+ *   Facilitator: x402.org/facilitator (supports Solana Devnet without API key)
+ *   Requires: X402_SOLANA_RECEIVING_ADDRESS secret (base58 Solana public key)
+ *   Solana mainnet is NOT enabled — requires CDP API keys (future PR).
  */
 
-// ── Asset constants ────────────────────────────────────────────────────────────
+// ── EVM asset constants ────────────────────────────────────────────────────────
 
 // Testnet USDC — Base Sepolia. No real monetary value.
 const USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
@@ -43,10 +51,21 @@ const USDC_BASE_MAINNET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const USDC_DECIMALS = 6;
 const X402_VERSION = 1;
 
-// ── Network constants ──────────────────────────────────────────────────────────
+// ── EVM network constants ──────────────────────────────────────────────────────
 
 const NETWORK_TESTNET = "eip155:84532"; // Base Sepolia — testnet
 const NETWORK_MAINNET = "eip155:8453";  // Base mainnet  — REAL money, use with care
+
+// ── Solana constants (Devnet only — mainnet requires CDP API keys, future PR) ──
+
+// Devnet USDC mint issued by Circle. No real monetary value.
+// Faucet: faucet.circle.com → select "Solana Devnet"
+// Mainnet mint (future reference): EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+const USDC_SOLANA_DEVNET = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+
+// CAIP-2 identifier for Solana Devnet.
+// Mainnet CAIP-2 (future reference): solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
+const NETWORK_SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 
 // ── Mainnet price cap ──────────────────────────────────────────────────────────
 
@@ -61,6 +80,21 @@ const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,99}$/;
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 type X402Mode = "testnet" | "mainnet";
+
+// Shared shape for both EVM and Solana payment requirements.
+// Both chains use 6-decimal USDC and the same x402 "exact" scheme.
+interface PaymentRequirements {
+  scheme: "exact";
+  network: string;
+  maxAmountRequired: string;
+  resource: string;
+  description: string;
+  mimeType: string;
+  payTo: string;
+  maxTimeoutSeconds: number;
+  asset: string;
+  extra: Record<string, string>;
+}
 
 export interface Env {
   /**
@@ -80,7 +114,7 @@ export interface Env {
   X402_NETWORK: string;
   /** Price per request as decimal USDC, e.g. "0.001". Set in wrangler.toml [vars]. */
   X402_PRICE_USDC: string;
-  /** Receiving wallet address. Set via `wrangler secret put X402_RECEIVING_ADDRESS`. */
+  /** Receiving wallet address (EVM). Set via `wrangler secret put X402_RECEIVING_ADDRESS`. */
   X402_RECEIVING_ADDRESS: string;
   /** Facilitator base URL (no trailing slash). Set via `wrangler secret put X402_FACILITATOR_URL`. */
   X402_FACILITATOR_URL: string;
@@ -93,6 +127,19 @@ export interface Env {
    * Do NOT set this for the micro-test. Leave unset.
    */
   X402_ALLOW_HIGHER_MAINNET_PRICE?: string;
+  /**
+   * Solana Devnet receiver address (base58 public key).
+   * Set via `wrangler secret put X402_SOLANA_RECEIVING_ADDRESS`.
+   * If absent, /api/x402/solana/* returns 503 x402_solana_not_configured.
+   * Solana mainnet is not supported in this build.
+   */
+  X402_SOLANA_RECEIVING_ADDRESS?: string;
+  /**
+   * Price per request in USDC for the Solana Devnet endpoint.
+   * Defaults to "0.001" when absent. No cap enforced (devnet only, no real value).
+   * Set in wrangler.toml [vars] or via `wrangler secret put X402_SOLANA_PRICE_USDC`.
+   */
+  X402_SOLANA_PRICE_USDC?: string;
 }
 
 // ── Mode helpers ───────────────────────────────────────────────────────────────
@@ -183,11 +230,11 @@ function validateEnv(env: Env): Response | null {
   return null;
 }
 
-// ── Payment requirements ───────────────────────────────────────────────────────
+// ── EVM payment requirements ───────────────────────────────────────────────────
 
-function buildPaymentRequirements(env: Env, mode: X402Mode, resource: string) {
+function buildPaymentRequirements(env: Env, mode: X402Mode, resource: string): PaymentRequirements {
   return {
-    scheme: "exact" as const,
+    scheme: "exact",
     network: env.X402_NETWORK,
     maxAmountRequired: usdcToAtomicUnits(env.X402_PRICE_USDC),
     resource,
@@ -218,6 +265,41 @@ function build402Response(env: Env, mode: X402Mode, resource: string): Response 
   });
 }
 
+// ── Solana Devnet payment requirements ────────────────────────────────────────
+
+function buildSolanaPaymentRequirements(env: Env, resource: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK_SOLANA_DEVNET,
+    maxAmountRequired: usdcToAtomicUnits(env.X402_SOLANA_PRICE_USDC ?? "0.001"),
+    resource,
+    description: "PatientGuide x402 Solana Devnet experiment",
+    mimeType: "application/json",
+    // X402_SOLANA_RECEIVING_ADDRESS is validated before this function is called.
+    payTo: env.X402_SOLANA_RECEIVING_ADDRESS!,
+    maxTimeoutSeconds: 300,
+    asset: USDC_SOLANA_DEVNET,
+    // No EIP-712 domain for Solana — extra is empty.
+    // Client uses @x402/svm or equivalent for Solana-native signing.
+    extra: {},
+  };
+}
+
+function buildSolana402Response(env: Env, resource: string): Response {
+  const body = {
+    x402Version: X402_VERSION,
+    accepts: [buildSolanaPaymentRequirements(env, resource)],
+    error: "Payment required — send X-PAYMENT header with Solana payment proof",
+  };
+  return new Response(JSON.stringify(body), {
+    status: 402,
+    headers: {
+      "Content-Type": "application/json",
+      "X-PAYMENT-REQUIRED": JSON.stringify(body),
+    },
+  });
+}
+
 // ── Facilitator calls ──────────────────────────────────────────────────────────
 
 interface VerifyResult {
@@ -228,7 +310,7 @@ interface VerifyResult {
 async function verifyPayment(
   facilitatorBase: string,
   paymentHeader: string,
-  paymentRequirements: ReturnType<typeof buildPaymentRequirements>
+  paymentRequirements: PaymentRequirements
 ): Promise<VerifyResult> {
   const res = await fetch(`${facilitatorBase}/verify`, {
     method: "POST",
@@ -250,7 +332,7 @@ interface SettleResult {
 async function settlePayment(
   facilitatorBase: string,
   paymentHeader: string,
-  paymentRequirements: ReturnType<typeof buildPaymentRequirements>
+  paymentRequirements: PaymentRequirements
 ): Promise<SettleResult> {
   const res = await fetch(`${facilitatorBase}/settle`, {
     method: "POST",
@@ -261,24 +343,19 @@ async function settlePayment(
   return (await res.json()) as SettleResult;
 }
 
-// ── Shared payment gate ────────────────────────────────────────────────────────
+// ── Payment gate (network-agnostic core) ──────────────────────────────────────
 
-async function runPaymentGate(
-  env: Env,
-  mode: X402Mode,
-  resource: string,
-  paymentHeader: string | null
+async function runGate(
+  facilitatorBase: string,
+  requirements: PaymentRequirements,
+  paymentHeader: string | null,
+  build402: () => Response
 ): Promise<{ settled: SettleResult } | Response> {
-  const facilitatorBase = env.X402_FACILITATOR_URL.replace(/\/+$/, "");
-  const paymentRequirements = buildPaymentRequirements(env, mode, resource);
-
-  if (!paymentHeader) {
-    return build402Response(env, mode, resource);
-  }
+  if (!paymentHeader) return build402();
 
   let verifyResult: VerifyResult;
   try {
-    verifyResult = await verifyPayment(facilitatorBase, paymentHeader, paymentRequirements);
+    verifyResult = await verifyPayment(facilitatorBase, paymentHeader, requirements);
   } catch {
     return jsonError(502, "facilitator_unreachable");
   }
@@ -289,7 +366,7 @@ async function runPaymentGate(
 
   let settleResult: SettleResult;
   try {
-    settleResult = await settlePayment(facilitatorBase, paymentHeader, paymentRequirements);
+    settleResult = await settlePayment(facilitatorBase, paymentHeader, requirements);
   } catch {
     return jsonError(502, "payment_settlement_failed");
   }
@@ -299,6 +376,37 @@ async function runPaymentGate(
   }
 
   return { settled: settleResult };
+}
+
+// ── EVM payment gate (Base Sepolia / Base mainnet) ────────────────────────────
+
+async function runPaymentGate(
+  env: Env,
+  mode: X402Mode,
+  resource: string,
+  paymentHeader: string | null
+): Promise<{ settled: SettleResult } | Response> {
+  return runGate(
+    env.X402_FACILITATOR_URL.replace(/\/+$/, ""),
+    buildPaymentRequirements(env, mode, resource),
+    paymentHeader,
+    () => build402Response(env, mode, resource)
+  );
+}
+
+// ── Solana payment gate (Devnet only) ─────────────────────────────────────────
+
+async function runSolanaPaymentGate(
+  env: Env,
+  resource: string,
+  paymentHeader: string | null
+): Promise<{ settled: SettleResult } | Response> {
+  return runGate(
+    env.X402_FACILITATOR_URL.replace(/\/+$/, ""),
+    buildSolanaPaymentRequirements(env, resource),
+    paymentHeader,
+    () => buildSolana402Response(env, resource)
+  );
 }
 
 function paymentReceiptHeader(settled: SettleResult, network: string): string {
@@ -407,6 +515,56 @@ export default {
       responseHeaders.set(
         "X-PAYMENT-RESPONSE",
         paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
+      );
+
+      return new Response(originResponse.body, {
+        status: originResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ── /api/x402/solana/guide-brief ─────────────────────────────────────────
+    if (url.pathname === "/api/x402/solana/guide-brief") {
+      // Guard: receiver address must be configured. Fails closed if absent.
+      // Solana mainnet is not supported — this endpoint is Devnet-only.
+      if (!env.X402_SOLANA_RECEIVING_ADDRESS) {
+        return jsonError(503, "x402_solana_not_configured");
+      }
+
+      const slug = url.searchParams.get("slug");
+      if (!slug) return jsonError(400, "missing_slug");
+      if (!SLUG_RE.test(slug)) return jsonError(400, "invalid_slug");
+
+      // Resource path mirrors the EVM endpoint pattern but under /solana/.
+      // Binds the payment proof to this specific Solana endpoint + slug.
+      const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
+
+      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader);
+      if (gateResult instanceof Response) return gateResult;
+
+      // ── Proxy to Netlify origin function ──────────────────────────────────
+      // Same origin function as the EVM endpoint — content is network-agnostic.
+      const originUrl =
+        `${canonicalOrigin}/.netlify/functions/x402-guide-brief` +
+        `?slug=${encodeURIComponent(slug)}`;
+
+      let originResponse: Response;
+      try {
+        originResponse = await fetch(originUrl, {
+          method: "GET",
+          headers: {
+            "X-Worker-Secret": env.X402_WORKER_SECRET,
+            "Accept": "application/json",
+          },
+        });
+      } catch {
+        return jsonError(502, "origin_unreachable");
+      }
+
+      const responseHeaders = new Headers(originResponse.headers);
+      responseHeaders.set(
+        "X-PAYMENT-RESPONSE",
+        paymentReceiptHeader(gateResult.settled, NETWORK_SOLANA_DEVNET)
       );
 
       return new Response(originResponse.body, {

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -267,7 +267,7 @@ function build402Response(env: Env, mode: X402Mode, resource: string): Response 
 
 // ── Solana Devnet payment requirements ────────────────────────────────────────
 
-function buildSolanaPaymentRequirements(env: Env, resource: string): PaymentRequirements {
+function buildSolanaPaymentRequirements(env: Env, resource: string, payTo: string): PaymentRequirements {
   return {
     scheme: "exact",
     network: NETWORK_SOLANA_DEVNET,
@@ -275,8 +275,7 @@ function buildSolanaPaymentRequirements(env: Env, resource: string): PaymentRequ
     resource,
     description: "PatientGuide x402 Solana Devnet experiment",
     mimeType: "application/json",
-    // X402_SOLANA_RECEIVING_ADDRESS is validated before this function is called.
-    payTo: env.X402_SOLANA_RECEIVING_ADDRESS!,
+    payTo,
     maxTimeoutSeconds: 300,
     asset: USDC_SOLANA_DEVNET,
     // No EIP-712 domain for Solana — extra is empty.
@@ -285,10 +284,10 @@ function buildSolanaPaymentRequirements(env: Env, resource: string): PaymentRequ
   };
 }
 
-function buildSolana402Response(env: Env, resource: string): Response {
+function buildSolana402Response(env: Env, resource: string, payTo: string): Response {
   const body = {
     x402Version: X402_VERSION,
-    accepts: [buildSolanaPaymentRequirements(env, resource)],
+    accepts: [buildSolanaPaymentRequirements(env, resource, payTo)],
     error: "Payment required — send X-PAYMENT header with Solana payment proof",
   };
   return new Response(JSON.stringify(body), {
@@ -399,13 +398,14 @@ async function runPaymentGate(
 async function runSolanaPaymentGate(
   env: Env,
   resource: string,
-  paymentHeader: string | null
+  paymentHeader: string | null,
+  payTo: string
 ): Promise<{ settled: SettleResult } | Response> {
   return runGate(
     env.X402_FACILITATOR_URL.replace(/\/+$/, ""),
-    buildSolanaPaymentRequirements(env, resource),
+    buildSolanaPaymentRequirements(env, resource, payTo),
     paymentHeader,
-    () => buildSolana402Response(env, resource)
+    () => buildSolana402Response(env, resource, payTo)
   );
 }
 
@@ -525,9 +525,17 @@ export default {
 
     // ── /api/x402/solana/guide-brief ─────────────────────────────────────────
     if (url.pathname === "/api/x402/solana/guide-brief") {
-      // Guard: receiver address must be configured. Fails closed if absent.
+      // Note: validateEnv() above validates the shared EVM env (X402_RECEIVING_ADDRESS,
+      // X402_NETWORK, etc.) before reaching this branch. The EVM/testnet config must
+      // remain present even when only the Solana endpoint is exercised. Do not
+      // refactor validateEnv to skip EVM checks for Solana requests.
+
+      // Guard: trim before testing so a whitespace-only secret fails closed with
+      // x402_solana_not_configured rather than reaching the facilitator as an
+      // invalid payTo address and returning payment_invalid instead.
       // Solana mainnet is not supported — this endpoint is Devnet-only.
-      if (!env.X402_SOLANA_RECEIVING_ADDRESS) {
+      const solanaPayTo = env.X402_SOLANA_RECEIVING_ADDRESS?.trim();
+      if (!solanaPayTo) {
         return jsonError(503, "x402_solana_not_configured");
       }
 
@@ -539,7 +547,7 @@ export default {
       // Binds the payment proof to this specific Solana endpoint + slug.
       const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
 
-      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader);
+      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo);
       if (gateResult instanceof Response) return gateResult;
 
       // ── Proxy to Netlify origin function ──────────────────────────────────

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -62,3 +62,27 @@ X402_PRICE_USDC = "0.001"
 #   wrangler secret put X402_WORKER_SECRET
 # Set the same X402_WORKER_SECRET value in Netlify:
 #   Site settings → Environment variables → X402_WORKER_SECRET
+
+# ── Solana Devnet rail (optional second payment rail) ─────────────────────────
+#
+# Adds /api/x402/solana/guide-brief for Solana Devnet x402 payments.
+# No real monetary value. Solana mainnet is NOT supported in this build.
+#
+# Network : solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1  (Solana Devnet)
+# Mint    : 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU  (Circle devnet USDC)
+# Faucet  : faucet.circle.com → select "Solana Devnet"
+#
+# Facilitator: x402.org/facilitator supports Solana Devnet without API key.
+#   (Same X402_FACILITATOR_URL secret — no additional facilitator needed.)
+#
+# Required secret:
+#   wrangler secret put X402_SOLANA_RECEIVING_ADDRESS
+#   → base58 Solana public key of your devnet receiver wallet
+#   → If absent, /api/x402/solana/* returns 503 x402_solana_not_configured
+#
+# Optional var (defaults to "0.001" when absent):
+# X402_SOLANA_PRICE_USDC = "0.001"
+#
+# Mainnet reference (do NOT use — requires CDP API keys, future PR):
+#   Network : solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
+#   Mint    : EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v


### PR DESCRIPTION
## Summary

- Adds `/api/x402/solana/guide-brief` as a separate Solana Devnet x402 endpoint alongside the existing Base/EVM rail
- Zero TypeScript errors (strict mode, `@cloudflare/workers-types`)
- Solana mainnet is **blocked at code level** â€” requires CDP API keys (future PR)
- No secrets committed. No mainnet deployment. No public routes gated. Base EVM behaviour unchanged.

## What changed

### `cloudflare/x402-worker/src/index.ts`

- **`PaymentRequirements` interface** â€” shared type for EVM and Solana requirements, decouples facilitator calls from `ReturnType<typeof buildPaymentRequirements>`
- **`runGate()`** â€” network-agnostic payment gate core (verify â†’ settle); both EVM and Solana delegate to it
- **`runPaymentGate()`** â€” unchanged public signature; now delegates to `runGate()` internally
- **`runSolanaPaymentGate()`** â€” new; calls `buildSolanaPaymentRequirements()` and delegates to `runGate()`
- **Solana constants** â€” `USDC_SOLANA_DEVNET`, `NETWORK_SOLANA_DEVNET`; mainnet equivalents as comments only
- **`buildSolanaPaymentRequirements()`** â€” produces Solana Devnet payment requirements (`extra: {}`, no EIP-712 domain)
- **`/api/x402/solana/guide-brief` route** â€” fails closed (503) if `X402_SOLANA_RECEIVING_ADDRESS` absent; proxies to same Netlify origin function after settlement
- **`Env` interface** â€” adds optional `X402_SOLANA_RECEIVING_ADDRESS` and `X402_SOLANA_PRICE_USDC`

### `cloudflare/x402-worker/wrangler.toml`

Documents Solana Devnet config, required secret, and mainnet reference values (commented out).

### `cloudflare/x402-worker/README.md`

- Updated status header and network identifiers table
- Added Solana Devnet to public routes table
- Added **Part 4 â€” Solana Devnet rail** section covering config, deploy steps, buyer test requirements, and facilitator support matrix

## Solana Devnet config

| Field | Value |
|---|---|
| Network | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
| USDC mint | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` (Circle devnet) |
| Price default | `0.001` USDC = `1000` atomic units |
| Facilitator | `https://x402.org/facilitator` (shared with EVM rail, no API key needed for devnet) |

## To activate (not yet deployed)

```bash
wrangler secret put X402_SOLANA_RECEIVING_ADDRESS  # base58 Solana devnet public key
npm run deploy
```

## Solana test script

A Solana buyer test script is a **follow-up task** â€” it requires `@x402/svm` or `@solana/web3.js` for Solana-native signing (ed25519, not EIP-712). The existing EVM test script cannot be used for Solana. Documented in README Part 4.

## Type-check

```
npm run type-check  â†’  0 errors
```

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
