### PR TITLE
fix(x402): include Solana facilitator fee payer in payment requirements

### DIFF
--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -516,6 +516,11 @@ cd cloudflare/x402-worker
 wrangler secret put X402_SOLANA_RECEIVING_ADDRESS
 # → paste base58 Solana public key
 
+# Facilitator fee-payer address — required by @x402/svm.
+# Source: GET https://www.x402.org/facilitator/supported → signers["solana:*"][0]
+wrangler secret put X402_SOLANA_FEE_PAYER
+# → paste base58 fee-payer public key from the facilitator supported endpoint
+
 # X402_FACILITATOR_URL must already be set (shared with EVM rail)
 # Then deploy:
 npm run deploy
@@ -533,6 +538,7 @@ Confirm the `accepts[0]` in the response body:
 - `asset`: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`
 - `payTo`: your Solana devnet receiver public key
 - `maxAmountRequired`: `1000` (0.001 USDC)
+- `extra.feePayer`: the x402.org/facilitator fee-payer address you set in `X402_SOLANA_FEE_PAYER`
 
 ### Solana Devnet buyer test client
 

--- a/cloudflare/x402-worker/README.md
+++ b/cloudflare/x402-worker/README.md
@@ -367,6 +367,10 @@ npm run deploy
 curl -i "https://patientguide.io/api/x402/ping"
 curl -i "https://patientguide.io/api/x402/guide-brief?slug=hypertension"
 
+# Solana Devnet endpoint — requires X402_SOLANA_RECEIVING_ADDRESS + X402_SOLANA_FEE_PAYER
+# X402_SOLANA_FEE_PAYER: GET https://www.x402.org/facilitator/supported → signers["solana:*"][0]
+curl -i "https://patientguide.io/api/x402/solana/guide-brief?slug=hypertension"
+
 # Origin bypass check — should return 403
 curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypertension"
 ```
@@ -392,7 +396,8 @@ curl -i "https://patientguide.io/.netlify/functions/x402-guide-brief?slug=hypert
 
 | Variable | Where | Description |
 |---|---|---|
-| `X402_SOLANA_RECEIVING_ADDRESS` | Wrangler secret | **Required** to activate Solana rail. Base58 Solana public key. If absent → `503 x402_solana_not_configured`. |
+| `X402_SOLANA_RECEIVING_ADDRESS` | Wrangler secret | **Required.** Base58 Solana public key of your devnet receiver. If absent → `503 x402_solana_not_configured`. |
+| `X402_SOLANA_FEE_PAYER` | Wrangler secret | **Required.** Base58 public key of the x402.org/facilitator Solana fee-payer address. Required by `@x402/svm` — the client reads `extra.feePayer` from the 402 response to build its transaction. The facilitator validates it belongs to its own key pool. Source: `GET https://www.x402.org/facilitator/supported` → `signers["solana:*"][0]`. If absent → `503 x402_solana_fee_payer_not_configured`. Rotate if the facilitator rotates its Solana key pool. |
 | `X402_SOLANA_PRICE_USDC` | `wrangler.toml [vars]` or secret (optional) | Price per request in decimal USDC. Defaults to `"0.001"` when absent. |
 
 ---

--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -140,6 +140,21 @@ export interface Env {
    * Set in wrangler.toml [vars] or via `wrangler secret put X402_SOLANA_PRICE_USDC`.
    */
   X402_SOLANA_PRICE_USDC?: string;
+  /**
+   * Solana fee-payer address managed by the x402.org facilitator.
+   * Required by @x402/svm (ExactSvmScheme / ExactSvmSchemeV1): the client reads
+   * extra.feePayer from the 402 response to build the partially-signed transaction.
+   * The facilitator validates that this address belongs to its own key pool.
+   *
+   * Source: GET https://www.x402.org/facilitator/supported
+   *   → kinds[].extra.feePayer for network solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1
+   *   → signers["solana:*"][0]
+   *
+   * Set via `wrangler secret put X402_SOLANA_FEE_PAYER`.
+   * If absent, /api/x402/solana/* returns 503 x402_solana_fee_payer_not_configured.
+   * Rotate this value if x402.org/facilitator rotates its Solana key pool.
+   */
+  X402_SOLANA_FEE_PAYER?: string;
 }
 
 // ── Mode helpers ───────────────────────────────────────────────────────────────
@@ -267,7 +282,7 @@ function build402Response(env: Env, mode: X402Mode, resource: string): Response 
 
 // ── Solana Devnet payment requirements ────────────────────────────────────────
 
