### PR TITLE
chore(x402): harden Worker proxy routes

### DIFF
--- a/cloudflare/x402-worker/src/index.ts
+++ b/cloudflare/x402-worker/src/index.ts
@@ -523,6 +523,45 @@ function paymentReceiptHeader(settled: SettleResult, network: string): string {
   });
 }
 
+// ── Origin proxy helper ────────────────────────────────────────────────────────
+
+// Proxies a paid request to the Netlify origin function and returns the
+// composed response. X-PAYMENT-RESPONSE is attached only when the origin
+// returns 2xx — if the origin errors after settlement, the error is forwarded
+// without advertising a success receipt.
+async function proxyToOrigin(
+  canonicalOrigin: string,
+  workerSecret: string,
+  functionName: string,
+  slug: string,
+  settled: SettleResult,
+  network: string
+): Promise<Response> {
+  const originUrl =
+    `${canonicalOrigin}/.netlify/functions/${functionName}` +
+    `?slug=${encodeURIComponent(slug)}`;
+  let originResponse: Response;
+  try {
+    originResponse = await fetch(originUrl, {
+      method: "GET",
+      headers: {
+        "X-Worker-Secret": workerSecret,
+        "Accept": "application/json",
+      },
+    });
+  } catch {
+    return jsonError(502, "origin_unreachable");
+  }
+  const responseHeaders = new Headers(originResponse.headers);
+  if (originResponse.ok) {
+    responseHeaders.set("X-PAYMENT-RESPONSE", paymentReceiptHeader(settled, network));
+  }
+  return new Response(originResponse.body, {
+    status: originResponse.status,
+    headers: responseHeaders,
+  });
+}
+
 // ── Worker entry point ─────────────────────────────────────────────────────────
 
 export default {
@@ -547,7 +586,7 @@ export default {
 
     // Strip BOM that Windows PowerShell may prepend when secrets are set via
     // piped input, and strip trailing slashes.
-    const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\/+$/, "");
+    const canonicalOrigin = env.PATIENTGUIDE_ORIGIN.replace(/^﻿/, "").replace(/\r/g, "").replace(/\/+$/, "");
 
     const paymentHeader = request.headers.get("X-PAYMENT");
 
@@ -578,6 +617,24 @@ export default {
       );
     }
 
+    // ── Method guard: structured PSO endpoints only accept GET ───────────────
+    // Non-GET requests (POST, PUT, etc.) are rejected before any payment flow.
+    // /api/x402/ping is intentionally excluded — it is a Worker-only test route.
+    const STRUCTURED_PATHS = new Set([
+      "/api/x402/guide-brief",
+      "/api/x402/red-flags",
+      "/api/x402/visit-prep",
+      "/api/x402/solana/guide-brief",
+      "/api/x402/solana/red-flags",
+      "/api/x402/solana/visit-prep",
+    ]);
+    if (STRUCTURED_PATHS.has(url.pathname) && request.method !== "GET") {
+      return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+        status: 405,
+        headers: { "Allow": "GET", "Content-Type": "application/json" },
+      });
+    }
+
     // ── /api/x402/guide-brief ────────────────────────────────────────────────
     if (url.pathname === "/api/x402/guide-brief") {
       const slug = url.searchParams.get("slug");
@@ -597,36 +654,7 @@ export default {
       const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
       if (gateResult instanceof Response) return gateResult;
 
-      // ── Proxy to Netlify origin function ──────────────────────────────────
-      // Settlement is required before origin access. If settlement fails above,
-      // runPaymentGate returns an error Response and we never reach this point.
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-guide-brief` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-guide-brief", slug, gateResult.settled, env.X402_NETWORK);
     }
 
     // ── /api/x402/solana/guide-brief ─────────────────────────────────────────
@@ -663,35 +691,8 @@ export default {
       const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo, solanaFeePayer);
       if (gateResult instanceof Response) return gateResult;
 
-      // ── Proxy to Netlify origin function ──────────────────────────────────
       // Same origin function as the EVM endpoint — content is network-agnostic.
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-guide-brief` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, NETWORK_SOLANA_DEVNET)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-guide-brief", slug, gateResult.settled, NETWORK_SOLANA_DEVNET);
     }
 
     // ── /api/x402/red-flags ──────────────────────────────────────────────────
