### PR TITLE
fix(x402): surface Solana settlement transaction hash

### DIFF
--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -399,6 +399,27 @@ interface SettleResult {
   networkId?: string;
 }
 
+// Map v2 facilitator settle response fields (transaction/network) to internal
+// SettleResult fields (txHash/networkId), preserving v1 responses as-is.
+function normalizeSettleResult(result: unknown): SettleResult {
+  const r = result as Record<string, unknown>;
+  return {
+    success: Boolean(r.success),
+    txHash:
+      typeof r.txHash === "string"
+        ? r.txHash
+        : typeof r.transaction === "string"
+          ? r.transaction
+          : undefined,
+    networkId:
+      typeof r.networkId === "string"
+        ? r.networkId
+        : typeof r.network === "string"
+          ? r.network
+          : undefined,
+  };
+}
+
 async function settlePayment(
   facilitatorBase: string,
   paymentHeader: string,
@@ -416,7 +437,7 @@ async function settlePayment(
     body: JSON.stringify({ x402Version: X402_VERSION, paymentPayload, paymentRequirements: toFacilitatorRequirements(paymentRequirements) }),
   });
   if (!res.ok) return { success: false };
-  return (await res.json()) as SettleResult;
+  return normalizeSettleResult(await res.json());
 }
 
 // ── Payment gate (network-agnostic core) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- The x402.org facilitator v2 `/settle` response returns `transaction` / `network` instead of `txHash` / `networkId`
- Added `normalizeSettleResult()` to map v2 field names to internal `SettleResult` shape, with v1 passthrough preserved
- `X-PAYMENT-RESPONSE` now surfaces a non-null Solana tx signature

## Change

`cloudflare/x402-worker/src/index.ts` — 22 lines added, 1 changed:
- New `normalizeSettleResult(result: unknown): SettleResult` function inserted before `settlePayment()`
- `settlePayment()` calls it instead of direct `as SettleResult` cast

No payment validation logic, guardrails, route gating, pricing, or mode/network config was touched.

## Validation

**Type-check:** `npm run type-check` — clean (0 errors)

**Deploy:** Worker version `62cf793b-a864-49ed-b83f-fcd072301f55`

**Paid request result:**
```
HTTP Status            : 200
X-PAYMENT-RESPONSE     : {success:true,txHash:2yHc9Addnx4rhdD2MHUmjXv6F2tDTAx7X1ZULE847fb4aVmAY423KC7Lnt2mgBwmenHL2anfP2WThWuSKS4q6eku,networkId:solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1}
Paid JSON returned     : YES
title                  : Hypertension: Symptoms, Causes, Diagnosis, Treatment, and Home Blood Pressure Monitoring
slug                   : hypertension

x402 Solana Devnet end-to-end test PASSED.
```

**Balances after (cumulative across both test runs):**
- Buyer USDC:    19.998
- Receiver USDC: 0.002

Generated with [Claude Code](https://claude.ai/claude-code)