-function buildSolanaPaymentRequirements(env: Env, resource: string, payTo: string): PaymentRequirements {
+function buildSolanaPaymentRequirements(env: Env, resource: string, payTo: string, feePayer: string): PaymentRequirements {
   return {
     scheme: "exact",
     network: NETWORK_SOLANA_DEVNET,
@@ -278,16 +293,17 @@ function buildSolanaPaymentRequirements(env: Env, resource: string, payTo: strin
     payTo,
     maxTimeoutSeconds: 300,
     asset: USDC_SOLANA_DEVNET,
-    // No EIP-712 domain for Solana — extra is empty.
-    // Client uses @x402/svm or equivalent for Solana-native signing.
-    extra: {},
+    // feePayer is the x402.org/facilitator Solana address that sponsors gas fees.
+    // Required by @x402/svm; validated by the facilitator during verify/settle.
+    // Value sourced from GET https://www.x402.org/facilitator/supported (signers["solana:*"]).
+    extra: { feePayer },
   };
 }
 
-function buildSolana402Response(env: Env, resource: string, payTo: string): Response {
+function buildSolana402Response(env: Env, resource: string, payTo: string, feePayer: string): Response {
   const body = {
     x402Version: X402_VERSION,
-    accepts: [buildSolanaPaymentRequirements(env, resource, payTo)],
+    accepts: [buildSolanaPaymentRequirements(env, resource, payTo, feePayer)],
     error: "Payment required — send X-PAYMENT header with Solana payment proof",
   };
   return new Response(JSON.stringify(body), {
@@ -399,13 +415,14 @@ async function runSolanaPaymentGate(
   env: Env,
   resource: string,
   paymentHeader: string | null,
-  payTo: string
+  payTo: string,
+  feePayer: string
 ): Promise<{ settled: SettleResult } | Response> {
   return runGate(
     env.X402_FACILITATOR_URL.replace(/\/+$/, ""),
-    buildSolanaPaymentRequirements(env, resource, payTo),
+    buildSolanaPaymentRequirements(env, resource, payTo, feePayer),
     paymentHeader,
-    () => buildSolana402Response(env, resource, payTo)
+    () => buildSolana402Response(env, resource, payTo, feePayer)
   );
 }
 
@@ -530,13 +547,20 @@ export default {
       // remain present even when only the Solana endpoint is exercised. Do not
       // refactor validateEnv to skip EVM checks for Solana requests.
 
-      // Guard: trim before testing so a whitespace-only secret fails closed with
-      // x402_solana_not_configured rather than reaching the facilitator as an
-      // invalid payTo address and returning payment_invalid instead.
+      // Guard: trim before testing so whitespace-only secrets fail closed.
       // Solana mainnet is not supported — this endpoint is Devnet-only.
       const solanaPayTo = env.X402_SOLANA_RECEIVING_ADDRESS?.trim();
       if (!solanaPayTo) {
         return jsonError(503, "x402_solana_not_configured");
+      }
+
+      // feePayer must be the x402.org/facilitator Solana address (from its key pool).
+      // Required by @x402/svm and validated by the facilitator during verify/settle.
+      // Set via `wrangler secret put X402_SOLANA_FEE_PAYER`.
+      // Source: GET https://www.x402.org/facilitator/supported → signers["solana:*"][0]
+      const solanaFeePayer = env.X402_SOLANA_FEE_PAYER?.trim();
+      if (!solanaFeePayer) {
+        return jsonError(503, "x402_solana_fee_payer_not_configured");
       }
 
       const slug = url.searchParams.get("slug");
@@ -547,7 +571,7 @@ export default {
       // Binds the payment proof to this specific Solana endpoint + slug.
       const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
 
-      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo);
+      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo, solanaFeePayer);
       if (gateResult instanceof Response) return gateResult;
 
       // ── Proxy to Netlify origin function ──────────────────────────────────

--- a/cloudflare/x402-worker/wrangler.toml
+++ b/cloudflare/x402-worker/wrangler.toml
@@ -75,10 +75,20 @@ X402_PRICE_USDC = "0.001"
 # Facilitator: x402.org/facilitator supports Solana Devnet without API key.
 #   (Same X402_FACILITATOR_URL secret — no additional facilitator needed.)
 #
-# Required secret:
+# Required secrets:
 #   wrangler secret put X402_SOLANA_RECEIVING_ADDRESS
 #   → base58 Solana public key of your devnet receiver wallet
 #   → If absent, /api/x402/solana/* returns 503 x402_solana_not_configured
+#
+#   wrangler secret put X402_SOLANA_FEE_PAYER
+#   → base58 public key of the x402.org/facilitator Solana fee-payer address
+#   → Required by @x402/svm (ExactSvmScheme / ExactSvmSchemeV1): the client
+#     reads extra.feePayer from the 402 response to build its transaction.
+#     The facilitator validates that this address belongs to its own key pool.
+#   → Source: GET https://www.x402.org/facilitator/supported
+#             → signers["solana:*"][0]
+#   → If absent, /api/x402/solana/* returns 503 x402_solana_fee_payer_not_configured
+#   → Rotate if x402.org/facilitator rotates its Solana key pool.
 #
 # Optional var (defaults to "0.001" when absent):
 # X402_SOLANA_PRICE_USDC = "0.001"


### PR DESCRIPTION
## Problem

The official `@x402/svm` client (`ExactSvmScheme` / `ExactSvmSchemeV1`) requires `extra.feePayer` in the 402 payment requirements. Without it, the client throws immediately:

```
feePayer is required in paymentRequirements.extra for SVM transactions
```

`buildSolanaPaymentRequirements()` was returning `extra: {}` — an empty object — blocking any official `@x402/svm` client from building a payment payload.

## How feePayer was discovered

The `feePayer` must be an address from the **facilitator's own Solana key pool**. The facilitator validates this during `/verify` and `/settle` — if the address doesn't belong to its pool it returns `fee_payer_not_managed_by_facilitator`.

The official discovery endpoint:

```
GET https://www.x402.org/facilitator/supported
```

Live response (confirmed):
```json
{
  "kinds": [
    { "x402Version": 1, "scheme": "exact", "network": "solana-devnet",
      "extra": { "feePayer": "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5" } },
    { "x402Version": 2, "scheme": "exact", "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
      "extra": { "feePayer": "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5", ... } }
  ],
  "signers": { "solana:*": ["CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5"], ... }
}
```

**The value is not hardcoded** — it lives in a new Wrangler secret `X402_SOLANA_FEE_PAYER` so it can be rotated if the facilitator rotates its key pool.

## Changes

### `cloudflare/x402-worker/src/index.ts`
- Add `X402_SOLANA_FEE_PAYER?: string` to `Env` with source documentation
- `buildSolanaPaymentRequirements()` gains a `feePayer` param → `extra: { feePayer }`
- `buildSolana402Response()` and `runSolanaPaymentGate()` thread `feePayer` through
- Solana handler: validates `X402_SOLANA_FEE_PAYER` before slug validation → `503 x402_solana_fee_payer_not_configured` if absent/blank

### `cloudflare/x402-worker/wrangler.toml`
- Documents `X402_SOLANA_FEE_PAYER` as a required secret with source instructions

### `cloudflare/x402-worker/README.md`
- Adds `X402_SOLANA_FEE_PAYER` to the Solana env vars table with full description
- Updates verification step with Solana curl example

## Additional finding: receiver ATA does not exist on Devnet

The receiver address `DBti9QNp9BwZCDDnw5BEQfqLrUXZvFyTTDpPDYC2AUpS` has **no USDC token account and no base account on Solana Devnet**. The `@x402/svm` facilitator does not create ATAs during settlement — it only signs and submits the client-built `TransferChecked` transaction. If the destination ATA doesn't exist the transaction will fail at settlement.

This is a separate follow-up item: the receiver wallet needs to be funded on Devnet and its USDC ATA created before end-to-end payment can settle. **This PR does not block on that** — it fixes the worker-side 402 response so the client can at least build and submit a payment.

## Checks

- `cd cloudflare/x402-worker && npm run type-check` — ✅ exit 0, no errors
- `npm run build` — ✅ exit 0, 786 pages, no new errors

## Safety

- No EVM/Base Sepolia or mainnet behaviour changed
- No public routes affected (`/guides/*`, `/posts/*`, etc. remain free)
- No mainnet enabled
- No Worker deployed (deploy requires explicit instruction)
- No private keys printed or committed

## To activate after merge

```bash
cd cloudflare/x402-worker
wrangler secret put X402_SOLANA_FEE_PAYER
# → enter: CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5
#   (from GET https://www.x402.org/facilitator/supported → signers["solana:*"][0])
```

Then deploy when ready.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)