### PR TITLE
feat(x402): add red-flags structured endpoint

### DIFF
--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -28,6 +28,8 @@
  *   /api/x402/ping                — Worker-only test endpoint (no origin call, Base/EVM)
  *   /api/x402/guide-brief         — Paid structured guide metadata (Base/EVM)
  *   /api/x402/solana/guide-brief  — Paid structured guide metadata (Solana Devnet)
+ *   /api/x402/red-flags           — Paid structured urgent-care signals (Base/EVM)
+ *   /api/x402/solana/red-flags    — Paid structured urgent-care signals (Solana Devnet)
  *
  * SOLANA DEVNET RAIL:
  *   A second payment rail on Solana Devnet. No real monetary value.
@@ -663,6 +665,101 @@ export default {
       // Same origin function as the EVM endpoint — content is network-agnostic.
       const originUrl =
         `${canonicalOrigin}/.netlify/functions/x402-guide-brief` +
+        `?slug=${encodeURIComponent(slug)}`;
+
+      let originResponse: Response;
+      try {
+        originResponse = await fetch(originUrl, {
+          method: "GET",
+          headers: {
+            "X-Worker-Secret": env.X402_WORKER_SECRET,
+            "Accept": "application/json",
+          },
+        });
+      } catch {
+        return jsonError(502, "origin_unreachable");
+      }
+
+      const responseHeaders = new Headers(originResponse.headers);
+      responseHeaders.set(
+        "X-PAYMENT-RESPONSE",
+        paymentReceiptHeader(gateResult.settled, NETWORK_SOLANA_DEVNET)
+      );
+
+      return new Response(originResponse.body, {
+        status: originResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ── /api/x402/red-flags ──────────────────────────────────────────────────
+    if (url.pathname === "/api/x402/red-flags") {
+      const slug = url.searchParams.get("slug");
+
+      if (!slug) {
+        return jsonError(400, "missing_slug");
+      }
+      if (!SLUG_RE.test(slug)) {
+        return jsonError(400, "invalid_slug");
+      }
+
+      const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
+
+      const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
+      if (gateResult instanceof Response) return gateResult;
+
+      const originUrl =
+        `${canonicalOrigin}/.netlify/functions/x402-red-flags` +
+        `?slug=${encodeURIComponent(slug)}`;
+
+      let originResponse: Response;
+      try {
+        originResponse = await fetch(originUrl, {
+          method: "GET",
+          headers: {
+            "X-Worker-Secret": env.X402_WORKER_SECRET,
+            "Accept": "application/json",
+          },
+        });
+      } catch {
+        return jsonError(502, "origin_unreachable");
+      }
+
+      const responseHeaders = new Headers(originResponse.headers);
+      responseHeaders.set(
+        "X-PAYMENT-RESPONSE",
+        paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
+      );
+
+      return new Response(originResponse.body, {
+        status: originResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ── /api/x402/solana/red-flags ───────────────────────────────────────────
+    if (url.pathname === "/api/x402/solana/red-flags") {
+      const solanaPayTo = env.X402_SOLANA_RECEIVING_ADDRESS?.trim();
+      if (!solanaPayTo) {
+        return jsonError(503, "x402_solana_not_configured");
+      }
+
+      const solanaFeePayer = env.X402_SOLANA_FEE_PAYER?.trim();
+      if (!solanaFeePayer) {
+        return jsonError(503, "x402_solana_fee_payer_not_configured");
+      }
+
+      const slug = url.searchParams.get("slug");
+      if (!slug) return jsonError(400, "missing_slug");
+      if (!SLUG_RE.test(slug)) return jsonError(400, "invalid_slug");
+
+      const resource = `${canonicalOrigin}${url.pathname}?slug=${encodeURIComponent(slug)}`;
+
+      const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo, solanaFeePayer);
+      if (gateResult instanceof Response) return gateResult;
+
+      const originUrl =
+        `${canonicalOrigin}/.netlify/functions/x402-red-flags` +
         `?slug=${encodeURIComponent(slug)}`;
 
       let originResponse: Response;

--- a/docs/x402-status.md
+++ b/docs/x402-status.md
@@ -142,10 +142,65 @@ node scripts/test-x402-solana-paid-request.mjs
 
 ---
 
+## Preview endpoints (implemented, not yet deployed)
+
+### Base Sepolia (EVM) — red-flags
+
+```
+https://patientguide.io/api/x402/red-flags?slug=hypertension
+```
+
+Expected payment requirements (mirrors guide-brief rail):
+
+| Field | Value |
+|-------|-------|
+| `x402Version` | `2` |
+| `scheme` | `exact` |
+| `network` | `eip155:84532` |
+| `asset` | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| `payTo` | `0x28C58Bc26Cd14b7f378937ED18081dA1A2976220` |
+| `maxAmountRequired` | `1000` (0.001 USDC) |
+| `extra` | `{"name":"USDC","version":"2"}` |
+
+Expected paid JSON shape: `{ slug, title, type: "red_flags", redFlags: [...], disclaimer }`.
+Initial data: hypertension only (curated static map in `netlify/functions/x402-red-flags.ts`).
+Unsupported slug returns 404 after successful payment — consistent with guide-brief behavior.
+
+Manual 402 check (unpaid):
+```sh
+curl -i "https://patientguide.io/api/x402/red-flags?slug=hypertension"
+```
+
+### Solana Devnet (SVM) — red-flags
+
+```
+https://patientguide.io/api/x402/solana/red-flags?slug=hypertension
+```
+
+Expected payment requirements (mirrors solana/guide-brief rail):
+
+| Field | Value |
+|-------|-------|
+| `x402Version` | `2` |
+| `scheme` | `exact` |
+| `network` | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+| `asset` (mint) | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` |
+| `payTo` | `DBti9QNp9BwZCDDnw5BEQfqLrUXZvFyTTDpPDYC2AUpS` |
+| `maxAmountRequired` | `1000` (0.001 USDC) |
+| `extra.feePayer` | present (same as solana/guide-brief) |
+
+Manual 402 check (unpaid):
+```sh
+curl -i "https://patientguide.io/api/x402/solana/red-flags?slug=hypertension"
+```
+
+---
+
 ## Next candidate work
 
 These are identified next steps — none are implemented yet:
 
-1. **Base mainnet facilitator/auth investigation** — determine what is required to enable the Base mainnet rail (facilitator registration, auth configuration) without enabling live payments prematurely.
-2. **"upto" or batch-style payments** — evaluate only after confirming facilitator support and official spec coverage. Do not implement speculatively.
-3. **Structured endpoint expansion** — identify which additional guide slugs or resource types make sense beyond `guide-brief` before expanding the `/api/x402/` surface.
+1. **Deploy red-flags endpoints** — deploy Worker and Netlify after PR is merged and verified.
+2. **Expand red-flags slugs** — add additional slugs to the curated static map in `x402-red-flags.ts` after content review. Do not add slugs speculatively.
+3. **Base mainnet facilitator/auth investigation** — determine what is required to enable the Base mainnet rail (facilitator registration, auth configuration) without enabling live payments prematurely.
+4. **"upto" or batch-style payments** — evaluate only after confirming facilitator support and official spec coverage. Do not implement speculatively.

--- a/netlify/functions/x402-red-flags.ts
+++ b/netlify/functions/x402-red-flags.ts
@@ -1,0 +1,112 @@
+/**
+ * x402 red-flags — paid structured urgent-care signals endpoint.
+ *
+ * Called by the Cloudflare x402 Worker AFTER a valid testnet payment is
+ * verified AND settled. Not intended for direct browser or curl access.
+ *
+ * SAFETY: X402_WORKER_SECRET must match the Worker secret. Absent or
+ * mismatched secret returns 403. Missing secret in production returns 500.
+ *
+ * Data source: curated static map in this file (hypertension only for preview).
+ * Educational content only — not a diagnosis or emergency triage tool.
+ *
+ * TESTNET/DEVNET ONLY — Base Sepolia (eip155:84532) and Solana Devnet.
+ */
+
+import type { Handler, HandlerEvent } from "@netlify/functions";
+
+interface RedFlag {
+  signal: string;
+  whyItMatters: string;
+  suggestedAction: string;
+}
+
+interface RedFlagsEntry {
+  slug: string;
+  title: string;
+  type: "red_flags";
+  redFlags: RedFlag[];
+  disclaimer: string;
+}
+
+// Curated static map — add slugs only when content has been reviewed.
+// Sources: broadly accepted urgent-care signals from clinical literature.
+// This is educational information, not a diagnosis or triage tool.
+const RED_FLAGS: Record<string, RedFlagsEntry> = {
+  hypertension: {
+    slug: "hypertension",
+    title: "Hypertension",
+    type: "red_flags",
+    redFlags: [
+      {
+        signal: "Chest pain, pressure, or tightness",
+        whyItMatters:
+          "Can indicate a heart attack or another urgent cardiovascular problem.",
+        suggestedAction: "Seek urgent medical care immediately.",
+      },
+      {
+        signal:
+          "Severe headache with confusion, weakness, vision changes, or trouble speaking",
+        whyItMatters:
+          "Can suggest stroke, hypertensive emergency, or another serious neurological problem.",
+        suggestedAction: "Seek emergency care immediately.",
+      },
+      {
+        signal: "Shortness of breath, fainting, or severe dizziness",
+        whyItMatters:
+          "Can occur with heart, lung, or blood pressure emergencies.",
+        suggestedAction: "Seek urgent medical care.",
+      },
+    ],
+    disclaimer:
+      "Educational information only. Not a diagnosis, emergency triage tool, or substitute for professional medical care. If symptoms are severe, sudden, or concerning, seek urgent medical help.",
+  },
+};
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,99}$/;
+
+const isLocalDev = process.env.CONTEXT === "dev" || !process.env.NETLIFY;
+
+function json(status: number, body: unknown, extra?: Record<string, string>): ReturnType<Handler> {
+  return {
+    statusCode: status,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store", ...extra },
+  };
+}
+
+export const handler: Handler = async (event: HandlerEvent) => {
+  // ── Secret enforcement ──────────────────────────────────────────────────
+  const expectedSecret = process.env.X402_WORKER_SECRET;
+
+  if (!expectedSecret) {
+    if (!isLocalDev) {
+      return json(500, { error: "x402_origin_not_configured" });
+    }
+  } else {
+    const provided = event.headers["x-worker-secret"];
+    if (provided !== expectedSecret) {
+      return json(403, { error: "forbidden" });
+    }
+  }
+
+  // ── Slug validation ─────────────────────────────────────────────────────
+  const slug = event.queryStringParameters?.slug ?? null;
+
+  if (!slug) {
+    return json(400, { error: "missing_slug" });
+  }
+
+  if (!SLUG_RE.test(slug)) {
+    return json(400, { error: "invalid_slug" });
+  }
+
+  // ── Red-flags lookup ────────────────────────────────────────────────────
+  const entry = RED_FLAGS[slug];
+
+  if (!entry) {
+    return json(404, { error: "guide_not_found" });
+  }
+
+  return json(200, entry);
+};


### PR DESCRIPTION
## Summary

Adds GET /api/x402/red-flags and GET /api/x402/solana/red-flags paid machine endpoints returning urgent-care signals for a given guide slug.

- Adds `/api/x402/red-flags?slug=hypertension` (Base Sepolia / EVM) and `/api/x402/solana/red-flags?slug=hypertension` (Solana Devnet), payment-gated at 0.001 USDC (same as guide-brief).
- New Netlify origin function `netlify/functions/x402-red-flags.ts` serves a curated static map of urgent-care signals. Hypertension only for this preview; unsupported slugs return 404 after payment, consistent with guide-brief.
- Worker handlers in `cloudflare/x402-worker/src/index.ts` mirror the guide-brief pattern exactly: slug validation before payment gate, resource URL binds proof to endpoint+slug, Solana variant guards feePayer/receiverAddress.
- No public routes touched. No mainnet changes. No pricing changes.

## 402 verification (manual, unpaid)

```sh
curl -i "https://patientguide.io/api/x402/red-flags?slug=hypertension"
curl -i "https://patientguide.io/api/x402/solana/red-flags?slug=hypertension"
```

Expected: HTTP 402, `x402Version: 2`, `scheme: exact`, same network/asset/payTo as respective guide-brief rail, `resource` matching red-flags URL.

## Test plan

- [x] Worker type-check passes (`npm run type-check` in `cloudflare/x402-worker`)
- [x] Site build passes (`npm run build` — 784 pages, no errors)
- [ ] After deploy: verify 402 shape with curl for both rails
- [ ] After deploy with disposable buyer: verify paid 200 + correct JSON shape

## Medical safety

Content is educational (hypertension red flags broadly accepted in clinical guidance). Uses cautious language ("can indicate", "seek urgent medical care"). No diagnosis claims, no self-treatment instructions, no medication advice. Disclaimer included in paid JSON payload.

---

> Humans will always read for free. Machines can test structured access.

Testnet/devnet preview only. Mainnet is not enabled.

Generated with [Claude Code](https://claude.ai/claude-code)
