### PR TITLE
fix(x402): update EVM buyer script for x402 v2 payload shape

### DIFF
--- a/scripts/test-x402-paid-request.mjs
+++ b/scripts/test-x402-paid-request.mjs
@@ -220,7 +220,7 @@ console.log("Step 3: Signing EIP-712 TransferWithAuthorization…");
 // Random 32-byte nonce as 0x-prefixed hex (bytes32)
 const nonce = toHex(randomBytes(32));
 const now = Math.floor(Date.now() / 1000);
-const validAfter  = (now - 600).toString();  // 10-min grace window
+const validAfter  = "0";                       // x402 v2: validAfter must be 0 (valid from epoch)
 const validBefore = (now + Number(req.maxTimeoutSeconds)).toString();
 
 const signature = await account.signTypedData({
@@ -254,12 +254,23 @@ const signature = await account.signTypedData({
 console.log("  Signature :", signature.slice(0, 22) + "…");
 console.log();
 
-// ── Step 4: Encode x402 v1 payment payload ────────────────────────────────────
+// ── Step 4: Encode x402 v2 payment payload ────────────────────────────────────
+// v2 shape: { x402Version, accepted, payload }
+// "accepted" mirrors the server's PaymentRequirements (scheme/network/asset/amount/etc).
+// "amount" is the v2 field name for what the 402 body calls "maxAmountRequired".
+// "payload" carries the EIP-3009 authorization + signature.
 
 const paymentPayload = {
-  x402Version: 1,
-  scheme:  req.scheme,
-  network: req.network,
+  x402Version: 2,
+  accepted: {
+    scheme:            req.scheme,
+    network:           req.network,
+    asset:             req.asset,
+    amount:            req.maxAmountRequired,  // v2 field name
+    payTo:             req.payTo,
+    maxTimeoutSeconds: req.maxTimeoutSeconds,
+    extra:             req.extra,
+  },
   payload: {
     authorization: {
       from:        account.address,
@@ -273,7 +284,7 @@ const paymentPayload = {
   },
 };
 
-// X-PAYMENT = base64(JSON.stringify(payload))  — x402 v1 spec
+// X-PAYMENT = base64(JSON.stringify(payload))  — x402 v2 spec
 const xPaymentHeader = Buffer.from(JSON.stringify(paymentPayload), "utf8").toString("base64");
 
 // ── Step 5: Paid request ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Updates `scripts/test-x402-paid-request.mjs` to build the correct x402 v2 `X-PAYMENT` payload shape, as defined by the official `x402@1.2.0` package (`x402-foundation/x402`).
- **Base Sepolia exact paid flow verified end-to-end** after this fix: HTTP 200 returned with paid guide JSON and `X-PAYMENT-RESPONSE`.
- Worker code, wrangler config, and secrets are unchanged.
- Public routes are unchanged.
- Mainnet is untouched.
- No private key committed to this repository.

## Root cause

After PR #130 bumped the Worker to x402 v2 (`X402_VERSION = 2`), the test script continued to build a v1-shaped payment payload:

```js
// v1 (old — broken)
{ x402Version: 1, scheme, network, payload: { authorization, signature } }
```

The x402 v2 spec wraps `scheme`/`network`/`asset`/`amount`/`payTo`/`maxTimeoutSeconds`/`extra` inside an `accepted` object, and uses `0` for `validAfter`:

```js
// v2 (fixed)
{
  x402Version: 2,
  accepted: { scheme, network, asset, amount, payTo, maxTimeoutSeconds, extra },
  payload: { authorization: { ..., validAfter: 0, ... }, signature }
}
```

## Changes

`scripts/test-x402-paid-request.mjs` only:

| Field | Before | After |
|---|---|---|
| `x402Version` | `1` | `2` |
| `validAfter` | `(now - 600).toString()` | `0` |
| Payload shape | top-level `scheme`, `network` | wrapped in `accepted` object |
| `amount` field | `maxAmountRequired` | `amount` (v2 field name) |

EIP-712 `TransferWithAuthorization` signing logic is unchanged.

## Security note

A disposable Base Sepolia burner wallet used during testing was accidentally exposed. That address should **not** be reused or funded with mainnet assets. No private key appears in this commit or anywhere in the repository.

## Test plan

- [x] `node --check scripts/test-x402-paid-request.mjs` — exit 0
- [x] Worker `tsc --noEmit` — exit 0
- [x] Full Base Sepolia e2e paid request — HTTP 200, paid JSON returned, `X-PAYMENT-RESPONSE` present
- [x] `git diff` scanned — no private key material

🤖 Generated with [Claude Code](https://claude.com/claude-code)