@@ -710,33 +711,7 @@ export default {
       const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
       if (gateResult instanceof Response) return gateResult;
 
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-red-flags` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-red-flags", slug, gateResult.settled, env.X402_NETWORK);
     }
 
     // ── /api/x402/solana/red-flags ───────────────────────────────────────────
@@ -760,33 +735,7 @@ export default {
       const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo, solanaFeePayer);
       if (gateResult instanceof Response) return gateResult;
 
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-red-flags` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, NETWORK_SOLANA_DEVNET)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-red-flags", slug, gateResult.settled, NETWORK_SOLANA_DEVNET);
     }
 
     // ── /api/x402/visit-prep ─────────────────────────────────────────────────
@@ -805,33 +754,7 @@ export default {
       const gateResult = await runPaymentGate(env, mode, resource, paymentHeader);
       if (gateResult instanceof Response) return gateResult;
 
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-visit-prep` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, env.X402_NETWORK)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-visit-prep", slug, gateResult.settled, env.X402_NETWORK);
     }
 
     // ── /api/x402/solana/visit-prep ──────────────────────────────────────────
@@ -855,33 +778,7 @@ export default {
       const gateResult = await runSolanaPaymentGate(env, resource, paymentHeader, solanaPayTo, solanaFeePayer);
       if (gateResult instanceof Response) return gateResult;
 
-      const originUrl =
-        `${canonicalOrigin}/.netlify/functions/x402-visit-prep` +
-        `?slug=${encodeURIComponent(slug)}`;
-
-      let originResponse: Response;
-      try {
-        originResponse = await fetch(originUrl, {
-          method: "GET",
-          headers: {
-            "X-Worker-Secret": env.X402_WORKER_SECRET,
-            "Accept": "application/json",
-          },
-        });
-      } catch {
-        return jsonError(502, "origin_unreachable");
-      }
-
-      const responseHeaders = new Headers(originResponse.headers);
-      responseHeaders.set(
-        "X-PAYMENT-RESPONSE",
-        paymentReceiptHeader(gateResult.settled, NETWORK_SOLANA_DEVNET)
-      );
-
-      return new Response(originResponse.body, {
-        status: originResponse.status,
-        headers: responseHeaders,
-      });
+      return proxyToOrigin(canonicalOrigin, env.X402_WORKER_SECRET, "x402-visit-prep", slug, gateResult.settled, NETWORK_SOLANA_DEVNET);
     }
 
     // ── Unknown /api/x402/* path ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four targeted hardening changes to `cloudflare/x402-worker/src/index.ts`. No payment config, secrets, Netlify functions, public routes, or mainnet config touched.

### 1. `proxyToOrigin` helper (deduplication)
Extracted shared fetch+response-assembly logic used by all six paid proxy routes into a single `proxyToOrigin(canonicalOrigin, workerSecret, functionName, slug, settled, network)` helper. Removes ~90 lines of copy-pasted code across guide-brief, red-flags, and visit-prep on both Base and Solana routes.

### 2. `originResponse.ok` guard (correctness fix)
`X-PAYMENT-RESPONSE` is now only attached when the origin returns HTTP 2xx. Previously a 404 or 500 from the origin still set `X-PAYMENT-RESPONSE: {"success":true,...}` while forwarding the error body. Fix is inside `proxyToOrigin` and applies to all six routes uniformly.

### 3. `canonicalOrigin` CR strip (robustness)
Added `.replace(/\r/g, "")` to the existing BOM+trailing-slash cleanup chain. Guards against Windows PowerShell carriage-return contamination when secrets are set via piped input.

### 4. GET-only method guard (hardening)
All six structured PSO endpoints (`/api/x402/guide-brief`, `/api/x402/red-flags`, `/api/x402/visit-prep` and their `/solana/` variants) now return HTTP 405 + `Allow: GET` for non-GET requests, before any payment flow is entered. `/api/x402/ping` is intentionally excluded.

## Test plan

- [x] `tsc --noEmit` — clean (no type errors)
- [x] `npm run build` — exit 0
- [x] All 6 endpoints still return 402 on live site (GET unpaid regression)
- [x] Public `/guides/hypertension` returns 301, no 402
- [ ] POST 405 guard — will activate on Worker deploy (no local runtime available)

## Files changed

- `cloudflare/x402-worker/src/index.ts` (+64 / -167)

No Netlify functions, Astro pages, payment config, secrets, or mainnet config changed.

Generated with Claude Code
