### PR TITLE
docs(x402): add tester launch pack

### DIFF
--- a/docs/x402-observability.md
+++ b/docs/x402-observability.md
@@ -1,0 +1,97 @@
+# x402 Observability Checklist
+
+Lightweight monitoring reference for after external tester posts go live.
+
+---
+
+## A. What to monitor
+
+### Request counts
+
+- `/api/x402/*` total request count
+- 402 responses by endpoint type (`guide-brief`, `red-flags`, `visit-prep`)
+- 402 responses by rail (Base Sepolia vs Solana Devnet)
+- 405 method-guard responses
+- 400 responses (invalid or missing slug parameter)
+- 404 responses (unsupported slug — after payment verification)
+- Paid success count (200), if visible in Worker logs
+- Non-2xx origin responses after successful payment (Worker upstream errors)
+
+### Traffic pattern
+
+- Top user agents
+- Top countries
+- Top paths within `/api/x402/*`
+- Client error breakdown: 402 vs 404 vs 405 vs 400
+
+### Free-tier integrity
+
+- Confirm public guide routes (`/guides/*`, `/posts/*`, `/`, `/robots.txt`, `/sitemap.xml`, `/llms.txt`, `/structured-access`, `/contact`) return non-402 status codes
+- Any unexpected 402 on public human routes is a critical incident
+
+---
+
+## B. Where to check
+
+| Source | What to check |
+|--------|---------------|
+| Cloudflare Analytics | Request counts, status code distribution, top paths, countries, user agents |
+| Cloudflare Worker logs | Paid success events, origin errors, error logs after payment |
+| Netlify function logs | Relevant only if Netlify functions are in the request path |
+| GitHub Issues | Tester-filed feedback, descriptor issues, compatibility reports |
+| `/contact` submissions | Direct tester messages via hello@patientguide.io |
+
+Cloudflare is the primary signal source for traffic data. Worker logs are the primary signal for post-payment errors.
+
+---
+
+## C. After posting to Reddit
+
+Record the following for each post:
+
+| Field | Record |
+|-------|--------|
+| Post URL | |
+| Subreddit | |
+| Timestamp (UTC) | |
+| Baseline `/api/x402/*` request count before posting | |
+| Traffic at +1h | |
+| Traffic at +6h | |
+| Traffic at +24h | |
+| GitHub Issues opened | |
+| `/contact` messages received | |
+| Endpoint errors observed | |
+| Useful comments or objections | |
+
+This baseline helps distinguish organic traffic from tester traffic and informs follow-up decisions.
+
+---
+
+## D. Safety and privacy
+
+- Never ask testers to provide private keys, seed phrases, or keypair files.
+- Never ask for sensitive health information.
+- Do not encourage mainnet testing — mainnet is not live.
+- If a tester shares a transaction hash or signature as part of a bug report, that is acceptable context. Do not actively solicit it unless it is directly relevant to diagnosing a reported issue.
+- Do not log or store any tester-provided health information, even if offered.
+
+---
+
+## E. Follow-up triage
+
+Classify incoming feedback into one of these buckets:
+
+| Category | Description |
+|----------|-------------|
+| `descriptor-issue` | Malformed or unexpected 402 descriptor field |
+| `client-compat` | x402 client parsing failure or unexpected behavior |
+| `solana-issue` | Solana Devnet-specific: feePayer, SPL mint, ATA, network |
+| `base-issue` | Base Sepolia-specific: EIP-712 signing, asset, network |
+| `docs-copy` | Missing information, unclear wording, wrong example |
+| `product-confusion` | Misunderstanding of what the service is or does |
+| `medical-safety` | Concern about health data framing or safety |
+| `spam-noise` | Irrelevant or low-signal |
+
+For `descriptor-issue` and `client-compat` reports: collect the raw 402 response body and client/library version before responding. These are the highest-value technical reports.
+
+For `medical-safety` concerns: respond calmly and factually, referencing the disclaimer and the fact that human guides are free and no patient data is collected. See `docs/x402-reddit-tester-posts.md` for prepared defensive replies.

--- a/docs/x402-reddit-tester-posts.md
+++ b/docs/x402-reddit-tester-posts.md
@@ -1,0 +1,212 @@
+# x402 Reddit Tester Posts
+
+Reusable draft copy for Reddit and similar communities when reaching out for x402 testnet/devnet feedback.
+
+---
+
+## A. Posting principles
+
+- Ask for **technical sanity checks**, not promotion.
+- Lead with x402, Base Sepolia, Solana Devnet, testnet, devnet — not the health topic.
+- Be humble and specific about what you want tested.
+- Make clear **this is not mainnet**. Lead with that when relevant.
+- Make clear **no human health guide is paywalled**. The paid surface is `/api/x402/*` only.
+- Avoid medical advice framing in all posts and replies.
+- Ask testers not to include private keys, seed phrases, keypair files, or sensitive health information in any response.
+- Direct feedback to GitHub Issues or `/contact`.
+
+---
+
+## B. Primary Reddit post
+
+**Title:**
+
+> Can anyone sanity-check my x402 testnet/devnet endpoints?
+
+**Body:**
+
+---
+
+Hey — I've been building a structured-access layer on top of [PatientGuide.io](https://patientguide.io) using the x402 payment protocol, and I'd appreciate a technical sanity check from anyone working with x402, Base Sepolia, or Solana Devnet clients.
+
+**What it is:**
+
+PatientGuide is a public health information site. Human-readable guides at `/guides/*` are always free. No human content is paywalled.
+
+The `/api/x402/*` namespace exposes structured JSON objects for agents and apps — Patient Support Objects like `guide-brief`, `red-flags`, and `visit-prep`. These are appointment prep checklists, urgent-warning signals, and structured guide summaries. Educational only — not diagnosis or treatment.
+
+**Rails:**
+
+- Base Sepolia (`eip155:84532`) — 0.001 testnet USDC
+- Solana Devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`) — 0.001 Devnet USDC
+
+**This is testnet/devnet only. Mainnet is not live.**
+
+**Quick unpaid check (no payment needed):**
+
+```sh
+curl -i "https://patientguide.io/api/x402/guide-brief?slug=hypertension"
+curl -i "https://patientguide.io/api/x402/red-flags?slug=hypertension"
+curl -i "https://patientguide.io/api/x402/visit-prep?slug=hypertension"
+curl -i "https://patientguide.io/api/x402/solana/visit-prep?slug=hypertension"
+```
+
+Each should return HTTP 402 with:
+- `x402Version: 2`
+- `scheme: exact`
+- `maxAmountRequired: "1000"` (0.001 USDC)
+- `resource` matching the exact URL called
+- Rail-specific `network`, `asset`/mint, `payTo`
+
+The Solana Devnet descriptor includes `extra.feePayer`.
+
+**What I'm looking for feedback on:**
+
+- Does the descriptor shape look correct to your x402 client?
+- Is the `resource` URL binding working as expected?
+- Any Base Sepolia or Solana Devnet client compatibility issues?
+- Any paid-but-denied edge cases worth knowing about?
+- Anything off with the x402 v2 implementation?
+
+**Feedback:**
+
+GitHub Issues: https://github.com/wavechecker/thought-archive/issues/new/choose
+Contact: https://patientguide.io/contact
+
+Please don't include private keys, seed phrases, or sensitive health information in any response. Testnet/Devnet burner wallets only.
+
+---
+
+## C. r/base variant
+
+**Title:**
+
+> Sanity check on my Base Sepolia x402 endpoints — descriptor shape and resource binding
+
+**Body:**
+
+---
+
+Building a structured-access API layer on [PatientGuide.io](https://patientguide.io) using x402 and Base Sepolia. Human-readable health guides stay free — the `/api/x402/*` namespace is the machine layer.
+
+**Rail:**
+
+- Base Sepolia (`eip155:84532`)
+- Asset: `0x036CbD53842c5426634e7929541eC2318f3dCF7e` (testnet USDC)
+- payTo: `0x28C58Bc26Cd14b7f378937ED18081dA1A2976220`
+- Scheme: `exact`
+- maxAmountRequired: `1000` (0.001 USDC)
+
+**Quick check:**
+
+```sh
+curl -i "https://patientguide.io/api/x402/guide-brief?slug=hypertension"
+```
+
+Returns HTTP 402 with x402 v2 descriptor. `resource` is bound to the exact URL called.
+
+**Not mainnet. Testnet only.**
+
+Looking for feedback on: descriptor shape correctness, `resource` URL binding, `exact` scheme behavior, Base Sepolia client compatibility.
+
+Feedback: https://github.com/wavechecker/thought-archive/issues/new/choose
+
+---
+
+## D. r/solana variant
+
+**Title:**
+
+> x402 Solana Devnet integration — looking for feedback on descriptor and feePayer field
+
+**Body:**
+
+---
+
+I've got an x402 structured-access endpoint running on Solana Devnet and would appreciate feedback from anyone working with SVM-side x402 clients.
+
+**What:** [PatientGuide.io](https://patientguide.io) — public health guides stay free, `/api/x402/solana/*` is a structured machine layer.
+
+**Devnet only. No mainnet.**
+
+**Rail:**
+
+- Network: `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`
+- Mint: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` (Devnet USDC)
+- payTo: `DBti9QNp9BwZCDDnw5BEQfqLrUXZvFyTTDpPDYC2AUpS`
+- maxAmountRequired: `1000` (0.001 USDC)
+- Descriptor includes `extra.feePayer`
+
+**Quick check:**
+
+```sh
+curl -i "https://patientguide.io/api/x402/solana/visit-prep?slug=hypertension"
+```
+
+Returns HTTP 402, x402 v2, Solana Devnet descriptor with `feePayer` in `extra`.
+
+Looking for: feedback on `feePayer` field handling, SPL token mint verification, `resource` URL binding, Devnet client compatibility.
+
+Please don't include private keys or seed phrases in any response.
+
+Feedback: https://github.com/wavechecker/thought-archive/issues/new/choose
+
+---
+
+## E. Short comment reply
+
+For "what is this?" or general curiosity:
+
+---
+
+PatientGuide.io is a public health information site — human-readable guides are always free. The `/api/x402/*` layer exposes structured JSON objects (appointment prep checklists, urgent-warning signals, guide summaries) for agents and apps, gated via x402 on Base Sepolia and Solana Devnet at 0.001 testnet USDC. Testnet/Devnet only. No mainnet. No human health guide is paywalled.
+
+---
+
+## F. Defensive replies
+
+**"Is this a crypto paywall for health info?"**
+
+No. All human-readable health guides at `/guides/*` and `/posts/*` are free and always will be. The x402 payment gate covers only `/api/x402/*` — machine-readable structured JSON endpoints for developers and agents. No patient-facing page is gated, and no payment is required to read any guide.
+
+---
+
+**"Why not just make a normal API?"**
+
+We might. This is specifically an x402 testnet preview — the goal is to explore whether machine-to-machine structured health data access can be decentralized and permissionless for agents without requiring API keys or account registration. It's a technical experiment, not a product decision locked in forever.
+
+---
+
+**"Is this medical advice?"**
+
+No. The structured objects are educational data — appointment prep checklists, urgent-warning signals, and guide summaries. Not diagnosis, treatment recommendations, or emergency triage. The site carries appropriate disclaimers and we're explicit in the docs that these should not be used as substitutes for professional medical care.
+
+---
+
+**"Why x402?"**
+
+We're interested in what agent-native payment protocols make possible for health information infrastructure — permissionless machine access without API key management, account registration, or centralized gatekeeping. x402 on testnet is a low-stakes place to figure out whether the descriptor and payment shape actually work before making stronger claims about the model.
+
+---
+
+**"Can I test without paying?"**
+
+Yes. The unpaid curl checks in the runbook let you verify the 402 gate is live and inspect the descriptor shape without sending any payment. You only need testnet/Devnet funds if you want to test the full paid flow.
+
+---
+
+**"Is mainnet live?"**
+
+No. Base mainnet and Solana mainnet are both disabled. This is testnet/Devnet only. We'll be clear when and if mainnet ever goes live.
+
+---
+
+**"Why health data?"**
+
+Health information is a domain where structured, machine-readable data is genuinely useful for agents — appointment prep, red-flag identification, condition overviews. PatientGuide already has this content in human-readable form. Structuring it for agents while keeping the human layer free is the experiment.
+
+---
+
+**"Are you collecting patient data?"**
+
+No. Testers interact with structured educational data about conditions. No patient records, personal health histories, or identifying information are collected or stored. We ask testers explicitly not to include personal health information in any feedback.

--- a/docs/x402-status.md
+++ b/docs/x402-status.md
@@ -276,6 +276,14 @@ Use the **x402 Preview Feedback** issue template for endpoint-specific reports. 
 
 ---
 
+## Tester documentation
+
+- [Tester runbook](x402-tester-runbook.md) — external tester guide for Base Sepolia and Solana Devnet
+- [Reddit drafts](x402-reddit-tester-posts.md) — launch copy and defensive reply templates
+- [Observability checklist](x402-observability.md) — post-launch monitoring and feedback triage
+
+---
+
 ## Next candidate work
 
 These are identified next steps — none are implemented yet:

--- a/docs/x402-tester-runbook.md
+++ b/docs/x402-tester-runbook.md
@@ -1,0 +1,177 @@
+# Testing PatientGuide x402 Preview
+
+> Humans will always read for free. Machines can test structured access.
+
+---
+
+## A. What this is
+
+PatientGuide.io is a public health information site. Human-readable guides at `/guides/*` and `/posts/*` are free, publicly accessible, and always will be.
+
+The `/api/x402/` namespace exposes a separate layer of **structured Patient Support Objects (PSOs)** for agents, apps, and developers. These endpoints return HTTP 402 and require a valid x402 payment to unlock structured JSON.
+
+- **Testnet/Devnet only.** No mainnet payments are live.
+- **Not a human paywall.** No public health guide is gated.
+- **Educational patient-support data only.** Not a diagnosis, treatment plan, or emergency triage tool.
+- **Rails: Base Sepolia and Solana Devnet.**
+
+If you're building an x402 client, Base Sepolia integration, Solana Devnet integration, or testing HTTP 402 structured-access flows — this preview is for you.
+
+---
+
+## B. Live object types
+
+Three Patient Support Object types are live on both rails:
+
+| Type | Description |
+|------|-------------|
+| `guide-brief` | Short structured overview of a health guide — title, slug, summary, key points |
+| `red-flags` | Structured urgent-warning signals — symptoms or signs that warrant immediate medical attention |
+| `visit-prep` | Appointment preparation checklist — what to track, what to bring, questions to ask, when to seek urgent help |
+
+All three are educational structured data. None constitute diagnosis, treatment, or triage.
+
+---
+
+## C. Rails and price
+
+### Base Sepolia (EVM)
+
+| Field | Value |
+|-------|-------|
+| Network | `eip155:84532` |
+| Asset | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| payTo | `0x28C58Bc26Cd14b7f378937ED18081dA1A2976220` |
+| Price | 0.001 USDC |
+| maxAmountRequired | `1000` |
+| extra | `{"name":"USDC","version":"2"}` |
+
+Base Sepolia endpoints follow the pattern: `https://patientguide.io/api/x402/{type}?slug={slug}`
+
+### Solana Devnet (SVM)
+
+| Field | Value |
+|-------|-------|
+| Network | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+| Mint/Asset | `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU` |
+| payTo | `DBti9QNp9BwZCDDnw5BEQfqLrUXZvFyTTDpPDYC2AUpS` |
+| Price | 0.001 USDC |
+| maxAmountRequired | `1000` |
+| extra.feePayer | present in descriptor |
+
+Solana Devnet endpoints follow the pattern: `https://patientguide.io/api/x402/solana/{type}?slug={slug}`
+
+---
+
+## D. Unpaid curl checks
+
+Run these to verify the 402 gate is live and inspect the descriptor shape. No payment required.
+
+```sh
+# Base Sepolia — guide-brief
+curl -i "https://patientguide.io/api/x402/guide-brief?slug=hypertension"
+
+# Base Sepolia — red-flags
+curl -i "https://patientguide.io/api/x402/red-flags?slug=hypertension"
+
+# Base Sepolia — visit-prep
+curl -i "https://patientguide.io/api/x402/visit-prep?slug=hypertension"
+
+# Solana Devnet — visit-prep
+curl -i "https://patientguide.io/api/x402/solana/visit-prep?slug=hypertension"
+```
+
+**Expected unpaid response for all endpoints:**
+
+- HTTP status: `402`
+- `x402Version`: `2`
+- `scheme`: `exact`
+- `maxAmountRequired`: `"1000"`
+- `resource` field exactly matches the URL you called
+- Rail-specific `network`, `asset`/mint, and `payTo` as listed in section C
+
+The `resource` URL binding is intentional — it is scoped to the specific endpoint and slug called.
+
+---
+
+## E. Method guard check
+
+Only GET is supported. Other methods return 405 before any payment evaluation.
+
+```sh
+curl -i -X POST "https://patientguide.io/api/x402/visit-prep?slug=hypertension"
+```
+
+**Expected:**
+
+- HTTP status: `405`
+- `Allow: GET` header
+- Body: `{"error":"method_not_allowed"}`
+- No payment requirements in the response
+
+---
+
+## F. Supported slugs
+
+### red-flags and visit-prep
+
+The following slugs are supported on both rails:
+
+- `hypertension`
+- `stroke`
+- `early-warning-signs-of-a-heart-attack`
+- `atrial-fibrillation`
+- `type-1-diabetes`
+- `asthma`
+- `sepsis`
+- `depression`
+
+Note: use `early-warning-signs-of-a-heart-attack` exactly — a generic `heart-attack` slug is not supported and returns 404.
+
+Unsupported slugs return 404 after successful payment verification. This is expected behavior for slugs outside the curated set.
+
+### guide-brief
+
+`guide-brief` is live on both rails. The curated static slug set for guide-brief may be narrower than the red-flags/visit-prep set. Use `hypertension` as the safe verified test slug.
+
+---
+
+## G. Feedback
+
+Please report issues, observations, and compatibility notes via:
+
+- **GitHub Issues:** https://github.com/wavechecker/thought-archive/issues/new/choose
+  Use the **x402 Preview Feedback** template.
+- **Contact page:** https://patientguide.io/contact
+
+When filing feedback, include as much of the following as is relevant:
+
+- Endpoint URL tested
+- Rail (Base Sepolia / Solana Devnet)
+- Object type (`guide-brief` / `red-flags` / `visit-prep`)
+- Client or tool used
+- Summary of unpaid 402 response received
+- Whether a paid test was attempted (yes/no)
+- Expected vs actual behavior
+- Error logs or response body
+- Transaction hash or signature (if applicable and non-sensitive)
+- Environment or runtime
+
+**Never include private keys, seed phrases, keypair files, or sensitive personal health information in any issue or message.**
+
+---
+
+## H. Safety
+
+**Key safety rules for testers:**
+
+- Never paste private keys into issues, chat, commits, logs, or forms.
+- Never paste seed phrases.
+- Never upload keypair files.
+- Do not use a funded mainnet wallet for testing. Use a purpose-generated disposable burner funded only with testnet/devnet assets.
+- Do not send sensitive personal health information.
+- Do not send medical histories or patient-identifying details.
+- Do not treat returned objects as diagnosis, treatment, or emergency triage. These are educational structured data for developers.
+- Mainnet is not live — do not attempt to pay on mainnet.
+
+If you encounter symptoms or a medical emergency, contact your local emergency services or a licensed medical professional. PatientGuide structured objects are not a substitute for professional medical care.


### PR DESCRIPTION
## Summary

- Adds `docs/x402-tester-runbook.md`: concise external tester runbook covering what the x402 preview is, live PSO types, Base Sepolia and Solana Devnet rail config, unpaid curl checks, method guard (405) check, supported slugs, feedback path, and safety warnings
- Adds `docs/x402-reddit-tester-posts.md`: reusable Reddit/community launch copy including primary post, r/base variant, r/solana variant, short comment reply, and defensive reply templates for common objections
- Adds `docs/x402-observability.md`: post-launch monitoring checklist with traffic metrics to watch, Cloudflare/Worker log sources, Reddit baseline tracking template, safety/privacy rules, and feedback triage categories
- Updates `docs/x402-status.md`: adds a minimal link section pointing to the three new docs

## What is unchanged

- No Worker code
- No Netlify functions
- No payment config
- No mainnet config
- No public pages
- No Netlify deploy triggered

## Test plan

- [x] `npm run build` passes — 779 pages built, no errors
- [x] Docs are GitHub-only and require no site deploy